### PR TITLE
Node Health Check was incorrectly mentioned as namespace dependent in  documentation.

### DIFF
--- a/ocp_resources/node_health_check.py
+++ b/ocp_resources/node_health_check.py
@@ -1,10 +1,10 @@
-from ocp_resources.resource import NamespacedResource
+from ocp_resources.resource import Resource
 
 
-class NodeHealthCheck(NamespacedResource):
+class NodeHealthCheck(Resource):
     """
     NodeHealthCheck object.
     Reference : https://github.com/medik8s/node-healthcheck-operator
     """
 
-    api_group = NamespacedResource.ApiGroup.REMEDIATION_MEDIK8S_IO
+    api_group = Resource.ApiGroup.REMEDIATION_MEDIK8S_IO


### PR DESCRIPTION


Signed-off-by: Geetika Kapoor <gkapoor@redhat.com>

##### Short description:

This PR is to fix node health check and removing it's dependency from namespace. There is a documentation bug to fix it  from openshift documentation. 

Refer : https://issues.redhat.com/browse/TELCODOCS-1029

##### More details:

##### What this PR does / why we need it:
When node health check operator is installed it installs Nodehealthcheck and self-node-remediation. Out of which nodehealthcheck is cluster scoped and self-node-remediation is namespaced scope but documentation mentioned both as namespaced scope.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
