### PR TITLE
move log line on backup to the right place

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -850,10 +850,9 @@ class ResourceEditor(object):
     def update(self, backup_resources=False):
         """Prepares backup dicts (where necessary) and applies patches"""
         # prepare update dicts and backups
-        LOGGER.info("ResourceEdit: Backing up old data")
-
         resource_to_patch = []
         if backup_resources:
+            LOGGER.info("ResourceEdit: Backing up old data")
             if self.user_backups:
                 resource_to_patch = self._patches
                 self._backups = self.user_backups


### PR DESCRIPTION
resource.py

following the MR on the archived gitlab:
https://gitlab.cee.redhat.com/cnv-qe/ocp-python-wrapper/-/merge_requests/157

Signed-off-by: Issac Besso <ibesso@redhat.com>

##### Short description:
logging line indicating backup data was always printed instead of printing only in the right context (when backup_resources was True).

##### More details:
continuing the work not done from the archived gitlab MR: https://gitlab.cee.redhat.com/cnv-qe/ocp-python-wrapper/-/merge_requests/157/

##### What this PR does / why we need it:
moving the logging line to the right location.
we need it because it was printed all the time, confusing the test runners.

##### Which issue(s) this PR fixes:
merely printout, so triaging would be easier.

##### Special notes for reviewer:
following meni's last comment in the gitlab MR, i put the comment where it was.
this PR is ready for merge.

##### Bug:
