### PR TITLE
enhance docstring for TimeoutSampler

### DIFF
--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -17,15 +17,32 @@ class TimeoutExpiredError(Exception):
 
 class TimeoutSampler:
     """
-    Samples the function output.
+    Yields a given function's return value.
 
-    This is a generator object that at first yields the output of function
-    `func`. After the yield, it either raises instance of `TimeoutExpiredError` or
-    sleeps `sleep` seconds.
+    Before each following iteration (the next yield) over the TimeSampler object, the generator sleeps until it reaches
+    timeout and throws a TimeoutExpiredError exception.
 
-    Yielding the output allows you to handle every value as you wish.
+    Args:
+        wait_timeout (int)
+        sleep (int)
+        func (callable): the function to be invoked upon each yield
+        exceptions (a single BaseException or derived classes or a tuple with multiple exceptions): expected exception
+            to ignore when running the generator code;
+            Default: Exception.
+        exceptions_msg: expected exception(s) message; if an exception is caught, but exceptions_msg could not be found
+            in the exception's expression (str), the exception (that was caught) is re-raised after recording the error.
+            Default: None.
+        print_log (bool): toggle to record timer-related info logs. Default: True.
+        func_kwargs: function **kwargs
 
-    Feel free to set the instance variables.
+    Yields:
+        the return value of the function func
+
+    Raises:
+        TimeoutExpiredError: when reaching the wait_timeout.
+        <Exception>: any exception which is not self.exception.
+            The exception can be raised by func's code or if exceptions_msg is provided and not found (see the logic in
+            the exceptions_msg arg docstring).
     """
 
     def __init__(

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -19,27 +19,27 @@ class TimeoutSampler:
     """
     Yields a given function's return value.
 
-    Before each following iteration (the next yield) over the TimeSampler object, the generator sleeps until it reaches
-    timeout and throws a TimeoutExpiredError exception.
+    Before each following iteration (the next yield) over the TimeSampler object, the generator sleeps for a given
+    sleep interval (seconds). This cycle will be repeated as the caller continues iterating the TimeoutSampler.
+    When the defined timeout expires, a TimeoutExpiredError exception is thrown.
 
     Args:
-        wait_timeout (int)
-        sleep (int)
-        func (callable): the function to be invoked upon each yield
-        exceptions (a single BaseException or derived classes or a tuple with multiple exceptions): expected exception
-            to ignore when running the generator code;
-            Default: Exception.
-        exceptions_msg: expected exception(s) message; if an exception is caught, but exceptions_msg could not be found
-            in the exception's expression (str), the exception (that was caught) is re-raised after recording the error.
-            Default: None.
-        print_log (bool): toggle to record timer-related info logs. Default: True.
-        func_kwargs: function **kwargs
+        wait_timeout (int): total timeout (seconds)
+        sleep (int): interval time to wait between each iteration (seconds)
+        func (function): the function to be invoked upon each yield
+        exceptions (Exception or tuple, default Exception): expected exception(s) to ignore when running the generator
+            code
+        exceptions_msg (str, default None): expected exception(s) message; if an exception is caught, but exceptions_msg
+            could not be found in the exception's expression (str), the exception (that was caught) is re-raised after
+            recording the error.
+        print_log (bool, default True): toggle to record timer-related info logs.
+        func_kwargs (dict): function **kwargs
 
     Yields:
         the return value of the function func
 
     Raises:
-        TimeoutExpiredError: when reaching the wait_timeout.
+        TimeoutExpiredError (Exception): when reaching the wait_timeout.
         <Exception>: any exception which is not self.exception.
             The exception can be raised by func's code or if exceptions_msg is provided and not found (see the logic in
             the exceptions_msg arg docstring).

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -39,8 +39,8 @@ class TimeoutSampler:
         the return value of the function func
 
     Raises:
-        TimeoutExpiredError (Exception): when reaching the wait_timeout.
-        <Exception>: any exception which is not self.exception.
+        TimeoutExpiredError (Exception): when reaching the wait_timeout
+        <Exception>: any exception which was not purposely ignored
             The exception can be raised by func's code or if exceptions_msg is provided and not found (see the logic in
             the exceptions_msg arg docstring).
     """


### PR DESCRIPTION
utils.py

add all the necessary fields to the docstring.

following archived project MR in gitlab:
https://gitlab.cee.redhat.com/cnv-qe/ocp-python-wrapper/-/merge_requests/153

Signed-off-by: Issac Besso <ibesso@redhat.com>

##### Short description:
Providing a proper and fully conformed to coding style docstring for the TimeoutSampler class.

##### More details:
The docstring for TimeoutSampler class was plain and missing documenting fields and explaining how it works.

##### What this PR does / why we need it:
This PR complements the docstring.
We need it just as all our code must conform to coding style and be complete (explain the class usage and use case and document all arguments).

##### Which issue(s) this PR fixes:
No issue. Just fixing the docstring.

##### Special notes for reviewer:
Please note that there were several reviews and comments in the archived gitlab project MR:
https://gitlab.cee.redhat.com/cnv-qe/ocp-python-wrapper/-/merge_requests/153
This is ready to be merged (note that I removed the docstring for the func_args arg that we already removed for its lack of use and inability to practically use it, and furthermore, we are calling functions with kwargs, so it was not needed.

##### Bug:
