### PR TITLE
virt-launcher: Switch to virtqemud

### DIFF
--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -245,7 +245,7 @@ class VirtualMachineInstance(NamespacedResource):
         return (
             ""
             if self.is_virt_launcher_pod_root
-            else "-c qemu+unix:///session?socket=/var/run/libvirt/libvirt-sock"
+            else "-c qemu+unix:///session?socket=/var/run/libvirt/virtqemud-sock"
         )
 
     def get_domstate(self):


### PR DESCRIPTION
Signed-off-by: akriti gupta <akrgupta@redhat.com>

##### Short description:

##### More details:

##### What this PR does / why we need it:
This PR update Virt Launcher Pod Hypervisor Connection URI socket to /var/run/libvirt/virtqemud-sock for 4.13
https://github.com/kubevirt/kubevirt/pull/8619

##### Release note:


> virt-launcher: use `virtqemud` daemon instead of `libvirtd`

