### PR TITLE
TimeoutSampler exceptions arg deprecation for Resource get() retry

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -37,6 +37,7 @@ fcfn_exclude_functions =
     func,
     LOGGER,
     findall,
+    raises,
 
 enable-extensions =
     FCFN,

--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -30,4 +30,4 @@ jobs:
         python -m pip install tox
     - name: Run tox
       run: |
-       tox -e code-check
+       tox -e code-check,unittests

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -1,8 +1,13 @@
 import logging
 import time
+from warnings import warn
 
 
 LOGGER = logging.getLogger(__name__)
+
+
+class InvalidArgumentsError(Exception):
+    pass
 
 
 class TimeoutExpiredError(Exception):
@@ -25,6 +30,47 @@ class TimeoutSampler:
     Yielding the output allows you to handle every value as you wish.
 
     Feel free to set the instance variables.
+
+    exceptions_dict should be in the following format:
+    {
+        exception0: [exception0_msg0],
+        exception1: [
+            exception1_msg0,
+            exception1_msg1
+        ],
+        exception2: []
+    }
+
+    If an exception is raised within `func`:
+        Example exception inheritance:
+            class Exception
+            class AExampleError(Exception)
+            class BExampleError(AExampleError)
+
+        The raised exception's class will fall into one of three categories:
+            1. An exception class specifically declared in exceptions_dict
+                exceptions_dict: {BExampleError: []}
+                raise: BExampleError
+                result: continue
+
+            2. A child class inherited from an exception class in exceptions_dict
+                exceptions_dict: {AExampleError: []}
+                raise: BExampleError
+                result: continue
+
+            3. Everything else, this will always re-raise the exception
+                exceptions_dict: {BExampleError: []}
+                raise: AExampleError
+                result: raise
+
+    Args:
+        wait_timeout (int): Time in seconds to wait for func to return a value equating to True
+        sleep (int): Time in seconds between calls to func
+        func (function): to be wrapped by TimeoutSampler
+        exceptions (tuple): Deprecated: Tuple containing all retry exceptions
+        exceptions_msg (str): Deprecated: String to match exception against
+        exceptions_dict (dict): Exception handling definition
+        print_log (bool): Print elapsed time to log
     """
 
     def __init__(
@@ -32,8 +78,9 @@ class TimeoutSampler:
         wait_timeout,
         sleep,
         func,
-        exceptions=None,
-        exceptions_msg=None,
+        exceptions=None,  # TODO: Deprecated and will be removed, use exceptions_dict
+        exceptions_msg=None,  # TODO: Deprecated and will be removed, use exceptions_dict
+        exceptions_dict=None,
         print_log=True,
         **func_kwargs,
     ):
@@ -41,60 +88,162 @@ class TimeoutSampler:
         self.sleep = sleep
         self.func = func
         self.func_kwargs = func_kwargs
-        self.exception = exceptions or Exception
         self.elapsed_time = None
-        self.exceptions_msg = exceptions_msg
         self.print_log = print_log
+
+        # TODO: when exceptions arg removed replace with: self.exceptions_dict = exceptions_dict or {Exception: []}
+        self.exceptions_dict = self._pre_process_exceptions(
+            exceptions=exceptions,
+            exceptions_msg=exceptions_msg,
+            exceptions_dict=exceptions_dict,
+        )
+        self._exceptions = tuple(self.exceptions_dict.keys())
+
+    def _pre_process_exceptions(self, exceptions, exceptions_msg, exceptions_dict):
+        """
+        Convert any deprecated `exceptions` and `exceptions_msg` arguments to an `exceptions_dict`
+
+        TODO: Deprecation: This method should be removed when the 'exceptions' argument is removed from __init__
+
+        Args:
+            exceptions (tuple): Deprecated: Tuple containing all retry exceptions
+            exceptions_msg (str): Deprecated: String to match exception against
+            exceptions_dict (dict): Exception handling definition
+
+        Returns:
+            dict: exceptions_dict compatible input
+        """
+        output = {}
+        if exceptions_dict and (exceptions or exceptions_msg):
+            raise InvalidArgumentsError(
+                "Must specify either exceptions_dict or exceptions/exception_msg, not both"
+            )
+
+        elif exceptions or exceptions_msg:
+            warn(
+                "TimeoutSampler() exception and exception_msg are now deprecated. "
+                "Please update to use exceptions_dict by Oct 12, 2021",
+                DeprecationWarning,
+            )
+
+        if exceptions_dict:
+            output.update(exceptions_dict)
+
+        elif exceptions is None:
+            output[Exception] = []
+
+        else:
+            if not isinstance(exceptions, tuple):
+                exceptions = (exceptions,)
+
+            for exp in exceptions:
+                if exceptions_msg:
+                    output[exp] = [exceptions_msg]
+                else:
+                    output[exp] = []
+
+        return output
 
     @property
     def _func_log(self):
+        """
+        Returns:
+            string: `func` information to include in log message
+        """
         return f"Function: {self.func} Kwargs: {self.func_kwargs}"
 
     def __iter__(self):
-        last_exp = None
+        """
+        Iterator
+
+        Yields:
+            any: Return value from `func`
+        """
         timeout_watch = TimeoutWatch(timeout=self.wait_timeout)
         if self.print_log:
             LOGGER.info(
                 f"Waiting for {self.wait_timeout} seconds, retry every {self.sleep} seconds"
             )
 
+        last_exp = None
         while timeout_watch.remaining_time() > 0:
             try:
                 self.elapsed_time = self.wait_timeout - timeout_watch.remaining_time()
                 yield self.func(**self.func_kwargs)
                 self.elapsed_time = None
+
                 time.sleep(self.sleep)
 
-            except self.exception as exp:
+            except self._exceptions as exp:
                 last_exp = exp
-                self.elapsed_time = None
+                last_exp_log = self._get_exception_log(exp=last_exp)
+                if self._is_raisable_exception(exp=last_exp):
+                    LOGGER.error(last_exp_log)
+                    raise exp
 
+                self.elapsed_time = None
                 time.sleep(self.sleep)
 
             finally:
                 if self.elapsed_time and self.print_log:
                     LOGGER.info(f"Elapsed time: {self.elapsed_time}")
 
-        raise TimeoutExpiredError(self._process_execution(exp=last_exp))
+        raise TimeoutExpiredError(self._get_exception_log(exp=last_exp))
 
-    def _process_execution(self, exp=None):
+    @staticmethod
+    def _is_exception_matched(exp, exception_messages):
+        """
+        Args:
+            exp (Exception): Exception object raised by `func`
+            exception_messages (list): Either an empty list allowing all text,
+                                       or a list of allowed strings to match against the exception text.
+
+        Returns:
+            bool: True if exception text is allowed or no exception text given, False otherwise
+        """
+        if not exception_messages:
+            return True
+
+        for msg in exception_messages:
+            # Prevent match if provided with empty string
+            if msg and msg in str(exp):
+                return True
+
+        return False
+
+    def _is_raisable_exception(self, exp):
+        """
+        Verify whether exception should be raised during execution of `func`
+
+        Args:
+            exp (Exception): Exception object raised by `func`
+
+        Returns:
+            bool: True if exp should be raised, False otherwise
+        """
+
+        for entry in self.exceptions_dict:
+            if isinstance(exp, entry):  # Check inheritance for raised exception
+                exception_messages = self.exceptions_dict.get(entry)
+                if self._is_exception_matched(
+                    exp=exp, exception_messages=exception_messages
+                ):
+                    return False
+
+        return True
+
+    def _get_exception_log(self, exp):
+        """
+        Args:
+            exp (any): Raised exception
+
+        Returns:
+            string: Log message for exception
+        """
         exp_name = exp.__class__.__name__ if exp else "N/A"
+
         last_exception_log = f"Last exception: {exp_name}: {exp}"
-
-        log = "{timeout}\n{func_log}\n{last_exception_log}".format(
-            timeout=self.wait_timeout,
-            func_log=self._func_log,
-            last_exception_log=last_exception_log,
-        )
-
-        if self.exceptions_msg:
-            if self.exceptions_msg not in str(exp):
-                LOGGER.error(log)
-                raise exp
-            else:
-                LOGGER.warning(f"{self.exceptions_msg}: Retrying")
-
-        return log
+        return f"{self.wait_timeout}\n{self._func_log}\n{last_exception_log}"
 
 
 class TimeoutWatch:

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -1,0 +1,303 @@
+import re
+import warnings
+
+import pytest
+
+from ocp_resources.utils import (
+    InvalidArgumentsError,
+    TimeoutExpiredError,
+    TimeoutSampler,
+)
+
+
+class TestTimeoutSampler:
+    @staticmethod
+    def _raise_exception(runtime_exception):
+        if runtime_exception:
+            raise runtime_exception
+
+    def _trigger_func_exception_during_iter(self, exceptions_dict, runtime_exception):
+        for _ in TimeoutSampler(
+            wait_timeout=1,
+            sleep=1,
+            func=self._raise_exception,
+            exceptions_dict=exceptions_dict,
+            print_log=False,
+            runtime_exception=runtime_exception,
+        ):
+            continue
+
+    @pytest.mark.parametrize(
+        "test_params, expected",
+        [
+            pytest.param(
+                {
+                    "init_exceptions_dict": {
+                        KeyError: [],
+                    },
+                    "runtime_exception": ValueError(),
+                },
+                {
+                    "raises": ValueError,
+                },
+                id="init_keyerror_raise_valueerror_with_no_msg",
+            ),
+            pytest.param(
+                {
+                    "init_exceptions_dict": {
+                        ValueError: ["allowed exception text"],
+                    },
+                    "runtime_exception": ValueError("test"),
+                },
+                {
+                    "raises": ValueError,
+                },
+                id="init_valueerror_with_msg_raise_valueerror_with_invalid_msg",
+            ),
+            pytest.param(
+                {
+                    "init_exceptions_dict": {
+                        KeyError: ["allowed exception text"],
+                        IndexError: ["allowed exception text"],
+                        ValueError: ["allowed exception text"],
+                    },
+                    "runtime_exception": IndexError("test"),
+                },
+                {
+                    "raises": IndexError,
+                },
+                id="init_multi_exceptions_raise_allowed_with_invalid_msg",
+            ),
+        ],
+    )
+    def test_timeout_sampler_raises(self, test_params, expected):
+        with pytest.raises(expected["raises"]):
+            self._trigger_func_exception_during_iter(
+                exceptions_dict=test_params.get("init_exceptions_dict"),
+                runtime_exception=test_params.get("runtime_exception"),
+            )
+
+    @pytest.mark.parametrize(
+        "test_params, expected",
+        [
+            pytest.param(
+                {},
+                {
+                    "exception_log_regex": "^.*\nLast exception: N/A: None$",
+                },
+                id="noargs_timeout_only",
+            ),
+            pytest.param(
+                {
+                    "runtime_exception": Exception(),
+                },
+                {
+                    "exception_log_regex": "^.*\nLast exception: Exception: $",
+                },
+                id="noargs_raise_exception_with_no_msg",
+            ),
+            pytest.param(
+                {
+                    "runtime_exception": ValueError(),
+                },
+                {
+                    "exception_log_regex": "^.*\nLast exception: ValueError: $",
+                },
+                id="noargs_raise_valueerror_with_no_msg",
+            ),
+            pytest.param(
+                {
+                    "init_exceptions_dict": {
+                        ValueError: ["test"],
+                    },
+                    "runtime_exception": ValueError("test"),
+                },
+                {
+                    "exception_log_regex": "^.*\nLast exception: ValueError: test$",
+                },
+                id="init_valueerror_with_msg_raise_valueerror_with_allowed_msg",
+            ),
+            pytest.param(
+                {
+                    "init_exceptions_dict": {
+                        KeyError: ["allowed exception text"],
+                        IndexError: ["allowed exception text"],
+                        ValueError: ["allowed exception text"],
+                    },
+                    "runtime_exception": IndexError("my allowed exception text"),
+                },
+                {
+                    "exception_log_regex": "^.*\nLast exception: IndexError: my allowed exception text$",
+                },
+                id="init_multi_exceptions_raise_allowed_with_allowed_msg",
+            ),
+        ],
+    )
+    def test_timeout_sampler_raises_timeout(self, test_params, expected):
+        exception_match = None
+        exception_log = None
+        try:
+            self._trigger_func_exception_during_iter(
+                exceptions_dict=test_params.get("init_exceptions_dict"),
+                runtime_exception=test_params.get("runtime_exception"),
+            )
+        except TimeoutExpiredError as exp:
+            exception_log = str(exp)
+            exception_match = re.compile(
+                pattern=expected["exception_log_regex"], flags=re.DOTALL
+            ).match(string=exception_log)
+
+        assert (
+            exception_match
+        ), f"Expected Regex: {expected['exception_log_regex']!r} Exception Log: {exception_log!r}"
+
+    @pytest.mark.parametrize(
+        "test_params, expected",
+        [
+            pytest.param(
+                {},
+                {
+                    "exceptions": (Exception,),
+                    "exceptions_dict": {Exception: []},
+                },
+                id="noargs",
+            ),
+            pytest.param(
+                {
+                    "exceptions": ValueError,
+                },
+                {
+                    "exceptions": (ValueError,),
+                    "exceptions_dict": {ValueError: []},
+                    "warning": {
+                        "class": DeprecationWarning,
+                        "text": "TimeoutSampler() exception and exception_msg are now deprecated.",
+                    },
+                },
+                id="init_valueerror_expect_deprecation_warning",
+            ),
+            pytest.param(
+                {
+                    "exceptions": ValueError,
+                    "exceptions_msg": "test message",
+                },
+                {
+                    "exceptions": (ValueError,),
+                    "exceptions_dict": {ValueError: ["test message"]},
+                    "warning": {
+                        "class": DeprecationWarning,
+                        "text": "TimeoutSampler() exception and exception_msg are now deprecated.",
+                    },
+                },
+                id="init_valueerror_with_msg_expect_deprecation_warning",
+            ),
+            pytest.param(
+                {
+                    "exceptions": (Exception, ValueError),
+                },
+                {
+                    "exceptions": (Exception, ValueError),
+                    "exceptions_dict": {
+                        Exception: [],
+                        ValueError: [],
+                    },
+                    "warning": {
+                        "class": DeprecationWarning,
+                        "text": "TimeoutSampler() exception and exception_msg are now deprecated.",
+                    },
+                },
+                id="init_multi_exception_with_no_msg_expect_deprecation_warning",
+            ),
+            pytest.param(
+                {
+                    "exceptions_dict": {
+                        Exception: ["exception msg"],
+                        ValueError: ["another exception msg"],
+                    },
+                },
+                {
+                    "exceptions": (Exception, ValueError),
+                    "exceptions_dict": {
+                        Exception: ["exception msg"],
+                        ValueError: ["another exception msg"],
+                    },
+                },
+                id="init_dict",
+            ),
+            pytest.param(
+                {
+                    "exceptions_dict": {
+                        Exception: [],
+                        ValueError: [],
+                    },
+                },
+                {
+                    "exceptions": (Exception, ValueError),
+                    "exceptions_dict": {
+                        Exception: [],
+                        ValueError: [],
+                    },
+                },
+                id="init_dict_no_msgs",
+            ),
+            pytest.param(
+                {
+                    "exceptions": TypeError,
+                    "exceptions_dict": {
+                        Exception: ["exception msg"],
+                        KeyError: ["another exception msg"],
+                    },
+                },
+                {
+                    "raises": InvalidArgumentsError,
+                },
+                id="init_deprecated_exceptions_and_new_dict_expect_raise_invalid_arguments",
+            ),
+            pytest.param(
+                {
+                    "exceptions_msg": "test exception message",
+                    "exceptions_dict": {
+                        Exception: ["exception msg"],
+                        KeyError: ["another exception msg"],
+                    },
+                },
+                {
+                    "raises": InvalidArgumentsError,
+                },
+                id="init_deprecated_msg_and_new_dict_expect_raise_invalid_arguments",
+            ),
+        ],
+    )
+    def test_timeout_sampler_pre_process_exceptions(self, test_params, expected):
+        # TODO: Remove this test when _pre_process_exceptions() is removed from TimeoutSampler
+        def _timeout_sampler():
+            return TimeoutSampler(
+                wait_timeout=1,
+                sleep=1,
+                func=lambda: True,
+                exceptions=test_params.get("exceptions"),
+                exceptions_msg=test_params.get("exceptions_msg"),
+                exceptions_dict=test_params.get("exceptions_dict"),
+                print_log=False,
+            )
+
+        if expected.get("raises"):
+            with pytest.raises(expected["raises"]):
+                _timeout_sampler()
+        else:
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                # Note: catch_warnings is not thread safe
+                timeout_sampler = _timeout_sampler()
+                if "warning" in expected:
+                    assert len(caught_warnings) == 1
+                    assert issubclass(
+                        caught_warnings[-1].category, expected["warning"]["class"]
+                    )
+                    assert expected["warning"]["text"] in str(
+                        caught_warnings[-1].message
+                    )
+                else:
+                    assert len(caught_warnings) == 0
+
+            assert expected["exceptions"] == timeout_sampler._exceptions
+            assert expected["exceptions_dict"] == timeout_sampler.exceptions_dict

--- a/tox.ini
+++ b/tox.ini
@@ -22,3 +22,13 @@ deps =
 commands =
     pip install .
     pytest tests
+
+[testenv:unittests]
+basepython = python3
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    pytest
+commands =
+    pip install .
+    pytest tests/unittests


### PR DESCRIPTION
```release-note
    TimeoutSampler exceptions arg deprecation for Resource get() retry
    
    TimeoutSampler:
    - Deprecated: 'exceptions' and 'exceptions_msg' arguments will be removed
    - New: exceptions_dict argument to handle additional exception states
    
    Resource:
    - Changed: additional exception states retried in get() to increase resiliency
```