### PR TITLE
cherry-pick to V4.9: Storage: fix snapshot resources

### DIFF
--- a/ocp_resources/constants.py
+++ b/ocp_resources/constants.py
@@ -4,3 +4,5 @@ from urllib3.exceptions import ProtocolError
 
 PROTOCOL_ERROR_EXCEPTION_DICT = {ProtocolError: []}
 NOT_FOUND_ERROR_EXCEPTION_DICT = {NotFoundError: []}
+TIMEOUT_1MINUTE = 60
+TIMEOUT_4MINUTES = 240

--- a/ocp_resources/constants.py
+++ b/ocp_resources/constants.py
@@ -4,5 +4,4 @@ from urllib3.exceptions import ProtocolError
 
 PROTOCOL_ERROR_EXCEPTION_DICT = {ProtocolError: []}
 NOT_FOUND_ERROR_EXCEPTION_DICT = {NotFoundError: []}
-TIMEOUT_1MINUTE = 60
 TIMEOUT_4MINUTES = 240

--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 
-from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT, TIMEOUT_4MINUTES
 from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
@@ -157,3 +157,14 @@ class VirtualMachine(NamespacedResource):
             VM printableStatus if VM.status.printableStatus else None
         """
         return self.instance.get("status", {}).get("printableStatus")
+
+    def wait_for_status_none(self, status, timeout=TIMEOUT_4MINUTES):
+        LOGGER.info(f"Wait for {self.kind} {self.name} status {status} to be None")
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=1,
+            exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
+            func=lambda: self.instance.get("status", {}).get(status),
+        ):
+            if sample is None:
+                return

--- a/ocp_resources/virtual_machine_restore.py
+++ b/ocp_resources/virtual_machine_restore.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from openshift.dynamic.exceptions import ResourceNotFoundError
 
 from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
 from ocp_resources.logger import get_logger
@@ -77,3 +78,26 @@ class VirtualMachineRestore(NamespacedResource):
         for sample in samples:
             if sample:
                 return
+
+    def wait_restore_done(self, timeout=TIMEOUT_4MINUTES):
+        """
+        Wait for the the restore to be done. This check 2 parameters, the restore status to be complete
+        and the VM status restoreInProgress to be None.
+
+        Args:
+            timeout (int): Time to wait.
+
+        Raises:
+            TimeoutExpiredError: If timeout reached.
+        """
+        self.wait_complete(timeout=timeout)
+
+        vm = VirtualMachine(
+            client=self.client,
+            namespace=self.namespace,
+            name=self.vm_name,
+        )
+
+        if vm.exists:
+            return vm.wait_for_status_none(status="restoreInProgress", timeout=timeout)
+        raise ResourceNotFoundError(f"VirtualMachine: {vm.name} not found")

--- a/ocp_resources/virtual_machine_restore.py
+++ b/ocp_resources/virtual_machine_restore.py
@@ -2,7 +2,7 @@
 
 from openshift.dynamic.exceptions import ResourceNotFoundError
 
-from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT, TIMEOUT_4MINUTES
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
 from ocp_resources.virtual_machine import VirtualMachine

--- a/ocp_resources/virtual_machine_snapshot.py
+++ b/ocp_resources/virtual_machine_snapshot.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 
 
-from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT
+from openshift.dynamic.exceptions import ResourceNotFoundError
+from ocp_resources.constants import PROTOCOL_ERROR_EXCEPTION_DICT, TIMEOUT_4MINUTES
 from ocp_resources.logger import get_logger
 from ocp_resources.resource import TIMEOUT, NamespacedResource
 from ocp_resources.utils import TimeoutSampler
@@ -74,3 +75,26 @@ class VirtualMachineSnapshot(NamespacedResource):
         for sample in samples:
             if sample:
                 return
+
+    def wait_snapshot_done(self, timeout=TIMEOUT_4MINUTES):
+        """
+        Wait for the the snapshot to be done. This check 2 parameters, the snapshot status to be readyToUse
+        and the VM status snapshotInProgress to be None.
+
+        Args:
+            timeout (int): Time to wait.
+
+        Raises:
+            TimeoutExpiredError: If timeout reached.
+        """
+        self.wait_ready_to_use(timeout=timeout)
+
+        vm = VirtualMachine(
+            client=self.client,
+            namespace=self.namespace,
+            name=self.vm_name,
+        )
+
+        if vm.exists:
+            return vm.wait_for_status_none(status="snapshotInProgress", timeout=timeout)
+        raise ResourceNotFoundError(f"VirtualMachine: {vm.name} not found")


### PR DESCRIPTION
* Storage: fix snapshot resources

  Restore status complete and snapshot status readyToUse are not enough to determine that the restore/snapshot are done. Added a function that takes the VM status in consideration as well

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
