### PR TITLE
CDI resource is not Namespace resource

### DIFF
--- a/ocp_resources/cdi.py
+++ b/ocp_resources/cdi.py
@@ -1,13 +1,13 @@
-from ocp_resources.resource import NamespacedResource
+from ocp_resources.resource import Resource
 
 
-class CDI(NamespacedResource):
+class CDI(Resource):
     """
     CDI object.
     """
 
-    api_group = NamespacedResource.ApiGroup.CDI_KUBEVIRT_IO
+    api_group = Resource.ApiGroup.CDI_KUBEVIRT_IO
 
-    class Status(NamespacedResource.Status):
+    class Status(Resource.Status):
         DEPLOYING = "Deploying"
         DEPLOYED = "Deployed"


### PR DESCRIPTION
##### Short description:
CDI resource is not Namespace resource and should inherit from Resource.


##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:

##### Release notes:
<!--  Write your release notes:
1. Enter your extended release note in the below block.
   If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
