### PR TITLE
Return cluster resource in deploy() if dry-run is passed

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -449,8 +449,9 @@ class Resource:
             if _resource:
                 return _resource
 
-        self.create(wait=wait)
-        return self
+        res = self.create(wait=wait)
+        #  dry-run object do not have instance, we return the cluster resource instead.
+        return res if self.dry_run is not None else self
 
     def clean_up(self):
         """


### PR DESCRIPTION
When calling deploy and passing dry-run no resource is created, therefore there is no `.instance`
We need to return the answer from the cluster is such case (the return of `create()`)