### PR TITLE
Add label parameter to Resource object

### DIFF
--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -17,7 +17,6 @@ class Namespace(Resource):
         name=None,
         client=None,
         teardown=True,
-        label=None,
         yaml_file=None,
         delete_timeout=TIMEOUT_4MINUTES,
         **kwargs,
@@ -30,11 +29,3 @@ class Namespace(Resource):
             delete_timeout=delete_timeout,
             **kwargs,
         )
-        self.label = label
-
-    def to_dict(self):
-        super().to_dict()
-        if not self.yaml_file and self.label:
-            self.res.setdefault("metadata", {}).setdefault("labels", {}).update(
-                self.label
-            )

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -320,6 +320,7 @@ class Resource:
         node_selector_labels=None,
         config_file=None,
         context=None,
+        label=None,
         timeout_seconds=TIMEOUT_1MINUTE,
     ):
         """
@@ -338,6 +339,7 @@ class Resource:
             config_file (str): Path to config file for connecting to remote cluster.
             context (str): Context name for connecting to remote cluster.
             timeout_seconds (int): timeout for a get api call, call out be terminated after this many seconds
+            label (dict): Resource labels
 
         """
         if not self.api_group and not self.api_version:
@@ -352,6 +354,7 @@ class Resource:
         self.resource_dict = None  # Filled in case yaml_file is not None
         self.config_file = config_file
         self.context = context
+        self.label = label
         if not (self.name or self.yaml_file):
             raise ValueError("name or yaml file is required")
 
@@ -412,6 +415,10 @@ class Resource:
                 "kind": self.kind,
                 "metadata": {"name": self.name},
             }
+            if self.label:
+                self.res.setdefault("metadata", {}).setdefault("labels", {}).update(
+                    self.label
+                )
 
     def to_dict(self):
         """


### PR DESCRIPTION
##### Short description:
Add label parameter to Resource class

##### More details:
- Added label parameter to Resource object so it will be added to the resource manifest under metadata->labels
- Changed namespace.py so it will use the new label parameter in Resource object

##### What this PR does / why we need it:
Label field is relevant to all resources, this will enable easier use of creating a resource with labels.
Also made changes to Namespace so they will use the label parameter 

##### Which issue(s) this PR fixes:
Enable use of label when creating a new DataSource
