### PR TITLE
temporary timeout change

### DIFF
--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -1,4 +1,4 @@
-from ocp_resources.resource import Resource
+from ocp_resources.resource import TIMEOUT, Resource
 from ocp_resources.utils import TimeoutExpiredError, nudge_delete
 
 
@@ -28,8 +28,9 @@ class ProjectRequest(Resource):
         name,
         client=None,
         teardown=True,
+        timeout=TIMEOUT,
     ):
-        super().__init__(name=name, client=client, teardown=teardown)
+        super().__init__(name=name, client=client, teardown=teardown, timeout=timeout)
 
     def clean_up(self):
         Project(name=self.name).delete(wait=True)


### PR DESCRIPTION
##### Short description: Add timeout arg to __init__ of ProjectRequest class

##### More details:

##### What this PR does / why we need it: allows to set a timeout for ProjectRequest on creation to pass to Resource.__init__

##### Which issue(s) this PR fixes: fixes the inability to set timeout upon creation

##### Special notes for reviewer:

##### Bug:
