### PR TITLE
override create() and deploy() for projectrequest

### DIFF
--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -1,3 +1,5 @@
+import yaml
+
 from ocp_resources.constants import TIMEOUT_4MINUTES
 from ocp_resources.resource import Resource
 
@@ -58,3 +60,28 @@ class ProjectRequest(Resource):
 
         """
         super().client_wait_deleted(timeout=timeout)
+
+    def deploy(self):
+        self.create()
+
+    def create(self):
+        """
+        Create a ProjectRequest
+
+        Returns:
+            bool: True if create succeeded, False otherwise.
+
+        Raises:
+            ValueMismatch: When body value doesn't match class value
+        """
+        if not self.res:
+            self.to_dict()
+
+        self.logger.info(f"Create {self.kind} {self.name}")
+        self.logger.info(f"Posting {self.res}")
+        self.logger.debug(f"\n{yaml.dump(self.res)}")
+
+        resource_ = self.api.create(
+            body=self.res, namespace=self.namespace, dry_run=self.dry_run
+        )
+        return resource_

--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -61,16 +61,7 @@ class ProjectRequest(Resource):
         """
         super().client_wait_deleted(timeout=timeout)
 
-    def deploy(self):
-        """
-        deploy a ProjectRequest
-
-        Returns:
-            bool: True if deploy succeeded, False otherwise.
-
-        Raises:
-            ValueMismatch: When body value doesn't match class value
-        """
+    def deploy(self, wait=False):
         if not self.res:
             self.to_dict()
 
@@ -79,4 +70,7 @@ class ProjectRequest(Resource):
         self.logger.debug(f"\n{yaml.dump(self.res)}")
 
         self.api.create(body=self.res, namespace=self.namespace, dry_run=self.dry_run)
+        if wait:
+            project = Project(name=self.name, client=self.client)
+            project.wait()
         return self

--- a/ocp_resources/project.py
+++ b/ocp_resources/project.py
@@ -62,14 +62,11 @@ class ProjectRequest(Resource):
         super().client_wait_deleted(timeout=timeout)
 
     def deploy(self):
-        self.create()
-
-    def create(self):
         """
-        Create a ProjectRequest
+        deploy a ProjectRequest
 
         Returns:
-            bool: True if create succeeded, False otherwise.
+            bool: True if deploy succeeded, False otherwise.
 
         Raises:
             ValueMismatch: When body value doesn't match class value
@@ -81,7 +78,5 @@ class ProjectRequest(Resource):
         self.logger.info(f"Posting {self.res}")
         self.logger.debug(f"\n{yaml.dump(self.res)}")
 
-        resource_ = self.api.create(
-            body=self.res, namespace=self.namespace, dry_run=self.dry_run
-        )
-        return resource_
+        self.api.create(body=self.res, namespace=self.namespace, dry_run=self.dry_run)
+        return self


### PR DESCRIPTION
##### Short description: Need to override deploy() call for project request, as currently if an unprivileged user is making a projectrequest post call, using the base class create(), this call would fail due to `self.instance.metadata.resourceVersion` line. As unprivileged user can't make this call.

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
