### PR TITLE
NameSpace: Do not force namespace if yaml file

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -932,9 +932,6 @@ class NamespacedResource(Resource):
                 "namespace", self.namespace
             )
 
-        if not self.namespace:
-            raise ValueError("Namespace must be passed or specified in the YAML file.")
-
         if not self.yaml_file:
             res["metadata"]["namespace"] = self.namespace
 


### PR DESCRIPTION
##### Short description:
In Namespace resource, we do not need to check if namespace when passing YAML file.

##### More details:
YAML file can have namespace or namespace as place order in template

