### PR TITLE
Fix the typo in VM status

### DIFF
--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -26,7 +26,7 @@ class VirtualMachine(NamespacedResource):
         PAUSED = "Paused"
         PROVISIONING = "Provisioning"
         STARTING = "Starting"
-        STOPPED = "stopped"
+        STOPPED = "Stopped"
         STOPPING = "Stopping"
         WAITING_FOR_VOLUME_BINDING = "WaitingForVolumeBinding"
 


### PR DESCRIPTION
##### Short description:
There is a typo in VM statuses: the word "stopped" should begin with a
capital letter S