### PR TITLE
yaml_file created resource object has no name

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -868,6 +868,11 @@ class Resource:
         def _instance():
             return self.api.get(name=self.name)
 
+        if self.yaml_file and not self.name:
+            self.to_dict()
+            if not self.name:
+                raise ValueError(f"Resource name is {self.name}")
+
         return self.retry_cluster_exceptions(func=_instance)
 
     @property


### PR DESCRIPTION
Cannot call instance until name has been set.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
