### PR TITLE
flavors rename to instance types and preference added

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -313,7 +313,9 @@ class Resource:
         DATA_IMPORT_CRON_TEMPLATE_KUBEVIRT_IO = "dataimportcrontemplate.kubevirt.io"
         EVENTS_K8S_IO = "events.k8s.io"
         FORKLIFT_KONVEYOR_IO = "forklift.konveyor.io"
+        # TODO flavor renamed to instancetype from 4.12, should be removed in the future
         FLAVOR_KUBEVIRT_IO = "flavor.kubevirt.io"
+        INSTANCE_TYPE_KUBEVIRT_IO = "instancetype.kubevirt.io"
         HCO_KUBEVIRT_IO = "hco.kubevirt.io"
         HOSTPATHPROVISIONER_KUBEVIRT_IO = "hostpathprovisioner.kubevirt.io"
         IMAGE_OPENSHIFT_IO = "image.openshift.io"

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -313,8 +313,6 @@ class Resource:
         DATA_IMPORT_CRON_TEMPLATE_KUBEVIRT_IO = "dataimportcrontemplate.kubevirt.io"
         EVENTS_K8S_IO = "events.k8s.io"
         FORKLIFT_KONVEYOR_IO = "forklift.konveyor.io"
-        # TODO flavor renamed to instancetype from 4.12, should be removed in the future
-        FLAVOR_KUBEVIRT_IO = "flavor.kubevirt.io"
         INSTANCE_TYPE_KUBEVIRT_IO = "instancetype.kubevirt.io"
         HCO_KUBEVIRT_IO = "hco.kubevirt.io"
         HOSTPATHPROVISIONER_KUBEVIRT_IO = "hostpathprovisioner.kubevirt.io"

--- a/ocp_resources/virtual_machine_cluster_flavor.py
+++ b/ocp_resources/virtual_machine_cluster_flavor.py
@@ -1,5 +1,0 @@
-from ocp_resources.resource import Resource
-
-
-class VirtualMachineClusterFlavor(Resource):
-    api_group = Resource.ApiGroup.FLAVOR_KUBEVIRT_IO

--- a/ocp_resources/virtual_machine_cluster_instance_types.py
+++ b/ocp_resources/virtual_machine_cluster_instance_types.py
@@ -1,0 +1,5 @@
+from ocp_resources.resource import Resource
+
+
+class VirtualMachineClusterInstancetype(Resource):
+    api_group = Resource.ApiGroup.INSTANCE_TYPE_KUBEVIRT_IO

--- a/ocp_resources/virtual_machine_cluster_preferences.py
+++ b/ocp_resources/virtual_machine_cluster_preferences.py
@@ -1,0 +1,5 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class VirtualMachineClusterPreference(NamespacedResource):
+    api_group = NamespacedResource.ApiGroup.INSTANCE_TYPE_KUBEVIRT_IO

--- a/ocp_resources/virtual_machine_flavor.py
+++ b/ocp_resources/virtual_machine_flavor.py
@@ -1,5 +1,0 @@
-from ocp_resources.resource import NamespacedResource
-
-
-class VirtualMachineFlavor(NamespacedResource):
-    api_group = NamespacedResource.ApiGroup.FLAVOR_KUBEVIRT_IO

--- a/ocp_resources/virtual_machine_instance_types.py
+++ b/ocp_resources/virtual_machine_instance_types.py
@@ -1,0 +1,5 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class VirtualMachineInstancetype(NamespacedResource):
+    api_group = NamespacedResource.ApiGroup.INSTANCE_TYPE_KUBEVIRT_IO

--- a/ocp_resources/virtual_machine_preferences.py
+++ b/ocp_resources/virtual_machine_preferences.py
@@ -1,0 +1,5 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class VirtualMachinePreference(NamespacedResource):
+    api_group = NamespacedResource.ApiGroup.INSTANCE_TYPE_KUBEVIRT_IO


### PR DESCRIPTION
##### Short description:
- Flavors CR name was changed to instance type
- Added preference CR

##### Which issue(s) this PR fixes:
new CR added for CNV 4.12 release

##### Special notes for reviewer:
Flavors constant in resource.py is kept until 4.11 is officially out since it is still being used by older versions, it should be deleted in the future.
