### PR TITLE
create(), remove body args

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -303,7 +303,7 @@ class NodeNetworkConfigurationPolicy(Resource):
         self.ipv4_ports_backup()
         self.ipv6_ports_backup()
 
-        self.create(body=self.res, wait=wait)
+        self.create(wait=wait)
         try:
             self.wait_for_status_success()
             return self

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -660,12 +660,11 @@ class Resource:
                 )
             raise
 
-    def create(self, body=None, wait=False):
+    def create(self, wait=False):
         """
         Create resource.
 
         Args:
-            body (dict): Resource data to create.
             wait (bool) : True to wait for resource status.
 
         Returns:
@@ -675,19 +674,6 @@ class Resource:
             ValueMismatch: When body value doesn't match class value
         """
         data = self.to_dict()
-        if body:
-            kind = body["kind"]
-            name = body.get("name")
-            api_version = body["apiVersion"]
-            if kind != self.kind:
-                raise ValueMismatch(f"{kind} != {self.kind}")
-            if name and name != self.name:
-                raise ValueMismatch(f"{name} != {self.name}")
-            if api_version != self.api_version:
-                raise ValueMismatch(f"{api_version} != {self.api_version}")
-
-            data.update(body)
-
         self.logger.info(f"Create {self.kind} {self.name}")
         self.logger.info(f"Posting {data}")
         self.logger.debug(f"\n{yaml.dump(data)}")


### PR DESCRIPTION
##### Short description:
body is not needed when calling create, we use to_dict to generate the resource body.
