### PR TITLE
use exceptions_dict

### DIFF
--- a/ocp_resources/benchmark.py
+++ b/ocp_resources/benchmark.py
@@ -1,7 +1,6 @@
 import logging
 
-from openshift.dynamic.exceptions import NotFoundError
-
+from ocp_resources.constants import NOT_FOUND_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 
@@ -44,7 +43,7 @@ class Benchmark(NamespacedResource):
             wait_timeout=30,
             sleep=1,
             func=lambda: getattr(self.instance, parent, None),
-            exceptions=NotFoundError,
+            exceptions_dict=NOT_FOUND_ERROR_EXCEPTION_DICT,
         )
         for sample in samples:
             if sample:

--- a/ocp_resources/catalog_source_config.py
+++ b/ocp_resources/catalog_source_config.py
@@ -1,7 +1,6 @@
 import logging
 
-from urllib3.exceptions import ProtocolError
-
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
@@ -69,7 +68,7 @@ class CatalogSourceConfig(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,

--- a/ocp_resources/cdi_config.py
+++ b/ocp_resources/cdi_config.py
@@ -2,8 +2,7 @@
 
 import logging
 
-from urllib3.exceptions import ProtocolError
-
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import TIMEOUT, Resource
 from ocp_resources.utils import TimeoutSampler
 
@@ -46,7 +45,7 @@ class CDIConfig(Resource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
         )

--- a/ocp_resources/constants.py
+++ b/ocp_resources/constants.py
@@ -1,0 +1,6 @@
+from openshift.dynamic.exceptions import NotFoundError
+from urllib3.exceptions import ProtocolError
+
+
+PROTOCOL_ERROR_EXCEPTION_DICT = {ProtocolError: []}
+NOT_FOUND_ERROR_EXCEPTION_DICT = {NotFoundError: []}

--- a/ocp_resources/daemonset.py
+++ b/ocp_resources/daemonset.py
@@ -1,8 +1,8 @@
 import logging
 
 import kubernetes
-from urllib3.exceptions import ProtocolError
 
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 
@@ -31,7 +31,7 @@ class DaemonSet(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,

--- a/ocp_resources/deployment.py
+++ b/ocp_resources/deployment.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from urllib3.exceptions import ProtocolError
-
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 
@@ -48,7 +47,7 @@ class Deployment(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
         )

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -148,7 +148,7 @@ class NodeNetworkConfigurationPolicy(Resource):
         samples = TimeoutSampler(
             wait_timeout=3,
             sleep=1,
-            exceptions=ConflictError,
+            exceptions_dict={ConflictError: []},
             func=self.update,
             resource_dict=resource,
         )

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -16,8 +16,11 @@ from openshift.dynamic.exceptions import (
     ServerTimeoutError,
 )
 from openshift.dynamic.resource import ResourceField
-from urllib3.exceptions import ProtocolError
 
+from ocp_resources.constants import (
+    NOT_FOUND_ERROR_EXCEPTION_DICT,
+    PROTOCOL_ERROR_EXCEPTION_DICT,
+)
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
@@ -485,7 +488,10 @@ class Resource:
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=sleep,
-            exceptions=(ProtocolError, NotFoundError),
+            exceptions_dict={
+                **PROTOCOL_ERROR_EXCEPTION_DICT,
+                **NOT_FOUND_ERROR_EXCEPTION_DICT,
+            },
             func=lambda: self.exists,
         )
         for sample in samples:
@@ -549,7 +555,7 @@ class Resource:
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=sleep,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,
@@ -738,7 +744,7 @@ class Resource:
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,

--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -2,8 +2,7 @@
 
 import logging
 
-from urllib3.exceptions import ProtocolError
-
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
@@ -110,7 +109,7 @@ class VirtualMachine(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=sleep,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,

--- a/ocp_resources/virtual_machine_import.py
+++ b/ocp_resources/virtual_machine_import.py
@@ -3,8 +3,7 @@
 
 import logging
 
-from urllib3.exceptions import ProtocolError
-
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 from ocp_resources.virtual_machine import VirtualMachine
@@ -231,7 +230,7 @@ class VirtualMachineImport(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -2,8 +2,8 @@ import logging
 
 import xmltodict
 from openshift.dynamic.exceptions import ResourceNotFoundError
-from urllib3.exceptions import ProtocolError
 
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.resource import TIMEOUT, NamespacedResource
@@ -152,7 +152,7 @@ class VirtualMachineInstance(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=(ProtocolError),
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.get_domstate,
         )
         for sample in samples:
@@ -163,7 +163,7 @@ class VirtualMachineInstance(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=(ProtocolError),
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=self.get_vmi_active_condition,
         )
         for sample in samples:

--- a/ocp_resources/virtual_machine_restore.py
+++ b/ocp_resources/virtual_machine_restore.py
@@ -3,8 +3,7 @@
 
 import logging
 
-from urllib3.exceptions import ProtocolError
-
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 from ocp_resources.virtual_machine import VirtualMachine
@@ -72,7 +71,7 @@ class VirtualMachineRestore(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=lambda: self.instance.get("status", {}).get("complete", None)
             == status,
         )

--- a/ocp_resources/virtual_machine_snapshot.py
+++ b/ocp_resources/virtual_machine_snapshot.py
@@ -2,8 +2,7 @@
 
 import logging
 
-from urllib3.exceptions import ProtocolError
-
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 from ocp_resources.virtual_machine import VirtualMachine
@@ -68,7 +67,7 @@ class VirtualMachineSnapshot(NamespacedResource):
         samples = TimeoutSampler(
             wait_timeout=timeout,
             sleep=1,
-            exceptions=ProtocolError,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
             func=lambda: self.instance.get("status", {}).get("readyToUse", None)
             == status,
         )


### PR DESCRIPTION
##### Short description:
use exceptions_dict instead of old exceptions args.

##### More details:
Following PR https://github.com/RedHatQE/openshift-python-wrapper/pull/24 that was merged, all ocp_resources-related code should be adjusted accordingly.

##### What this PR does / why we need it:
i see warnings in my metrics tests and discovered that it was due to using one of the resource.py methods (wait_for_condition).

##### Which issue(s) this PR fixes:
1. avoiding faillure on October 12
2. make sure the warnings do not appear in the pytest run summary.

##### Special notes for reviewer:

##### Bug:
