### PR TITLE
namespae resource: support get raw object in get()

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -825,7 +825,7 @@ class NamespacedResource(Resource):
         Args:
             dyn_client (DynamicClient): Open connection to remote cluster
             singular_name (str): Resource kind (in lowercase), in use where we have multiple matches for resource
-            raw (bool): If True return rew object from openshift-restclient-python
+            raw (bool): If True return raw object from openshift-restclient-python
 
 
         Returns:


### PR DESCRIPTION
`label_selector` is not working when we have multiple resources with the same name
We return `openshift-python-wrapper` python object and this leads to get every time different resource when calling `.instance`

issue was opened in `openshift-restclient-python`:
https://github.com/openshift/openshift-restclient-python/issues/415
