### PR TITLE
Cherrypick remove nudge delete on namespaces (#74)

### DIFF
--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -1,7 +1,6 @@
 import logging
 
 from ocp_resources.resource import Resource
-from ocp_resources.utils import TimeoutExpiredError, nudge_delete
 
 
 LOGGER = logging.getLogger(__name__)
@@ -44,7 +43,4 @@ class Namespace(Resource):
             timeout (int): Time to wait for the resource.
 
         """
-        try:
-            super().client_wait_deleted(timeout=timeout)
-        except TimeoutExpiredError:
-            nudge_delete(name=self.name)
+        super().client_wait_deleted(timeout=timeout)

--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -34,13 +34,3 @@ class Namespace(Resource):
         if self.label:
             res.setdefault("metadata", {}).setdefault("labels", {}).update(self.label)
         return res
-
-    def client_wait_deleted(self, timeout):
-        """
-        client-side Wait until resource is deleted
-
-        Args:
-            timeout (int): Time to wait for the resource.
-
-        """
-        super().client_wait_deleted(timeout=timeout)

--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -27,13 +27,3 @@ class ProjectRequest(Resource):
 
     def clean_up(self):
         Project(name=self.name).delete(wait=True)
-
-    def client_wait_deleted(self, timeout):
-        """
-        client-side Wait until resource is deleted
-
-        Args:
-            timeout (int): Time to wait for the resource.
-
-        """
-        super().client_wait_deleted(timeout=timeout)

--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -1,5 +1,4 @@
 from ocp_resources.resource import TIMEOUT, Resource
-from ocp_resources.utils import TimeoutExpiredError, nudge_delete
 
 
 class Project(Resource):
@@ -37,7 +36,4 @@ class ProjectRequest(Resource):
             timeout (int): Time to wait for the resource.
 
         """
-        try:
-            super().client_wait_deleted(timeout=timeout)
-        except TimeoutExpiredError:
-            nudge_delete(name=self.name)
+        super().client_wait_deleted(timeout=timeout)

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -1,5 +1,4 @@
 import logging
-import subprocess
 import time
 
 
@@ -113,19 +112,3 @@ class TimeoutWatch:
         Return the remaining part of timeout since the object was created.
         """
         return self.start_time + self.timeout - time.time()
-
-
-# TODO: remove the nudge when the underlying issue with namespaces stuck in
-# Terminating state is fixed.
-# Upstream bug: https://github.com/kubernetes/kubernetes/issues/60807
-def nudge_delete(name):
-    LOGGER.info(f"Nudging namespace {name} while waiting for it to delete")
-    try:
-        # kube client is deficient so we have to use curl to kill stuck
-        # finalizers
-        subprocess.check_output(["./scripts/clean-namespace.sh", name])
-    except subprocess.CalledProcessError as exp:
-        # deliberately ignore all errors since an intermittent nudge
-        # failure is not the end of the world
-        LOGGER.error(f"Error happened while nudging namespace {name}: {exp}")
-        raise


### PR DESCRIPTION
##### Short description:
Cherrypick "Remove nudge_delete functionality"

##### More details:
Upstream bug: kubernetes/kubernetes#60807 is closed, there is no need to use nudge_delete anymore.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:

##### Release notes:
Cherrypick "Remove nudge_delete functionality"; as https://github.com/kubernetes/kubernetes/issues/60807 is fixed, there's no need to forcefully clean up resources.
