### PR TITLE
NNCP: support adding interfaces

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -177,7 +177,10 @@ class NodeNetworkConfigurationPolicy(Resource):
         set_ipv6=True,
         ipv6_enable=False,
     ):
-        self.res = self.to_dict()
+        #  If self.res is already defined (from to_dict()), don't call it again.
+        if not self.res:
+            self.res = self.to_dict()
+
         self.res.setdefault("spec", {}).setdefault("desiredState", {})
         if not iface:
             iface = {
@@ -284,8 +287,8 @@ class NodeNetworkConfigurationPolicy(Resource):
                 self._absent_interface()
                 self.wait_for_status_success()
                 self.wait_for_interface_deleted()
-            except Exception as e:
-                LOGGER.error(e)
+            except Exception as exp:
+                LOGGER.error(exp)
 
         self.delete()
 


### PR DESCRIPTION
Support adding multiple interfaces to NNCP

Example:
```
nncp = NodeNetworkConfigurationPolicy(
    name="test-nncp",
    worker_pods=utility_pods,
    ports=[nodes_available_nics[worker_node1.name][0]],
)
nncp.add_interface(name="iface1", type_="linux-bridge", state="up")
nncp.add_interface(name="iface2", type_="linux-bridge", state="up")
nncp.deploy()
```