### PR TITLE
Support skip teardown from os env

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -185,7 +185,7 @@ class NodeNetworkConfigurationPolicy(Resource):
             return self
         except Exception as e:
             LOGGER.error(e)
-            self.clean_up()
+            super().__exit__(exception_type=None, exception_value=None, traceback=None)
             raise
 
     @property

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -411,6 +411,13 @@ class Resource:
         return self.deploy()
 
     def __exit__(self, exception_type, exception_value, traceback):
+        # For debug, export kind (class name) + !TEARDOWN to skip resource teardown.
+        # For example:export VirtualMachineInstance!TEARDOWN=True
+        no_teardown_from_environment = os.environ.get(f"{self.kind}!TEARDOWN")
+        if no_teardown_from_environment:
+            LOGGER.warning(f"Skip teardown. Got {no_teardown_from_environment}")
+            return
+
         if self.teardown:
             self.clean_up()
 

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -413,9 +413,12 @@ class Resource:
     def __exit__(self, exception_type, exception_value, traceback):
         # For debug, export kind (class name) + NOTEARDOWN to skip resource teardown.
         # For example:export VirtualMachineInstanceNOTEARDOWN=True
-        no_teardown_from_environment = os.environ.get(f"{self.kind}NOTEARDOWN")
+        skip_teardown_env = f"{self.kind}NOTEARDOWN"
+        no_teardown_from_environment = os.environ.get(skip_teardown_env)
         if no_teardown_from_environment:
-            LOGGER.warning(f"Skip teardown. Got {no_teardown_from_environment}")
+            LOGGER.warning(
+                f"Skip teardown. Got {skip_teardown_env}={no_teardown_from_environment}"
+            )
             return
 
         if self.teardown:

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -411,9 +411,9 @@ class Resource:
         return self.deploy()
 
     def __exit__(self, exception_type, exception_value, traceback):
-        # For debug, export kind (class name) + !TEARDOWN to skip resource teardown.
-        # For example:export VirtualMachineInstance!TEARDOWN=True
-        no_teardown_from_environment = os.environ.get(f"{self.kind}!TEARDOWN")
+        # For debug, export kind (class name) + NOTEARDOWN to skip resource teardown.
+        # For example:export VirtualMachineInstanceNOTEARDOWN=True
+        no_teardown_from_environment = os.environ.get(f"{self.kind}NOTEARDOWN")
         if no_teardown_from_environment:
             LOGGER.warning(f"Skip teardown. Got {no_teardown_from_environment}")
             return


### PR DESCRIPTION
##### Short description:
Support skip teardown for any resource by export os environment
for example:
export VirtualMachineInstanceNOTEARDOWN will skip teardown for VirtualMachineInstance resources

##### What this PR does / why we need it:
For debugging failed resources

