### PR TITLE
Add ConflictError to DEFAULT_CLUSTER_RETRY_EXCEPTIONS

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -1093,12 +1093,11 @@ class ResourceEditor:
                     resource_dict=patch
                 )  # replace the resource metadata
 
-    @staticmethod
-    def _apply_patches_sampler(patches, action_text, action):
+    def _apply_patches_sampler(self, patches, action_text, action):
         exceptions_dict = {ConflictError: []}
         exceptions_dict.update(DEFAULT_CLUSTER_RETRY_EXCEPTIONS)
         return Resource.retry_cluster_exceptions(
-            func=ResourceEditor._apply_patches,
+            func=self._apply_patches,
             exceptions_dict=exceptions_dict,
             patches=patches,
             action_text=action_text,

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -10,6 +10,7 @@ import urllib3
 import yaml
 from openshift.dynamic import DynamicClient
 from openshift.dynamic.exceptions import (
+    ConflictError,
     InternalServerError,
     NotFoundError,
     ServerTimeoutError,
@@ -25,6 +26,7 @@ DEFAULT_CLUSTER_RETRY_EXCEPTIONS = {
     ConnectionResetError: [],
     InternalServerError: ["etcdserver: leader changed"],
     ServerTimeoutError: [],
+    ConflictError: [],
 }
 
 LOGGER = logging.getLogger(__name__)

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -659,16 +659,16 @@ class Resource:
         func,
         **kwargs,
     ):
-        exceptions_dict = DEFAULT_CLUSTER_RETRY_EXCEPTIONS
-        if "exceptions_dict" in kwargs:
-            exceptions_dict.update(kwargs["exceptions_dict"])
-            del kwargs["exceptions_dict"]
+        if "exceptions_dict" not in kwargs:
+            kwargs["exceptions_dict"] = DEFAULT_CLUSTER_RETRY_EXCEPTIONS
+        else:
+            kwargs["exceptions_dict"].update(DEFAULT_CLUSTER_RETRY_EXCEPTIONS)
+
         sampler = TimeoutSampler(
             wait_timeout=10,
             sleep=1,
             func=func,
             print_log=False,
-            exceptions_dict=exceptions_dict,
             **kwargs,
         )
         for sample in sampler:


### PR DESCRIPTION
##### Short description: Retry on ConflictError

##### More details: This is specifically needed for ResourceEditor. If patch is done on a resource too soon, it can get a ConflictError if the past update is not complete yet, and this is a normal behavior that works if a retry attempt is made

##### What this PR does / why we need it:
Without this change currently, we are having to use TimeoutSampler and add ConflictError to exceptions_dict, every time we make calls to ResourceEditor
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
None