### PR TITLE
Add storage API to data volume

### DIFF
--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -75,11 +75,11 @@ class DataVolume(NamespacedResource):
         storage_class=None,
         url=None,
         content_type=ContentType.KUBEVIRT,
-        access_modes=AccessMode.RWO,
+        access_modes=None,
         cert_configmap=None,
         secret=None,
         client=None,
-        volume_mode=VolumeMode.FILE,
+        volume_mode=None,
         hostpath_node=None,
         source_pvc=None,
         source_namespace=None,
@@ -90,6 +90,7 @@ class DataVolume(NamespacedResource):
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
+        use_storage_api=False,
     ):
         super().__init__(
             name=name,
@@ -106,18 +107,24 @@ class DataVolume(NamespacedResource):
         self.secret = secret
         self.content_type = content_type
         self.size = size
-        self.access_modes = access_modes
+        self.access_modes = (
+            access_modes if use_storage_api or access_modes else self.AccessMode.ROX
+        )
         self.storage_class = storage_class
-        self.volume_mode = volume_mode
+        self.volume_mode = (
+            volume_mode if use_storage_api or volume_mode else self.VolumeMode.FILE
+        )
         self.hostpath_node = hostpath_node
         self.source_pvc = source_pvc
         self.source_namespace = source_namespace
         self.multus_annotation = multus_annotation
         self.bind_immediate_annotation = bind_immediate_annotation
         self.preallocation = preallocation
+        self.use_storage_api = use_storage_api
 
     def to_dict(self):
         res = super().to_dict()
+        api_to_use = "storage" if self.use_storage_api else "pvc"
         if self.yaml_file:
             return res
 
@@ -125,21 +132,22 @@ class DataVolume(NamespacedResource):
             {
                 "spec": {
                     "source": {self.source: {"url": self.url}},
-                    "pvc": {
-                        "accessModes": [self.access_modes],
+                    api_to_use: {
                         "resources": {"requests": {"storage": self.size}},
                     },
                 }
             }
         )
+        if self.access_modes:
+            res["spec"][api_to_use]["accessModes"] = [self.access_modes]
         if self.content_type:
             res["spec"]["contentType"] = self.content_type
         if self.storage_class:
-            res["spec"]["pvc"]["storageClassName"] = self.storage_class
+            res["spec"][api_to_use]["storageClassName"] = self.storage_class
         if self.secret:
             res["spec"]["source"][self.source]["secretRef"] = self.secret.name
         if self.volume_mode:
-            res["spec"]["pvc"]["volumeMode"] = self.volume_mode
+            res["spec"][api_to_use]["volumeMode"] = self.volume_mode
         if self.source == "http" or "registry":
             res["spec"]["source"][self.source]["url"] = self.url
         if self.cert_configmap:


### PR DESCRIPTION
  A new feature available in 4.10 is storage API
  that will replace the PVC API.
  At the moment, the default API of DataVolume class
  will remain PVC as both available in 4.10.

