### PR TITLE
OCSInitialization resource from the ocs.openshift.io API group

### DIFF
--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -25,6 +25,9 @@ class OCSInitialization(NamespacedResource):
         enable_ceph_tools=None,
         **kwargs,
     ):
+        if not enable_ceph_tools:
+            raise ValueError("Please provide enable_ceph_tools")
+
         super().__init__(
             name=name,
             namespace=namespace,
@@ -40,10 +43,6 @@ class OCSInitialization(NamespacedResource):
     def to_dict(self):
         super().to_dict()
         if not self.yaml_file:
-            if not self.enable_ceph_tools:
-                raise ValueError(
-                    "Please provide either enable_ceph_tools or a valid YAML file"
-                )
             self.res.update(
                 {
                     "spec": {

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -1,0 +1,9 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class OCSInitialization(NamespacedResource):
+    """
+    OCSInitialization object.
+    """
+
+    api_group = NamespacedResource.ApiGroup.OCS_OPENSHIFT_IO

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -9,6 +9,11 @@ class OCSInitialization(NamespacedResource):
     API reference (source code linked here due to lack of API doc for this resource):
         https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/ocsinitialization_types.go
 
+    Args:
+        enable_ceph_tools : Boolean
+            When set to True, creates a Deployment named "rook-ceph-tools" in the "openshift-storage" namespace.
+            More information about the Rook Ceph Toolbox can be found here:
+            https://rook.io/docs/rook/v1.10/Troubleshooting/ceph-toolbox/
     """
 
     api_group = NamespacedResource.ApiGroup.OCS_OPENSHIFT_IO

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -43,9 +43,7 @@ class OCSInitialization(NamespacedResource):
 
     def to_dict(self):
         super().to_dict()
-        if not self.yaml_file:
-            if not self.enable_ceph_tools:
-                raise ValueError("Please provide enable_ceph_tools")
+        if self.yaml_file is None and self.enable_ceph_tools is not None:
             self.res.update(
                 {
                     "spec": {

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -3,12 +3,6 @@ from ocp_resources.resource import NamespacedResource
 
 
 class OCSInitialization(NamespacedResource):
-    """
-    OCSInitialization object.
-
-    API reference (source code linked here due to lack of API doc for this resource):
-        https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/ocsinitialization_types.go
-    """
 
     api_group = NamespacedResource.ApiGroup.OCS_OPENSHIFT_IO
 
@@ -25,8 +19,14 @@ class OCSInitialization(NamespacedResource):
         **kwargs,
     ):
         """
-        enable_ceph_tools : Boolean
-            When set to True, creates a Deployment named "rook-ceph-tools" in the "openshift-storage" namespace.
+        OCSInitialization object.
+
+        API reference (source code linked here due to lack of API doc for this resource):
+            https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/ocsinitialization_types.go
+
+        Args:
+        enable_ceph_tools (Boolean):
+            When True, creates a Deployment named "rook-ceph-tools" in the "openshift-storage" namespace.
             More information about the Rook Ceph Toolbox can be found here:
             https://rook.io/docs/rook/v1.10/Troubleshooting/ceph-toolbox/
         """

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -30,8 +30,6 @@ class OCSInitialization(NamespacedResource):
         enable_ceph_tools=None,
         **kwargs,
     ):
-        if not enable_ceph_tools:
-            raise ValueError("Please provide enable_ceph_tools")
 
         super().__init__(
             name=name,
@@ -48,6 +46,8 @@ class OCSInitialization(NamespacedResource):
     def to_dict(self):
         super().to_dict()
         if not self.yaml_file:
+            if not self.enable_ceph_tools:
+                raise ValueError("Please provide enable_ceph_tools")
             self.res.update(
                 {
                     "spec": {

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -8,12 +8,6 @@ class OCSInitialization(NamespacedResource):
 
     API reference (source code linked here due to lack of API doc for this resource):
         https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/ocsinitialization_types.go
-
-    Args:
-        enable_ceph_tools : Boolean
-            When set to True, creates a Deployment named "rook-ceph-tools" in the "openshift-storage" namespace.
-            More information about the Rook Ceph Toolbox can be found here:
-            https://rook.io/docs/rook/v1.10/Troubleshooting/ceph-toolbox/
     """
 
     api_group = NamespacedResource.ApiGroup.OCS_OPENSHIFT_IO
@@ -30,6 +24,12 @@ class OCSInitialization(NamespacedResource):
         enable_ceph_tools=None,
         **kwargs,
     ):
+        """
+        enable_ceph_tools : Boolean
+            When set to True, creates a Deployment named "rook-ceph-tools" in the "openshift-storage" namespace.
+            More information about the Rook Ceph Toolbox can be found here:
+            https://rook.io/docs/rook/v1.10/Troubleshooting/ceph-toolbox/
+        """
 
         super().__init__(
             name=name,

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -43,7 +43,7 @@ class OCSInitialization(NamespacedResource):
 
     def to_dict(self):
         super().to_dict()
-        if self.yaml_file is None and self.enable_ceph_tools is not None:
+        if not self.yaml_file and self.enable_ceph_tools is not None:
             self.res.update(
                 {
                     "spec": {

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -20,15 +20,13 @@ class OCSInitialization(NamespacedResource):
     ):
         """
         OCSInitialization object.
-
         API reference (source code linked here due to lack of API doc for this resource):
             https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/ocsinitialization_types.go
 
         Args:
-        enable_ceph_tools (Boolean):
-            When True, creates a Deployment named "rook-ceph-tools" in the "openshift-storage" namespace.
-            More information about the Rook Ceph Toolbox can be found here:
-            https://rook.io/docs/rook/v1.10/Troubleshooting/ceph-toolbox/
+            enable_ceph_tools (bool): When True, creates a Deployment named "rook-ceph-tools" in the "openshift-storage"
+             namespace. More information about the Rook Ceph Toolbox can be found here:
+             https://rook.io/docs/rook/v1.10/Troubleshooting/ceph-toolbox/
         """
 
         super().__init__(

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -1,3 +1,4 @@
+from ocp_resources.constants import TIMEOUT_4MINUTES
 from ocp_resources.resource import NamespacedResource
 
 
@@ -7,3 +8,28 @@ class OCSInitialization(NamespacedResource):
     """
 
     api_group = NamespacedResource.ApiGroup.OCS_OPENSHIFT_IO
+
+    def __init__(
+        self,
+        name=None,
+        namespace=None,
+        client=None,
+        teardown=False,
+        privileged_client=None,
+        yaml_file=None,
+        delete_timeout=TIMEOUT_4MINUTES,
+        **kwargs,
+    ):
+        super().__init__(
+            name=name,
+            namespace=namespace,
+            client=client,
+            teardown=teardown,
+            privileged_client=privileged_client,
+            yaml_file=yaml_file,
+            delete_timeout=delete_timeout,
+            **kwargs,
+        )
+
+    def to_dict(self):
+        super().to_dict()

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -22,7 +22,7 @@ class OCSInitialization(NamespacedResource):
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
-        enable_ceph_tools=False,
+        enable_ceph_tools=None,
         **kwargs,
     ):
         super().__init__(
@@ -40,6 +40,10 @@ class OCSInitialization(NamespacedResource):
     def to_dict(self):
         super().to_dict()
         if not self.yaml_file:
+            if not self.enable_ceph_tools:
+                raise ValueError(
+                    "Please provide either enable_ceph_tools or a valid YAML file"
+                )
             self.res.update(
                 {
                     "spec": {

--- a/ocp_resources/ocs_initialization.py
+++ b/ocp_resources/ocs_initialization.py
@@ -5,6 +5,10 @@ from ocp_resources.resource import NamespacedResource
 class OCSInitialization(NamespacedResource):
     """
     OCSInitialization object.
+
+    API reference (source code linked here due to lack of API doc for this resource):
+        https://github.com/red-hat-storage/ocs-operator/blob/main/api/v1/ocsinitialization_types.go
+
     """
 
     api_group = NamespacedResource.ApiGroup.OCS_OPENSHIFT_IO
@@ -18,6 +22,7 @@ class OCSInitialization(NamespacedResource):
         privileged_client=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
+        enable_ceph_tools=False,
         **kwargs,
     ):
         super().__init__(
@@ -30,6 +35,15 @@ class OCSInitialization(NamespacedResource):
             delete_timeout=delete_timeout,
             **kwargs,
         )
+        self.enable_ceph_tools = enable_ceph_tools
 
     def to_dict(self):
         super().to_dict()
+        if not self.yaml_file:
+            self.res.update(
+                {
+                    "spec": {
+                        "enableCephTools": self.enable_ceph_tools,
+                    }
+                }
+            )

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -299,6 +299,7 @@ class Resource:
         V2V_KUBEVIRT_IO = "v2v.kubevirt.io"
         VELERO_IO = "velero.io"
         VM_KUBEVIRT_IO = "vm.kubevirt.io"
+        OCS_OPENSHIFT_IO = "ocs.openshift.io"
 
     class ApiVersion:
         V1 = "v1"

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -269,6 +269,7 @@ class Resource:
         NODE_LABELLER_KUBEVIRT_IO = "node-labeller.kubevirt.io"
         NMSTATE_IO = "nmstate.io"
         NODEMAINTENANCE_KUBEVIRT_IO = "nodemaintenance.kubevirt.io"
+        OCS_OPENSHIFT_IO = "ocs.openshift.io"
         OPERATOR_OPENSHIFT_IO = "operator.openshift.io"
         OPERATORS_COREOS_COM = "operators.coreos.com"
         OPERATORS_OPENSHIFT_IO = "operators.openshift.io"
@@ -299,7 +300,6 @@ class Resource:
         V2V_KUBEVIRT_IO = "v2v.kubevirt.io"
         VELERO_IO = "velero.io"
         VM_KUBEVIRT_IO = "vm.kubevirt.io"
-        OCS_OPENSHIFT_IO = "ocs.openshift.io"
 
     class ApiVersion:
         V1 = "v1"


### PR DESCRIPTION
##### Short description: OCSInitialization resource and ocs.openshift.io ApiGroup

##### More details: This adds the `OCSInitialization` resource as well as the `ocs.openshift.io` ApiGroup

##### What this PR does / why we need it: This will allow us to enable Ceph tools on the cluster by patching the resource

##### Which issue(s) this PR fixes: This doesn't fix any issues.

##### Special notes for reviewer: Please note that this doesn't require `__init__` as it not meant to be created, but patched.

##### Bug:
