### PR TITLE
Support dry-run

### DIFF
--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -20,6 +20,7 @@ class Namespace(Resource):
         label=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
+        dry_run=None,
     ):
         super().__init__(
             name=name,
@@ -27,6 +28,7 @@ class Namespace(Resource):
             teardown=teardown,
             yaml_file=yaml_file,
             delete_timeout=delete_timeout,
+            dry_run=dry_run,
         )
         self.label = label
 

--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -20,7 +20,7 @@ class Namespace(Resource):
         label=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
-        dry_run=None,
+        **kwargs,
     ):
         super().__init__(
             name=name,
@@ -28,7 +28,7 @@ class Namespace(Resource):
             teardown=teardown,
             yaml_file=yaml_file,
             delete_timeout=delete_timeout,
-            dry_run=dry_run,
+            **kwargs,
         )
         self.label = label
 

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -344,6 +344,7 @@ class Resource:
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
+        dry_run=None,
     ):
         """
         Create a API resource
@@ -385,6 +386,7 @@ class Resource:
         self.teardown = teardown
         self.timeout = timeout
         self.delete_timeout = delete_timeout
+        self.dry_run = dry_run
 
     @ClassProperty
     def kind(cls):  # noqa: N805
@@ -640,7 +642,7 @@ class Resource:
         LOGGER.info(f"Create {self.kind} {self.name}")
         LOGGER.info(f"Posting {data}")
         LOGGER.debug(f"\n{yaml.dump(data)}")
-        res = self.api.create(body=data, namespace=self.namespace)
+        res = self.api.create(body=data, namespace=self.namespace, dry_run=self.dry_run)
         if wait and res:
             return self.wait()
         return res
@@ -848,6 +850,7 @@ class NamespacedResource(Resource):
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
+        dry_run=None,
     ):
         super().__init__(
             name=name,
@@ -857,6 +860,8 @@ class NamespacedResource(Resource):
             privileged_client=privileged_client,
             yaml_file=yaml_file,
             delete_timeout=delete_timeout,
+            dry_run=dry_run,
+
         )
         self.namespace = namespace
         if not (self.name and self.namespace) and not self.yaml_file:

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -861,7 +861,6 @@ class NamespacedResource(Resource):
             yaml_file=yaml_file,
             delete_timeout=delete_timeout,
             **kwargs,
-
         )
         self.namespace = namespace
         if not (self.name and self.namespace) and not self.yaml_file:

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -850,7 +850,7 @@ class NamespacedResource(Resource):
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
-        dry_run=None,
+        **kwargs,
     ):
         super().__init__(
             name=name,
@@ -860,7 +860,7 @@ class NamespacedResource(Resource):
             privileged_client=privileged_client,
             yaml_file=yaml_file,
             delete_timeout=delete_timeout,
-            dry_run=dry_run,
+            **kwargs,
 
         )
         self.namespace = namespace

--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -42,6 +42,7 @@ class VirtualMachine(NamespacedResource):
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
+        dry_run=None,
     ):
         super().__init__(
             name=name,
@@ -51,6 +52,7 @@ class VirtualMachine(NamespacedResource):
             privileged_client=privileged_client,
             yaml_file=yaml_file,
             delete_timeout=delete_timeout,
+            dry_run=dry_run,
         )
         self.body = body
 

--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -42,7 +42,7 @@ class VirtualMachine(NamespacedResource):
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
-        dry_run=None,
+        **kwargs,
     ):
         super().__init__(
             name=name,
@@ -52,7 +52,7 @@ class VirtualMachine(NamespacedResource):
             privileged_client=privileged_client,
             yaml_file=yaml_file,
             delete_timeout=delete_timeout,
-            dry_run=dry_run,
+            **kwargs,
         )
         self.body = body
 


### PR DESCRIPTION
Add support to create resource with dry_run flag.

This will not create the resource, but only simulate the creation.
