### PR TITLE
Resource additions for standalone k8s-nmstate. (#657)

### DIFF
--- a/ocp_resources/catalog_source.py
+++ b/ocp_resources/catalog_source.py
@@ -21,6 +21,7 @@ class CatalogSource(NamespacedResource):
         teardown=True,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
+        update_strategy_registry_poll_interval=None,
         **kwargs,
     ):
         super().__init__(
@@ -36,6 +37,9 @@ class CatalogSource(NamespacedResource):
         self.image = image
         self.display_name = display_name
         self.publisher = publisher
+        self.update_strategy_registry_poll_interval = (
+            update_strategy_registry_poll_interval
+        )
 
     def to_dict(self):
         res = super().to_dict()
@@ -52,5 +56,16 @@ class CatalogSource(NamespacedResource):
                 }
             }
         )
+
+        if self.update_strategy_registry_poll_interval:
+            res["spec"].update(
+                {
+                    "updateStrategy": {
+                        "registryPoll": {
+                            "interval": self.update_strategy_registry_poll_interval,
+                        },
+                    },
+                }
+            )
 
         return res

--- a/ocp_resources/nmstate.py
+++ b/ocp_resources/nmstate.py
@@ -1,0 +1,9 @@
+from ocp_resources.resource import Resource
+
+
+class NMState(Resource):
+    """
+    NMState, a CR of k8s-nmstate
+    """
+
+    api_group = Resource.ApiGroup.NMSTATE_IO


### PR DESCRIPTION
1. NMState CR.
2. Add spec.updateStrategy.registryPoll.interval to
 CatalogSource.
(Needed for installing standalone k8s-nmstate).

##### Short description: Need to backport this to 4.10, this would enable us to interact with standalone nmstate

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
