### PR TITLE
add etcd timeout to DEFAULT_CLUSTER_RETRY_EXCEPTIONS

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -27,7 +27,10 @@ from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 DEFAULT_CLUSTER_RETRY_EXCEPTIONS = {
     ConnectionAbortedError: [],
     ConnectionResetError: [],
-    InternalServerError: ["etcdserver: leader changed"],
+    InternalServerError: [
+        "etcdserver: leader changed",
+        "etcdserver: request timed out",
+    ],
     ServerTimeoutError: [],
 }
 


### PR DESCRIPTION
##### Short description: We need to retry get calls on "etcdserver: request timed out"

##### More details: Without that piece upgrade testing failed, eventhough subsequent get/post/delete worked fine

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
