### PR TITLE
test_resources_definitions: Add exclude resource

### DIFF
--- a/tests/test_validate_resources.py
+++ b/tests/test_validate_resources.py
@@ -10,6 +10,9 @@ import pytest
 import requests
 
 
+EXCLUDE_RESOURCES = {"ingress.py": "Ingress"}
+
+
 def _process_api_type(api_type, api_value, resource_dict, cls):
     if api_type == "api_group":
         return _get_api_group(
@@ -94,9 +97,13 @@ def resources_definitions_errors(resources_definitions):
     errors = []
     for _file in _resource_file():
         with open(_file, "r") as fd:
+            exclude_cls = EXCLUDE_RESOURCES.get(_file.split("/")[-1])
             tree = ast.parse(source=fd.read())
             classes = [cls for cls in tree.body if isinstance(cls, ast.ClassDef)]
             for cls in classes:
+                if cls.name == exclude_cls:
+                    continue
+
                 resource_dict = resources_definitions.get(cls.name)
                 if not resource_dict:
                     continue

--- a/tests/test_validate_resources.py
+++ b/tests/test_validate_resources.py
@@ -97,7 +97,7 @@ def resources_definitions_errors(resources_definitions):
     errors = []
     for _file in _resource_file():
         with open(_file, "r") as fd:
-            exclude_cls = EXCLUDE_RESOURCES.get(_file.split("/")[-1])
+            exclude_cls = EXCLUDE_RESOURCES.get(os.path.basename(_file))
             tree = ast.parse(source=fd.read())
             classes = [cls for cls in tree.body if isinstance(cls, ast.ClassDef)]
             for cls in classes:


### PR DESCRIPTION
##### Short description:
Ingress resource is both namespace and not namespace resource (depend on the api_group)
while `oc get ingress.config.openshift.io` works `oc get inress -A` show nothing.

Exclude ingress from the test for now.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
