### PR TITLE
Return from nncp_wait_for_configuration if configured successfully

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -345,6 +345,12 @@ class NodeNetworkConfigurationPolicy(Resource):
                 return condition["reason"]
 
     def wait_for_configuration_conditions_unknown_or_progressing(self, wait_timeout=30):
+        if (
+            self.status
+            and self.status == self.Conditions.Reason.SUCCESSFULLY_CONFIGURED
+        ):
+            return
+
         samples = TimeoutSampler(
             wait_timeout=wait_timeout,
             sleep=1,


### PR DESCRIPTION
Refactor wait_for_confinuration_conditions_unknown_or_progressing to return if nncp is already configured successfully. It can happen that when debugging, a nncp is configured successfully, but an assert raises if we get into wait_for_configuration_conditions_unknown_or_progressing after the nncp was already configured successfully.

Signed-off-by: Anat Wax <awax@redhat.com>

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
