### PR TITLE
update Virt Launcher Pod Hypervisor Connection URI

### DIFF
--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -245,7 +245,7 @@ class VirtualMachineInstance(NamespacedResource):
         return (
             ""
             if self.is_virt_launcher_pod_root
-            else "-c qemu+unix:///session?socket=/var/run/libvirt/libvirt-sock"
+            else "-c qemu+unix:///session?socket=/var/run/libvirt/virtqemud.sock"
         )
 
     def get_domstate(self):


### PR DESCRIPTION
Signed-off-by: akriti gupta <akrgupta@redhat.com>

##### Short description:

##### More details:
This PR updates Virt Launcher Pod Hypervisor Connection URI socket to /var/run/libvirt/virtqemud.sock from /var/run/libvirt/libvirt-sock for 4.13
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
