### PR TITLE
Convert self.api() to property

### DIFF
--- a/ocp_resources/catalog_source_config.py
+++ b/ocp_resources/catalog_source_config.py
@@ -70,7 +70,7 @@ class CatalogSourceConfig(NamespacedResource):
             wait_timeout=timeout,
             sleep=1,
             exceptions=ProtocolError,
-            func=self.api().get,
+            func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,
         )

--- a/ocp_resources/cdi_config.py
+++ b/ocp_resources/cdi_config.py
@@ -47,7 +47,7 @@ class CDIConfig(Resource):
             wait_timeout=timeout,
             sleep=1,
             exceptions=ProtocolError,
-            func=self.api().get,
+            func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
         )
         for sample in samples:

--- a/ocp_resources/daemonset.py
+++ b/ocp_resources/daemonset.py
@@ -32,7 +32,7 @@ class DaemonSet(NamespacedResource):
             wait_timeout=timeout,
             sleep=1,
             exceptions=ProtocolError,
-            func=self.api().get,
+            func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,
         )

--- a/ocp_resources/deployment.py
+++ b/ocp_resources/deployment.py
@@ -49,7 +49,7 @@ class Deployment(NamespacedResource):
             wait_timeout=timeout,
             sleep=1,
             exceptions=ProtocolError,
-            func=self.api().get,
+            func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
         )
         for sample in samples:

--- a/ocp_resources/mtv.py
+++ b/ocp_resources/mtv.py
@@ -88,7 +88,7 @@ class MTV:
         samples = TimeoutSampler(
             wait_timeout=wait_timeout,
             sleep=1,
-            func=self.api().get,
+            func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,
         )

--- a/ocp_resources/persistent_volume.py
+++ b/ocp_resources/persistent_volume.py
@@ -19,5 +19,9 @@ class PersistentVolume(Resource):
         Returns the maximum number (int) of PV's which are in 'Available' state
         """
         return len(
-            [pv for pv in self.api.get()["items"] if pv.status.phase == "Available"]
+            [
+                pv
+                for pv in self.api.get()["items"]
+                if pv.status.phase == Resource.Condition.AVAILABLE
+            ]
         )

--- a/ocp_resources/persistent_volume.py
+++ b/ocp_resources/persistent_volume.py
@@ -19,5 +19,5 @@ class PersistentVolume(Resource):
         Returns the maximum number (int) of PV's which are in 'Available' state
         """
         return len(
-            [pv for pv in self.api().get()["items"] if pv.status.phase == "Available"]
+            [pv for pv in self.api.get()["items"] if pv.status.phase == "Available"]
         )

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -433,10 +433,11 @@ class Resource(object):
         ).get(*args, **kwargs)
 
     def _prepare_singular_name_kwargs(self, **kwargs):
+        kwargs = kwargs if kwargs else {}
         if self.singular_name:
-            kwargs = kwargs if kwargs else {}
             kwargs["singular_name"] = self.singular_name
-            return kwargs
+
+        return kwargs
 
     def full_api(self, **kwargs):
         """

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -613,9 +613,7 @@ class Resource(object):
 
     def delete(self, wait=False, timeout=TIMEOUT, body=None):
         try:
-            res = self.api.delete(
-                name=self.name, namespace=self.namespace, body=body
-            )
+            res = self.api.delete(name=self.name, namespace=self.namespace, body=body)
         except NotFoundError:
             return False
 

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -466,11 +466,7 @@ class Resource(object):
 
     @property
     def api(self):
-        kwargs = self._prepare_singular_name_kwargs()
-
-        return self.client.resources.get(
-            api_version=self.api_version, kind=self.kind, **kwargs
-        )
+        return self.full_api()
 
     def wait(self, timeout=TIMEOUT, sleep=1):
         """

--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -58,7 +58,7 @@ class VirtualMachine(NamespacedResource):
     def _subresource_api_url(self):
         return (
             f"{self.client.configuration.host}/"
-            f"apis/subresources.kubevirt.io/{self.api().api_version}/"
+            f"apis/subresources.kubevirt.io/{self.api.api_version}/"
             f"namespaces/{self.namespace}/virtualmachines/{self.name}"
         )
 
@@ -111,7 +111,7 @@ class VirtualMachine(NamespacedResource):
             wait_timeout=timeout,
             sleep=sleep,
             exceptions=ProtocolError,
-            func=self.api().get,
+            func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,
         )

--- a/ocp_resources/virtual_machine_import.py
+++ b/ocp_resources/virtual_machine_import.py
@@ -232,7 +232,7 @@ class VirtualMachineImport(NamespacedResource):
             wait_timeout=timeout,
             sleep=1,
             exceptions=ProtocolError,
-            func=self.api().get,
+            func=self.api.get,
             field_selector=f"metadata.name=={self.name}",
             namespace=self.namespace,
         )

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -43,7 +43,7 @@ class VirtualMachineInstance(NamespacedResource):
     def _subresource_api_url(self):
         return (
             f"{self.client.configuration.host}/"
-            f"apis/subresources.kubevirt.io/{self.api().api_version}/"
+            f"apis/subresources.kubevirt.io/{self.api.api_version}/"
             f"namespaces/{self.namespace}/virtualmachineinstances/{self.name}"
         )
 


### PR DESCRIPTION
##### Short description:

##### More details:
We use self.api without **kwargs in our code, it makes sense to convert it to property.
Add full_api method to maintain its functionality.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
