### PR TITLE
nncp - change 'status' to propety

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -345,6 +345,7 @@ class NodeNetworkConfigurationPolicy(Resource):
             }
         ).update()
 
+    @property
     def status(self):
         for condition in self.instance.status.conditions:
             if condition["type"] == self.Conditions.Type.AVAILABLE:


### PR DESCRIPTION
##### Short description:
nncp - change 'status' to property to match Resource.status type

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
