### PR TITLE
dv.wait - raise TimeoutExpiredError if DV's status is Pending

### DIFF
--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -219,7 +219,7 @@ class DataVolume(NamespacedResource):
                 func=lambda: self.instance.status.phase,
             ):
                 # If DV status is Pending (or Status is not yet updated) continue to wait, else exit the wait loop
-                if sample and sample in [self.Status.PENDING, None]:
+                if sample in [self.Status.PENDING, None]:
                     continue
                 else:
                     break

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -185,7 +185,7 @@ class DataVolume(NamespacedResource):
         return self.pvc.wait_deleted(timeout=timeout)
 
     def wait(self, timeout=600, failure_timeout=120):
-        self._check_pending_status(failure_timeout=failure_timeout)
+        self._check_none_pending_status(failure_timeout=failure_timeout)
 
         # If DV's status is not Pending, continue with the flow
         self.wait_for_status(status=self.Status.SUCCEEDED, timeout=timeout)
@@ -209,8 +209,8 @@ class DataVolume(NamespacedResource):
             client=self.client,
         )
 
-    def _check_pending_status(self, failure_timeout=120):
-        # Avoid waiting for "Succeeded" status if DV's in Pending status
+    def _check_none_pending_status(self, failure_timeout=120):
+        # Avoid waiting for "Succeeded" status if DV's in Pending/None status
         for sample in TimeoutSampler(
             wait_timeout=failure_timeout,
             sleep=15,

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -184,7 +184,7 @@ class DataVolume(NamespacedResource):
         super().wait_deleted(timeout=timeout)
         return self.pvc.wait_deleted(timeout=timeout)
 
-    def wait(self, timeout=600, failure_timeout=60):
+    def wait(self, timeout=600, failure_timeout=120):
         self._check_pending_status(failure_timeout=failure_timeout)
 
         # If DV's status is not Pending, continue with the flow
@@ -209,7 +209,7 @@ class DataVolume(NamespacedResource):
             client=self.client,
         )
 
-    def _check_pending_status(self, failure_timeout=60):
+    def _check_pending_status(self, failure_timeout=120):
         pending_counter = 0
         # Avoid waiting for "Succeeded" status if DV's in Pending status
         for sample in TimeoutSampler(

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -215,8 +215,7 @@ class DataVolume(NamespacedResource):
         for sample in TimeoutSampler(
             wait_timeout=failure_timeout,
             sleep=15,
-            func=lambda: self.instance.get("status").get("phase")
-            == self.Status.PENDING,
+            func=lambda: self.instance.status.phase == self.Status.PENDING,
         ):
             if sample:
                 pending_counter += 1

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -215,7 +215,7 @@ class DataVolume(NamespacedResource):
         try:
             for sample in TimeoutSampler(
                 wait_timeout=failure_timeout,
-                sleep=15,
+                sleep=10,
                 func=lambda: self.instance.status.phase,
             ):
                 # If DV status is Pending (or Status is not yet updated) continue to wait, else exit the wait loop

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -215,7 +215,7 @@ class DataVolume(NamespacedResource):
         for sample in TimeoutSampler(
             wait_timeout=failure_timeout,
             sleep=15,
-            func=lambda: self.instance.items.status == self.Status.PENDING,
+            func=lambda: self.instance.status.phase == self.Status.PENDING,
         ):
             if sample:
                 pending_counter += 1

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -215,7 +215,8 @@ class DataVolume(NamespacedResource):
         for sample in TimeoutSampler(
             wait_timeout=failure_timeout,
             sleep=15,
-            func=lambda: self.instance.status.get("phase") == self.Status.PENDING,
+            func=lambda: self.instance.get("status").get("phase")
+            == self.Status.PENDING,
         ):
             if sample:
                 pending_counter += 1

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -215,7 +215,7 @@ class DataVolume(NamespacedResource):
         for sample in TimeoutSampler(
             wait_timeout=failure_timeout,
             sleep=15,
-            func=lambda: self.instance.status.phase == self.Status.PENDING,
+            func=lambda: self.instance.status.get("phase") == self.Status.PENDING,
         ):
             if sample:
                 pending_counter += 1

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -216,10 +216,10 @@ class DataVolume(NamespacedResource):
             for sample in TimeoutSampler(
                 wait_timeout=failure_timeout,
                 sleep=15,
-                func=lambda: self.instance.status.phase in [self.Status.PENDING, None],
+                func=lambda: self.instance.status.phase,
             ):
                 # If DV status is Pending (or Status is not yet updated), continue to wait, else exit the wait loop
-                if sample:
+                if sample and sample in [self.Status.PENDING, None]:
                     continue
                 else:
                     break

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -218,7 +218,7 @@ class DataVolume(NamespacedResource):
                 sleep=15,
                 func=lambda: self.instance.status.phase,
             ):
-                # If DV status is Pending (or Status is not yet updated), continue to wait, else exit the wait loop
+                # If DV status is Pending (or Status is not yet updated) continue to wait, else exit the wait loop
                 if sample and sample in [self.Status.PENDING, None]:
                     continue
                 else:

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -19,10 +19,6 @@ class TimeoutExpiredError(Exception):
         return f"Timed Out: {self.value}"
 
 
-class WaitForStatusError(Exception):
-    pass
-
-
 class TimeoutSampler:
     """
     Samples the function output.

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -19,6 +19,10 @@ class TimeoutExpiredError(Exception):
         return f"Timed Out: {self.value}"
 
 
+class WaitForStatusError(Exception):
+    pass
+
+
 class TimeoutSampler:
     """
     Samples the function output.


### PR DESCRIPTION
##### Short description:
Avoid waiting for a timeout for a DV to reach Succeeded status if it reached Pending within a given timeout

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
