### PR TITLE
Added clean_up to Project

### DIFF
--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -13,6 +13,9 @@ class Project(Resource):
     class Status(Resource.Status):
         ACTIVE = "Active"
 
+    def clean_up(self):
+        Project(name=self.name).delete(wait=True)
+
 
 class ProjectRequest(Resource):
     """


### PR DESCRIPTION
##### Short description:
Add clean_up function to Project object
##### More details:

##### What this PR does / why we need it:
Project is a namespace with unprivileged_user, because of that an exception occurs when calling my_project.delete(wait=True).
The "wait=True" calls to API.get.namespace, which an unprivileged_user cant access.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
