### PR TITLE
[v4.10] Fix the typo in VM status

### DIFF
--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -26,7 +26,7 @@ class VirtualMachine(NamespacedResource):
         PAUSED = "Paused"
         PROVISIONING = "Provisioning"
         STARTING = "Starting"
-        STOPPED = "stopped"
+        STOPPED = "Stopped"
         STOPPING = "Stopping"
 
     def __init__(


### PR DESCRIPTION
##### Short description: There is a typo in VM statuses: the word "stopped" should begin with a capital letter S

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
