### PR TITLE
VolumeSnapshotClass resource is not namespaced

### DIFF
--- a/ocp_resources/volume_snapshot.py
+++ b/ocp_resources/volume_snapshot.py
@@ -1,4 +1,4 @@
-from ocp_resources.resource import NamespacedResource
+from ocp_resources.resource import NamespacedResource, Resource
 
 
 class VolumeSnapshot(NamespacedResource):
@@ -9,9 +9,9 @@ class VolumeSnapshot(NamespacedResource):
     api_group = NamespacedResource.ApiGroup.SNAPSHOT_STORAGE_K8S_IO
 
 
-class VolumeSnapshotClass(NamespacedResource):
+class VolumeSnapshotClass(Resource):
     """
     VolumeSnapshotClass object.
     """
 
-    api_group = NamespacedResource.ApiGroup.SNAPSHOT_STORAGE_K8S_IO
+    api_group = Resource.ApiGroup.SNAPSHOT_STORAGE_K8S_IO


### PR DESCRIPTION
##### Short description:
```bash
[cnv-qe-jenkins@alex48-451-xzjsk-executor cnv-tests]$ oc api-resources | grep volumesna
volumesnapshotclasses                                                        snapshot.storage.k8s.io/v1                     false        VolumeSnapshotClass
volumesnapshotcontents                                                       snapshot.storage.k8s.io/v1                     false        VolumeSnapshotContent
volumesnapshots                                                              snapshot.storage.k8s.io/v1                     true         VolumeSnapshot
```
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
