### PR TITLE
When non-root virt-launcher:  Switch to virtqemud if machine type has rhel9 and 

### DIFF
--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -242,11 +242,22 @@ class VirtualMachineInstance(NamespacedResource):
         Returns:
             String: Hypervisor Connection URI
         """
-        return (
-            ""
-            if self.is_virt_launcher_pod_root
-            else "-c qemu+unix:///session?socket=/var/run/libvirt/virtqemud-sock"
-        )
+        if self.is_virt_launcher_pod_root:
+            hypervisor_connection_uri = ""
+        else:
+            virtqemud_socket = "virtqemud"
+            socket = (
+                virtqemud_socket
+                if virtqemud_socket
+                in self.virt_launcher_pod.execute(
+                    command=["ls", "/var/run/libvirt/"], container="compute"
+                )
+                else "libvirt"
+            )
+            hypervisor_connection_uri = (
+                f"-c qemu+unix:///session?socket=/var/run/libvirt/{socket}-sock"
+            )
+        return hypervisor_connection_uri
 
     def get_domstate(self):
         """


### PR DESCRIPTION
Signed-off-by: akriti gupta <akrgupta@redhat.com>

##### Short description:

##### More details:

##### What this PR does / why we need it:
This PR update Virt Launcher Pod Hypervisor Connection URI socket to /var/run/libvirt/virtqemud-sock if machine type has rhel9 
https://github.com/kubevirt/kubevirt/pull/8619

##### Release note:


> virt-launcher: use `virtqemud` daemon instead of `libvirtd` if machine type is rhel9

