### PR TITLE
Add Topolvm storage class and reorder the storage classes

### DIFF
--- a/ocp_resources/storage_class.py
+++ b/ocp_resources/storage_class.py
@@ -15,17 +15,19 @@ class StorageClass(Resource):
         These are names of StorageClass instances when you run `oc get sc`
         """
 
-        LOCAL_BLOCK = "local-block"
-        HOSTPATH = "hostpath-provisioner"
         CEPH_RBD = "ocs-storagecluster-ceph-rbd"
-        NFS = "nfs"
+        HOSTPATH = "hostpath-provisioner"
         HOSTPATH_CSI = "hostpath-csi"
+        LOCAL_BLOCK = "local-block"
+        NFS = "nfs"
+        TOPOLVM = "odf-lvm-vg1"
 
     class Provisioner:
-        HOSTPATH = "kubevirt.io/hostpath-provisioner"
-        NO_PROVISIONER = "kubernetes.io/no-provisioner"
         CEPH_RBD = "openshift-storage.rbd.csi.ceph.com"
+        HOSTPATH = "kubevirt.io/hostpath-provisioner"
         HOSTPATH_CSI = "kubevirt.io.hostpath-provisioner"
+        NO_PROVISIONER = "kubernetes.io/no-provisioner"
+        TOPOLVM = "topolvm.cybozu.com"
 
     class VolumeBindingMode:
         """


### PR DESCRIPTION
##### Short description:
Add Topolvm storage class and reorder the storage classes in alphabetical order

##### More details:
Starting SNO 4.12, Topolvm is the default storage class that is being deployed by Assisted Installer
