### PR TITLE
Removing matchLabels from vmi_selector

### DIFF
--- a/ocp_resources/migration_policy.py
+++ b/ocp_resources/migration_policy.py
@@ -59,8 +59,6 @@ class MigrationPolicy(Resource):
             selectors.setdefault("namespaceSelector", self.namespace_selector)
 
         if self.vmi_selector:
-            selectors.setdefault("virtualMachineInstanceSelector", {}).setdefault(
-                "matchLabels", self.vmi_selector
-            )
+            selectors.setdefault("virtualMachineInstanceSelector", self.vmi_selector)
 
         return res


### PR DESCRIPTION
Signed-off-by: akriti gupta <akrgupta@redhat.com>

##### Short description:
Following PR https://github.com/kubevirt/kubevirt/pull/7510 suggests matchLabels is now gone from MigrationPolicy spec, thus removing the matchLabels field from vmi_selector while creating migtation Policy
##### More details:

##### What this PR does / why we need it:
Removes matchLabels field from vmi_selector while creating Migration Policy
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:
#####Release note:
None

##### Bug:
