### PR TITLE
Move log to delete(), add more information to log in clean_up()

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -423,8 +423,6 @@ class Resource:
             except Exception as exception_:
                 LOGGER.warning(exception_)
 
-        data = self.to_dict()
-        LOGGER.info(f"Deleting {data}")
         self.delete(wait=True, timeout=self.timeout)
 
     @classmethod
@@ -618,12 +616,17 @@ class Resource:
         return res
 
     def delete(self, wait=False, timeout=TIMEOUT, body=None):
+        LOGGER.info(f"Delete {self.kind} {self.name}")
+        if self.exists:
+            data = self.instance.to_dict()
+            LOGGER.info(f"Deleting {data}")
+            LOGGER.debug(f"\n{yaml.dump(data)}")
+
         try:
             res = self.api.delete(name=self.name, namespace=self.namespace, body=body)
         except NotFoundError:
             return False
 
-        LOGGER.info(f"Delete {self.kind} {self.name}")
         if wait and res:
             return self.wait_deleted(timeout=timeout)
         return res

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -421,7 +421,9 @@ class Resource:
             try:
                 _collect_data(resource_object=self)
             except Exception as exception_:
-                LOGGER.warning(exception_)
+                LOGGER.warning(
+                    f"Log collector failed to collect info for {self.kind} {self.name}\nexception: {exception_}"
+                )
 
         self.delete(wait=True, timeout=self.timeout)
 

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -622,7 +622,6 @@ class Resource:
         if self.exists:
             data = self.instance.to_dict()
             LOGGER.info(f"Deleting {data}")
-            LOGGER.debug(f"\n{yaml.dump(data)}")
 
         try:
             res = self.api.delete(name=self.name, namespace=self.namespace, body=body)


### PR DESCRIPTION
##### Short description:

- Move logs with resource data to delete()
- Only log if the resource exists
- Add more information to log in clean_up()

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
