### PR TITLE
add machineset resource implementation

### DIFF
--- a/ocp_resources/machineset.py
+++ b/ocp_resources/machineset.py
@@ -1,0 +1,20 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class MachineSet(NamespacedResource):
+    """
+    MachineSet object.
+    """
+    api_group = NamespacedResource.ApiGroup.MACHINE_OPENSHIFT_IO
+
+    @property
+    def available_replicas(self):
+        return self.instance.status.availableReplicas
+
+    @property
+    def ready_replicas(self):
+        return self.instance.status.readyReplicas
+
+    @property
+    def num_of_replicas(self):
+        return self.instance.status.replicas


### PR DESCRIPTION
This patch adds the machineset resource.
The purpose of this patch is to allow endpoint users to be able to
create machineset resource on OpenShift.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:

##### Release notes:
<!--  Write your release notes:
1. Enter your extended release note in the below block.
   If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
