### PR TITLE
TimeoutSampler: Print func and func kwargs before start loop

### DIFF
--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -147,10 +147,16 @@ class TimeoutSampler:
     def _get_func_info(self, _func, type_):
         res = getattr(_func, type_, None)
         if res:
-            if type_ == "__name__" and res == "<lambda>":
-                return f"lambda: {_func.__qualname__.split('.')[1]}.{'.'.join(_func.__code__.co_names)}"
+            # If func is lambda function.
+            if _func.__name__ == "<lambda>":
+                if type_ == "__module__":
+                    return f"{res}.{_func.__qualname__.split('.')[1]}"
+
+                elif type_ == "__name__":
+                    return f"lambda: {'.'.join(_func.__code__.co_names)}"
             return res
 
+        # If func is partial function.
         if getattr(_func, "func", None):
             return self._get_func_info(_func=_func.func, type_=type_)
 

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -162,7 +162,7 @@ class TimeoutSampler:
         timeout_watch = TimeoutWatch(timeout=self.wait_timeout)
         if self.print_log:
             LOGGER.info(
-                f"Waiting for {self.wait_timeout} seconds, retry every {self.sleep} seconds"
+                f"{self._func_log}: Waiting for {self.wait_timeout} seconds, retry every {self.sleep} seconds"
             )
 
         last_exp = None

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -148,7 +148,7 @@ class TimeoutSampler:
         res = getattr(_func, type_, None)
         if res:
             if type_ == "__name__" and res == "<lambda>":
-                return f"lambda: {'.'.join(_func.__code__.co_names)}"
+                return f"lambda: {_func.__qualname__.split('.')[1]}.{'.'.join(_func.__code__.co_names)}"
             return res
 
         if getattr(_func, "func", None):


### PR DESCRIPTION
##### Short description:
If the user is not set it's own log the current log is useless, for example:
`ocp_resources.utils 2021-09-03 21:44:05 INFO Waiting for 120 seconds, retry every 1 seconds`
mean nothing.

This have more info:
```
ocp_resources.utils 2021-09-03 22:20:41 INFO Waiting for 120 seconds, retry every 1 seconds. (Function: utilities.infra._get_not_running_pods None)

```

Improve func_log to return real names.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
