### PR TITLE
Add MetalLB and it's resources

### DIFF
--- a/ocp_resources/ip_address_pool.py
+++ b/ocp_resources/ip_address_pool.py
@@ -1,0 +1,56 @@
+# API reference: https://metallb.universe.tf/apis/#metallb.io/v1beta1.IPAddressPool
+
+from ocp_resources.resource import NamespacedResource
+
+
+class IPAddressPool(NamespacedResource):
+    """
+    IPAddressPool object.
+    """
+
+    api_group = NamespacedResource.ApiGroup.METALLB_IO
+
+    def __init__(
+        self,
+        name=None,
+        namespace=None,
+        client=None,
+        addresses=None,
+        auto_assign=True,
+        avoid_buggy_ips=False,
+        **kwargs,
+    ):
+        """
+        Args:
+            name (str): Name of the MetalLB or it's CR's.
+            namespace (str): Namespace of the MetalLB
+            client: (DynamicClient): DynamicClient to use.
+            addresses (list): List of IP addresses.
+            auto_assign (bool): IP address assignment. (default: True)
+            avoid_buggy_ips (bool): Avoid buggy IP address (default: False)
+        """
+        super().__init__(
+            name=name,
+            namespace=namespace,
+            client=client,
+            **kwargs,
+        )
+        self.addresses = addresses
+        self.auto_assign = auto_assign
+        self.avoid_buggy_ips = avoid_buggy_ips
+
+    def to_dict(self):
+        super().to_dict()
+        if not self.yaml_file:
+            if not self.addresses:
+                raise ValueError(
+                    "Either required parameter is missing 'addresses' or provide yaml_file."
+                )
+
+            self.res["spec"] = {"addresses": self.addresses}
+
+            if self.auto_assign:
+                self.res["spec"]["autoAssign"] = self.auto_assign
+
+            if self.avoid_buggy_ips:
+                self.res["spec"]["avoidBuggyIPs"] = self.avoid_buggy_ips

--- a/ocp_resources/l2_advertisement.py
+++ b/ocp_resources/l2_advertisement.py
@@ -1,0 +1,56 @@
+# API reference: https://metallb.universe.tf/apis/#metallb.io/v1beta1.L2Advertisement
+
+from ocp_resources.resource import NamespacedResource
+
+
+class L2Advertisement(NamespacedResource):
+    """
+    L2Advertisement object.
+    """
+
+    api_group = NamespacedResource.ApiGroup.METALLB_IO
+
+    def __init__(
+        self,
+        name=None,
+        namespace=None,
+        client=None,
+        interfaces=None,
+        ip_address_pools=None,
+        ip_address_pools_selectors=None,
+        **kwargs,
+    ):
+        """
+        Args:
+            name (str): Name of the MetalLB or it's CR's.
+            namespace (str): Namespace of the MetalLB
+            client: (DynamicClient): DynamicClient to use.
+            interfaces (list): List of interfaces.
+            ip_address_pools (list): The list of IPAddressPools to advertise via this advertisement, selected by name.
+            ip_address_pools_selectors (list): A selector for the IPAddressPools which would get advertised
+                        via this advertisement.(if nothing mentioned then it will be applied to all the IPAddressPools)
+        """
+        super().__init__(
+            name=name,
+            namespace=namespace,
+            client=client,
+            **kwargs,
+        )
+        self.interfaces = interfaces
+        self.ip_address_pools = ip_address_pools
+        self.ip_address_pools_selectors = ip_address_pools_selectors
+
+    def to_dict(self):
+        super().to_dict()
+        if not self.yaml_file:
+            self.res["spec"] = {}
+            if self.interfaces:
+                self.res["spec"]["interfaces"] = self.interfaces
+
+            if self.ip_address_pools:
+                self.res["spec"]["ipAddressPools"] = self.ip_address_pools
+
+            if self.ip_address_pools_selectors:
+                self.res["spec"][
+                    "ipAddressPoolSelectors"
+                ] = self.ip_address_pools_selectors

--- a/ocp_resources/metallb.py
+++ b/ocp_resources/metallb.py
@@ -1,0 +1,53 @@
+# Reference Doc: https://github.com/metallb/metallb-operator/blob/main/api/v1beta1/metallb_types.go
+
+from ocp_resources.resource import NamespacedResource
+
+
+class MetalLB(NamespacedResource):
+    """
+    MetalLB object.
+    """
+
+    api_group = NamespacedResource.ApiGroup.METALLB_IO
+
+    def __init__(
+        self,
+        name=None,
+        namespace=None,
+        client=None,
+        log_level="info",
+        speaker_config=None,
+        speaker_tolerations=None,
+        **kwargs,
+    ):
+        """
+        Args:
+            name (str): Name of the MetalLB or it's CR's.
+            namespace (str): Namespace of the MetalLB
+            client: (DynamicClient): DynamicClient to use.
+            log_level(str): The verbosity of the controller and the speaker logging.
+                            Allowed values are: all, debug, info, warn, error, none. (default: info)
+            speaker_config (dict): Additional configs to be applied on MetalLB Speaker daemonset.
+            speaker_tolerations (list): List of tolerations to be applied on Speaker Daemonset.
+        """
+        super().__init__(
+            name=name,
+            namespace=namespace,
+            client=client,
+            **kwargs,
+        )
+        self.log_level = log_level
+        self.speaker_config = speaker_config
+        self.speaker_tolerations = speaker_tolerations
+
+    def to_dict(self):
+        super().to_dict()
+        if not self.yaml_file:
+            self.res["spec"] = {}
+            self.res["spec"]["logLevel"] = self.log_level
+
+            if self.speaker_config:
+                self.res["spec"]["speakerConfig"] = self.speaker_config
+
+            if self.speaker_tolerations:
+                self.res["spec"]["speakerTolerations"] = self.speaker_tolerations

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -279,6 +279,7 @@ class Resource:
         MACHINE_OPENSHIFT_IO = "machine.openshift.io"
         MACHINECONFIGURATION_OPENSHIFT_IO = "machineconfiguration.openshift.io"
         MAISTRA_IO = "maistra.io"
+        METALLB_IO = "metallb.io"
         MIGRATIONS_KUBEVIRT_IO = "migrations.kubevirt.io"
         MONITORING_COREOS_COM = "monitoring.coreos.com"
         NETWORKADDONSOPERATOR_NETWORK_KUBEVIRT_IO = (


### PR DESCRIPTION
Add MetalLB Resources into ocp_wrapper.

##### Short description: In this PR adding MetalLB, IPAddressPool and L2Advertisement CR"s.

##### More details: For on-premises cluster, MetalLB will play role of managing LoadBalancer. 

##### What this PR does / why we need it: In order to check the compatibility of MetalLB and it's resources with the Bare metal clusters. We require these resources to be added in this repository.

Signed-off-by: Satyajit Bulage <sbulage@redhat.com>