### PR TITLE
add infrastructure resource

### DIFF
--- a/ocp_resources/infrastructure.py
+++ b/ocp_resources/infrastructure.py
@@ -1,0 +1,13 @@
+from ocp_resources.resource import Resource
+
+
+class Infrastructure(Resource):
+    """
+    Infrastructure object.
+    """
+
+    api_version = f"{Resource.ApiGroup.CONFIG_OPENSHIFT_IO}/v1"
+
+    @property
+    def infrastructure_name(self):
+        return self.instance.status.infrastructureName


### PR DESCRIPTION
##### Short description:

add the infrastructure resource 

##### More details:

Infrastructure reference:

https://docs.openshift.com/container-platform/4.8/rest_api/config_apis/infrastructure-config-openshift-io-v1.html

##### What this PR does / why we need it:

simply to add the infrastructure resource of OpenShift.

In OcpOnRHV project we need to use some of its fields for some fields of the machine-set when creating it.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
