### PR TITLE
Move kube_v1_api init to pod.execute (#561)

### DIFF
--- a/ocp_resources/pod.py
+++ b/ocp_resources/pod.py
@@ -60,7 +60,6 @@ class Pod(NamespacedResource):
             delete_timeout=delete_timeout,
             **kwargs,
         )
-        self._kube_api = kubernetes.client.CoreV1Api(api_client=self.client.client)
 
     @property
     def containers(self):
@@ -91,8 +90,9 @@ class Pod(NamespacedResource):
         error_channel = {}
         stream_closed_error = "stream resp is closed"
         LOGGER.info(f"Execute {command} on {self.name} ({self.node.name})")
+        kube_v1_api = kubernetes.client.CoreV1Api(api_client=self.client.client)
         resp = kubernetes.stream.stream(
-            api_method=self._kube_api.connect_get_namespaced_pod_exec,
+            api_method=kube_v1_api.connect_get_namespaced_pod_exec,
             name=self.name,
             namespace=self.namespace,
             command=command,


### PR DESCRIPTION
Reducing the number of attributes that must be handled
to serialize resources

Co-authored-by: Meni Yakove <441263+myakove@users.noreply.github.com>

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
