### PR TITLE
Allow appending NNCPs

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -339,7 +339,7 @@ class NodeNetworkConfigurationPolicy(Resource):
         :param specs: list, list of config to append from supplied nncp
 
         Example:
-        bridge_nncp.append(bond_nncp, [bond_nncp.Spec.Routes, bond_nncp.Spec.Interfaces])
+        bridge_nncp.append(bond_nncp, [bond_nncp.Spec.ROUTES, bond_nncp.Spec.INTERFACES])
         will append routes and ifaces configured in bond_nncp to bridge_nncp.
         """
         if not self.res:


### PR DESCRIPTION
Allow appending NNCP config.
This will allow adding ifaces/routes/capture config from one nncp to the other.
Current option to add_interface is very limiting when creating NNCPs that require more complex config (Like one with a bridge iface and a bond iface)