### PR TITLE
ResourceEditor: ResourceField sanitizing

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -975,17 +975,17 @@ class ResourceEditor(object):
         """Recursively turns any ResourceField objects into dicts to avoid issues caused by appending lists, etc."""
         if issubclass(type(res), ResourceField):
             return ResourceEditor._dictify_resourcefield(res=dict(res.items()))
-        elif type(res) == dict:
+        elif isinstance(res, dict):
             return {
                 ResourceEditor._dictify_resourcefield(
                     res=key
                 ): ResourceEditor._dictify_resourcefield(res=value)
                 for key, value in res.items()
             }
-        elif type(res) == list:
+        elif isinstance(res, list):
             return [ResourceEditor._dictify_resourcefield(res=x) for x in res]
-        else:
-            return res
+
+        return res
 
     @staticmethod
     def _create_backup(original, patch):

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -978,7 +978,7 @@ class ResourceEditor(object):
     @staticmethod
     def _dictify_resourcefield(res):
         """Recursively turns any ResourceField objects into dicts to avoid issues caused by appending lists, etc."""
-        if issubclass(type(res), ResourceField):
+        if isinstance(res, ResourceField):
             return ResourceEditor._dictify_resourcefield(res=dict(res.items()))
         elif isinstance(res, dict):
             return {


### PR DESCRIPTION
Added a static method to ResourceEditor which recursively turns
ResourceField objects into dicts to avoid issues when applying patches
created by appending/changing existing resource fields.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
