### PR TITLE
WIP: Upstream exception migration

### DIFF
--- a/ocp_resources/constants.py
+++ b/ocp_resources/constants.py
@@ -1,4 +1,4 @@
-from openshift.dynamic.exceptions import NotFoundError
+from kubernetes.dynamic.exceptions import NotFoundError
 from urllib3.exceptions import ProtocolError
 
 

--- a/ocp_resources/daemonset.py
+++ b/ocp_resources/daemonset.py
@@ -1,6 +1,6 @@
 import logging
 
-import kubernetes
+from kubernetes.client import V1DeleteOptions
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.resource import TIMEOUT, NamespacedResource
@@ -62,5 +62,5 @@ class DaemonSet(NamespacedResource):
         super().delete(
             wait=wait,
             timeout=timeout,
-            body=kubernetes.client.V1DeleteOptions(propagation_policy="Foreground"),
+            body=V1DeleteOptions(propagation_policy="Foreground"),
         )

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -1,7 +1,7 @@
 import logging
 import re
 
-from openshift.dynamic.exceptions import ConflictError
+from kubernetes.dynamic.exceptions import ConflictError
 
 from ocp_resources.node_network_configuration_enactment import (
     NodeNetworkConfigurationEnactment,

--- a/ocp_resources/node_network_state.py
+++ b/ocp_resources/node_network_state.py
@@ -1,7 +1,7 @@
 import logging
 import time
 
-from openshift.dynamic.exceptions import ConflictError
+from kubernetes.dynamic.exceptions import ConflictError
 
 from ocp_resources.resource import Resource
 from ocp_resources.utils import TimeoutSampler

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -2,7 +2,7 @@ import logging
 import shlex
 
 import xmltodict
-from openshift.dynamic.exceptions import ResourceNotFoundError
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.node import Node

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,5 @@
-import kubernetes
 import pytest
+from kubernetes.config import new_client_from_config
 from openshift.dynamic import DynamicClient
 
 from ocp_resources.namespace import Namespace
@@ -10,7 +10,7 @@ from tests.utils import generate_yaml_from_template
 
 @pytest.fixture(scope="session")
 def client():
-    return DynamicClient(client=kubernetes.config.new_client_from_config())
+    return DynamicClient(client=new_client_from_config())
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Due to changes upstream in openshift-restclient-python the majority of exceptions have moved to the kubernetes module
https://github.com/openshift/openshift-restclient-python/pull/411/files
