### PR TITLE
Add controller revision resource

### DIFF
--- a/ocp_resources/controller_revision.py
+++ b/ocp_resources/controller_revision.py
@@ -1,5 +1,43 @@
+# https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/controller-revision-v1/
+from ocp_resources.constants import TIMEOUT_4MINUTES
 from ocp_resources.resource import NamespacedResource
 
 
 class ControllerRevision(NamespacedResource):
     api_group = NamespacedResource.ApiGroup.APPS
+
+    def __init__(
+        self,
+        name=None,
+        namespace=None,
+        client=None,
+        teardown=True,
+        timeout=TIMEOUT_4MINUTES,
+        privileged_client=None,
+        yaml_file=None,
+        delete_timeout=TIMEOUT_4MINUTES,
+        owner_references=None,
+        revision_object=None,
+        **kwargs,
+    ):
+        super().__init__(
+            name=name,
+            namespace=namespace,
+            client=client,
+            teardown=teardown,
+            timeout=timeout,
+            privileged_client=privileged_client,
+            yaml_file=yaml_file,
+            delete_timeout=delete_timeout,
+            **kwargs,
+        )
+        self.owner_references = owner_references
+        self.revision_object = revision_object
+
+    def to_dict(self):
+        """
+        Generate intended dict representation of the resource.
+        """
+        self._base_body()
+        self.res["metadata"]["ownerReference"] = self.owner_references
+        self.res["data"] = self.revision_object.res

--- a/ocp_resources/controller_revision.py
+++ b/ocp_resources/controller_revision.py
@@ -1,0 +1,5 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class ControllerRevision(NamespacedResource):
+    api_group = NamespacedResource.ApiGroup.APPS

--- a/ocp_resources/controller_revision.py
+++ b/ocp_resources/controller_revision.py
@@ -35,9 +35,11 @@ class ControllerRevision(NamespacedResource):
         self.revision_object = revision_object
 
     def to_dict(self):
-        """
-        Generate intended dict representation of the resource.
-        """
-        self._base_body()
-        self.res["metadata"]["ownerReference"] = self.owner_references
-        self.res["data"] = self.revision_object.res
+        super().to_dict()
+        if not self.yaml_file:
+            if self.owner_references:
+                self.res.setdefault("metadata", {}).update(
+                    {"ownerReference": self.owner_references}
+                )
+            if self.revision_object:
+                self.res.update({"data": self.revision_object.res})


### PR DESCRIPTION
##### Short description:
Add controller revision resource to ocp_resources

##### More details:
controller revision is used to control and log the version (changed on edits) of the resource it is attached to
