### PR TITLE
add timeout arg to ProjectRequest.__init__

### DIFF
--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -1,4 +1,4 @@
-from ocp_resources.resource import Resource
+from ocp_resources.resource import TIMEOUT, Resource
 from ocp_resources.utils import TimeoutExpiredError, nudge_delete
 
 
@@ -23,13 +23,8 @@ class ProjectRequest(Resource):
 
     api_group = Resource.ApiGroup.PROJECT_OPENSHIFT_IO
 
-    def __init__(
-        self,
-        name,
-        client=None,
-        teardown=True,
-    ):
-        super().__init__(name=name, client=client, teardown=teardown)
+    def __init__(self, name, client=None, teardown=True, timeout=TIMEOUT):
+        super().__init__(name=name, client=client, teardown=teardown, timeout=timeout)
 
     def clean_up(self):
         Project(name=self.name).delete(wait=True)


### PR DESCRIPTION
##### Short description: add timeout arg to ProjectRequest __init__

##### More details:

##### What this PR does / why we need it:
Due to timeouts in the last teardown, i had to increase the timeout.
This was not possible, because ProjectRequest did not have timeout to populate

##### Which issue(s) this PR fixes:
1. occasional timeouts
2. inability to intiailize ProjectRequest object with a custom timeout

##### Special notes for reviewer:

##### Bug:
