### PR TITLE
use self.timeout instead of timeout arg and support timeout in ProjectRequest __init__

### DIFF
--- a/ocp_resources/daemonset.py
+++ b/ocp_resources/daemonset.py
@@ -48,13 +48,12 @@ class DaemonSet(NamespacedResource):
                 ):
                     return
 
-    def delete(self, wait=False, timeout=TIMEOUT):
+    def delete(self, wait=False):
         """
         Delete Daemonset
 
         Args:
             wait (bool): True to wait for Daemonset to be deleted.
-            timeout (int): Time to wait for resource deletion
 
         Returns:
             bool: True if delete succeeded, False otherwise.
@@ -70,5 +69,5 @@ class DaemonSet(NamespacedResource):
 
         LOGGER.info(f"Delete {self.name}")
         if wait and res:
-            return self.wait_deleted(timeout=timeout)
+            return self.wait_deleted()
         return res

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -3,7 +3,7 @@
 import logging
 
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
-from ocp_resources.resource import TIMEOUT, NamespacedResource, Resource
+from ocp_resources.resource import NamespacedResource, Resource
 
 
 LOGGER = logging.getLogger(__name__)
@@ -165,24 +165,19 @@ class DataVolume(NamespacedResource):
 
         return res
 
-    def wait_deleted(self, timeout=TIMEOUT):
+    def wait_deleted(self):
         """
         Wait until DataVolume and the PVC created by it are deleted
-
-        Args:
-        timeout (int):  Time to wait for the DataVolume and PVC to be deleted.
 
         Returns:
         bool: True if DataVolume and its PVC are gone, False if timeout reached.
         """
-        super().wait_deleted(timeout=timeout)
-        return self.pvc.wait_deleted(timeout=timeout)
+        super().wait_deleted()
+        return self.pvc.wait_deleted()
 
-    def wait(self, timeout=600):
-        self.wait_for_status(status=self.Status.SUCCEEDED, timeout=timeout)
-        self.pvc.wait_for_status(
-            status=PersistentVolumeClaim.Status.BOUND, timeout=timeout
-        )
+    def wait(self):
+        self.wait_for_status(status=self.Status.SUCCEEDED)
+        self.pvc.wait_for_status(status=PersistentVolumeClaim.Status.BOUND)
 
     @property
     def pvc(self):

--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -1,4 +1,4 @@
-from ocp_resources.resource import Resource
+from ocp_resources.resource import TIMEOUT, Resource
 from ocp_resources.utils import TimeoutExpiredError, nudge_delete
 
 
@@ -28,21 +28,18 @@ class ProjectRequest(Resource):
         name,
         client=None,
         teardown=True,
+        timeout=TIMEOUT,
     ):
-        super().__init__(name=name, client=client, teardown=teardown)
+        super().__init__(name=name, client=client, teardown=teardown, timeout=timeout)
 
     def clean_up(self):
         Project(name=self.name).delete(wait=True)
 
-    def client_wait_deleted(self, timeout):
+    def client_wait_deleted(self):
         """
         client-side Wait until resource is deleted
-
-        Args:
-            timeout (int): Time to wait for the resource.
-
         """
         try:
-            super().client_wait_deleted(timeout=timeout)
+            super().client_wait_deleted()
         except TimeoutExpiredError:
             nudge_delete(name=self.name)


### PR DESCRIPTION
resource.py
- remove the timeout arg from all relevant methods
- use self.timeout when creating the TimeoutSampler

project.py
- add timeout arg to ProjectRequest.__init__

##### Short description:
1. in Resource methods, use the self.timeout instead of the timeout arg passed to the methods.
2. add the possibility to set timeout for ProjectRequest object upon creation.

##### More details:
1. timeout should be set in __init__ and when calling the methods, they should use the object's timeout attribute and not an arg.
2. I could not create a ProjectRequest object with custom timeout.


##### What this PR does / why we need it:
This PR fixes the wrong usage of timeout:
1. self.timeout was initialized in __init__ but never used.
2. each method would pass a timeout arg.
3. no option to override it from outside the ocp_resources.
4. no option to set a custom timeout for the ProjectRequest class.


##### Which issue(s) this PR fixes:
no. 3 and 4 above.

##### Special notes for reviewer:
I went over each Resource.delete() call to make sure that no timeout arg was used, and actually there was no such usage.

##### Bug:
