### PR TITLE
Fixed an issue with high-performance templates

### DIFF
--- a/ocp_resources/template.py
+++ b/ocp_resources/template.py
@@ -15,7 +15,7 @@ class Template(NamespacedResource):
 
     class Workload:
         DESKTOP = "desktop"
-        HIGH_PERFORMANCE = "highperformance"
+        HIGHPERFORMANCE = "highperformance"
         SERVER = "server"
 
     class Flavor:


### PR DESCRIPTION
The previous attribute name HIGH_PERFORMANCE caused an AttributeError.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
