### PR TITLE
Adjust ApiGroup for SM Resources

### DIFF
--- a/ocp_resources/destination_rule.py
+++ b/ocp_resources/destination_rule.py
@@ -8,4 +8,4 @@ class DestinationRule(NamespacedResource):
     Destination Rule object.
     """
 
-    api_version = NamespacedResource.ApiGroup.NETWORKING_ISTIO_IO
+    api_group = NamespacedResource.ApiGroup.NETWORKING_ISTIO_IO

--- a/ocp_resources/service_mesh_member_roll.py
+++ b/ocp_resources/service_mesh_member_roll.py
@@ -8,7 +8,7 @@ class ServiceMeshMemberRoll(NamespacedResource):
     Service Mesh Member Roll object.
     """
 
-    api_version = NamespacedResource.ApiGroup.MAISTRA_IO
+    api_group = NamespacedResource.ApiGroup.MAISTRA_IO
 
     class Status:
         CONFIGURED = "Configured"

--- a/ocp_resources/virtual_service.py
+++ b/ocp_resources/virtual_service.py
@@ -8,4 +8,4 @@ class VirtualService(NamespacedResource):
     Virtual Service object.
     """
 
-    api_version = NamespacedResource.ApiGroup.NETWORKING_ISTIO_IO
+    api_group = NamespacedResource.ApiGroup.NETWORKING_ISTIO_IO


### PR DESCRIPTION
##### Short description:
Change to api_group for the following resources:

ServiceMeshMemberRoll
DestinationRule
VirtualService
The api_version is supposed to be fetched according to the requirement of the api-resources

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
