### PR TITLE
Add microsecond precision to log

### DIFF
--- a/ocp_resources/logger.py
+++ b/ocp_resources/logger.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 from logging.handlers import RotatingFileHandler
 
 from colorlog import ColoredFormatter
@@ -26,6 +27,11 @@ class DuplicateFilter(logging.Filter):
         return False
 
 
+class WrapperLogFormatter(ColoredFormatter):
+    def formatTime(self, record, datefmt=None):  # noqa: N802
+        return datetime.fromtimestamp(record.created).isoformat()
+
+
 def get_logger(name):
     log_level = os.environ.get("OPENSHIFT_PYTHON_WRAPPER_LOG_LEVEL", "INFO")
     log_file = os.environ.get("OPENSHIFT_PYTHON_WRAPPER_LOG_FILE", "")
@@ -33,9 +39,8 @@ def get_logger(name):
         raise ValueError(f"Invalid log level: {log_level}")
 
     logger_obj = logging.getLogger(name)
-    log_formatter = ColoredFormatter(
-        fmt="%(name)s %(asctime)s %(log_color)s%(levelname) s%(reset)s %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
+    log_formatter = WrapperLogFormatter(
+        fmt="%(asctime)s %(name)s %(log_color)s%(levelname)s%(reset)s %(message)s",
         log_colors={
             "DEBUG": "cyan",
             "INFO": "green",


### PR DESCRIPTION
Log times of operations are overlapping in seconds and milliseconds

Reorder log output so datetime is at beginning of entry


Current:
```
ocp_resources.resource 2022-07-11 13:44:01 INFO Create DaemonSet utility
```

Updated:
```
2022-07-11T13:47:03.534892 ocp_resources.resource INFO Create DaemonSet utility
```
