### PR TITLE
[CI] Update pre-commit pycln rev tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
           - --remove-all-unused-imports
 
   - repo: https://github.com/hadialqattan/pycln
-    rev: "0.0.1-beta.1"
+    rev: "v0.0.1-beta.1"
     hooks:
       - id: pycln
 


### PR DESCRIPTION
Changed: pycln git tags have been updated with a 'v' prefix