### PR TITLE
Adding a new status constant ERROR_UNSCHEDULABLE under vm status

### DIFF
--- a/ocp_resources/virtual_machine.py
+++ b/ocp_resources/virtual_machine.py
@@ -33,6 +33,7 @@ class VirtualMachine(NamespacedResource):
         STOPPED = "Stopped"
         STOPPING = "Stopping"
         WAITING_FOR_VOLUME_BINDING = "WaitingForVolumeBinding"
+        ERROR_UNSCHEDULABLE = "ErrorUnschedulable"
 
     def __init__(
         self,


### PR DESCRIPTION
##### Short description:
Adding a new status constant ERROR_UNSCHEDULABLE under vm status
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
