### PR TITLE
[4.9] Add microsecond precision to log (#695)

### DIFF
--- a/ocp_resources/benchmark.py
+++ b/ocp_resources/benchmark.py
@@ -1,11 +1,10 @@
-import logging
-
 from ocp_resources.constants import NOT_FOUND_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class Benchmark(NamespacedResource):

--- a/ocp_resources/catalog_source.py
+++ b/ocp_resources/catalog_source.py
@@ -1,9 +1,8 @@
-import logging
-
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class CatalogSource(NamespacedResource):

--- a/ocp_resources/catalog_source_config.py
+++ b/ocp_resources/catalog_source_config.py
@@ -1,11 +1,10 @@
-import logging
-
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class CatalogSourceConfig(NamespacedResource):

--- a/ocp_resources/cdi_config.py
+++ b/ocp_resources/cdi_config.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import logging
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, Resource
 from ocp_resources.utils import TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class CDIConfig(Resource):

--- a/ocp_resources/daemonset.py
+++ b/ocp_resources/daemonset.py
@@ -1,13 +1,12 @@
-import logging
-
 import kubernetes
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class DaemonSet(NamespacedResource):

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 
-import logging
 
+from ocp_resources.logger import get_logger
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.resource import TIMEOUT, NamespacedResource, Resource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class DataVolume(NamespacedResource):

--- a/ocp_resources/deployment.py
+++ b/ocp_resources/deployment.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-import logging
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class Deployment(NamespacedResource):

--- a/ocp_resources/event.py
+++ b/ocp_resources/event.py
@@ -1,9 +1,8 @@
-import logging
-
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import Resource
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class Event:

--- a/ocp_resources/logger.py
+++ b/ocp_resources/logger.py
@@ -1,0 +1,71 @@
+import logging
+import os
+from datetime import datetime
+from logging.handlers import RotatingFileHandler
+
+from colorlog import ColoredFormatter
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DuplicateFilter(logging.Filter):
+    def filter(self, record):
+        repeated_number_exists = getattr(self, "repeated_number", None)
+        current_log = (record.module, record.levelno, record.msg)
+        if current_log != getattr(self, "last_log", None):
+            self.last_log = current_log
+            if repeated_number_exists:
+                LOGGER.warning(f"Last log repeated {self.repeated_number} times.")
+
+            self.repeated_number = 0
+            return True
+        if repeated_number_exists:
+            self.repeated_number += 1
+        else:
+            self.repeated_number = 1
+        return False
+
+
+class WrapperLogFormatter(ColoredFormatter):
+    def formatTime(self, record, datefmt=None):  # noqa: N802
+        return datetime.fromtimestamp(record.created).isoformat()
+
+
+def get_logger(name):
+    log_level = os.environ.get("OPENSHIFT_PYTHON_WRAPPER_LOG_LEVEL", "INFO")
+    log_file = os.environ.get("OPENSHIFT_PYTHON_WRAPPER_LOG_FILE", "")
+    if log_level not in ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]:
+        raise ValueError(f"Invalid log level: {log_level}")
+
+    logger_obj = logging.getLogger(name)
+    log_formatter = WrapperLogFormatter(
+        fmt="%(asctime)s %(name)s %(log_color)s%(levelname)s%(reset)s %(message)s",
+        log_colors={
+            "DEBUG": "cyan",
+            "INFO": "green",
+            "WARNING": "yellow",
+            "ERROR": "red",
+            "CRITICAL": "red,bg_white",
+        },
+        secondary_log_colors={},
+    )
+
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(fmt=log_formatter)
+    console_handler.addFilter(filter=DuplicateFilter())
+
+    logger_obj.addHandler(hdlr=console_handler)
+    logger_obj.setLevel(level=log_level)
+    logger_obj.addFilter(filter=DuplicateFilter())
+
+    if log_file:
+        log_handler = RotatingFileHandler(
+            filename=log_file, maxBytes=100 * 1024 * 1024, backupCount=20
+        )
+        log_handler.setFormatter(fmt=log_formatter)
+        log_handler.setLevel(level=log_level)
+        logger_obj.addHandler(hdlr=log_handler)
+
+    logger_obj.propagate = False
+    return logger_obj

--- a/ocp_resources/machine_set.py
+++ b/ocp_resources/machine_set.py
@@ -1,10 +1,9 @@
-import logging
-
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 TIMEOUT = 300

--- a/ocp_resources/mtv.py
+++ b/ocp_resources/mtv.py
@@ -1,9 +1,8 @@
-import logging
-
+from ocp_resources.logger import get_logger
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 def _get_status_condition_log_message(**status_condition):

--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -1,9 +1,8 @@
-import logging
-
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import Resource
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 _DELETE_NUDGE_DELAY = 30
 _DELETE_NUDGE_INTERVAL = 5

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -1,8 +1,8 @@
-import logging
 import re
 
 from openshift.dynamic.exceptions import ConflictError
 
+from ocp_resources.logger import get_logger
 from ocp_resources.node_network_configuration_enactment import (
     NodeNetworkConfigurationEnactment,
 )
@@ -11,7 +11,7 @@ from ocp_resources.resource import Resource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class NNCPConfigurationFailed(Exception):

--- a/ocp_resources/node_network_state.py
+++ b/ocp_resources/node_network_state.py
@@ -1,13 +1,13 @@
-import logging
 import time
 
 from openshift.dynamic.exceptions import ConflictError
 
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import Resource
 from ocp_resources.utils import TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 SLEEP = 1
 TIMEOUT = 240

--- a/ocp_resources/persistent_volume_claim.py
+++ b/ocp_resources/persistent_volume_claim.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import logging
 
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class PersistentVolumeClaim(NamespacedResource):

--- a/ocp_resources/pod.py
+++ b/ocp_resources/pod.py
@@ -1,14 +1,14 @@
 import json
-import logging
 
 import kubernetes
 
+from ocp_resources.logger import get_logger
 from ocp_resources.node import Node
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutWatch
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class ExecOnPodError(Exception):

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -1,6 +1,5 @@
 import contextlib
 import json
-import logging
 import os
 import re
 from distutils.version import Version
@@ -21,6 +20,7 @@ from ocp_resources.constants import (
     NOT_FOUND_ERROR_EXCEPTION_DICT,
     PROTOCOL_ERROR_EXCEPTION_DICT,
 )
+from ocp_resources.logger import get_logger
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
@@ -31,7 +31,7 @@ DEFAULT_CLUSTER_RETRY_EXCEPTIONS = {
     ServerTimeoutError: [],
 }
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 TIMEOUT = 240
 MAX_SUPPORTED_API_VERSION = "v1"
 

--- a/ocp_resources/route.py
+++ b/ocp_resources/route.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import logging
 
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class Route(NamespacedResource):

--- a/ocp_resources/sriov_network_node_state.py
+++ b/ocp_resources/sriov_network_node_state.py
@@ -1,10 +1,9 @@
-import logging
-
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class SriovNetworkNodeState(NamespacedResource):

--- a/ocp_resources/upload_token_request.py
+++ b/ocp_resources/upload_token_request.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import logging
 
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class UploadTokenRequest(NamespacedResource):

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -1,8 +1,9 @@
-import logging
 import time
 
+from ocp_resources.logger import get_logger
 
-LOGGER = logging.getLogger(__name__)
+
+LOGGER = get_logger(name=__name__)
 
 
 class TimeoutExpiredError(Exception):

--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import logging
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 from ocp_resources.virtual_machine_instance import VirtualMachineInstance
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class VirtualMachine(NamespacedResource):

--- a/ocp_resources/virtual_machine_import.py
+++ b/ocp_resources/virtual_machine_import.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 
 
-import logging
-
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 from ocp_resources.virtual_machine import VirtualMachine
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 def _map_mappings(mappings):

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -1,17 +1,17 @@
-import logging
 import shlex
 
 import xmltodict
 from openshift.dynamic.exceptions import ResourceNotFoundError
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class VirtualMachineInstance(NamespacedResource):

--- a/ocp_resources/virtual_machine_restore.py
+++ b/ocp_resources/virtual_machine_restore.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 
 
-import logging
-
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 from ocp_resources.virtual_machine import VirtualMachine
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class VirtualMachineRestore(NamespacedResource):

--- a/ocp_resources/virtual_machine_snapshot.py
+++ b/ocp_resources/virtual_machine_snapshot.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import logging
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 from ocp_resources.virtual_machine import VirtualMachine
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = get_logger(name=__name__)
 
 
 class VirtualMachineSnapshot(NamespacedResource):

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         "openshift==0.12.1",
         "xmltodict",
         "urllib3",
+        "colorlog",
     ],
     python_requires=">=3.6",
 )


### PR DESCRIPTION
Log times of operations are overlapping in seconds and milliseconds

(cherry picked from commit 0e88cf8fefad267248aeeff3dbf2943d3f313aac)

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
