### PR TITLE
removing matchlabels field from migration policy 

### DIFF
--- a/ocp_resources/migration_policy.py
+++ b/ocp_resources/migration_policy.py
@@ -56,9 +56,7 @@ class MigrationPolicy(Resource):
             res["spec"]["completionTimeoutPerGiB"] = self.completion_timeout_per_gb
 
         if self.namespace_selector:
-            selectors.setdefault("namespaceSelector", {}).setdefault(
-                "matchLabels", self.namespace_selector
-            )
+            selectors.setdefault("namespaceSelector", self.namespace_selector)
 
         if self.vmi_selector:
             selectors.setdefault("virtualMachineInstanceSelector", {}).setdefault(


### PR DESCRIPTION
Signed-off-by: akriti gupta <akrgupta@redhat.com>

##### Short description: Following PR [https://github.com/kubevirt/kubevirt/pull/7510](https://github.com/kubevirt/kubevirt/pull/7510) suggests matchLabels  is now gone from MigrationPolicy spec, thus removing the matchLabels field from migtation Policy

##### More details:

##### What this PR does / why we need it:
Removes matchLabels field from specs of migration policy
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
**Release note**:
None