### PR TITLE
Refactor the code according to flake8 errors

### DIFF
--- a/ocp_resources/node.py
+++ b/ocp_resources/node.py
@@ -14,12 +14,9 @@ class Node(Resource):
     @property
     def kubelet_ready(self):
         return any(
-            [
-                stat
-                for stat in self.instance.status.conditions
-                if stat["reason"] == "KubeletReady"
-                and stat["status"] == self.Condition.Status.TRUE
-            ]
+            stat["reason"] == "KubeletReady"
+            and stat["status"] == self.Condition.Status.TRUE
+            for stat in self.instance.status.conditions
         )
 
     @property

--- a/ocp_resources/virtual_machine_restore.py
+++ b/ocp_resources/virtual_machine_restore.py
@@ -69,8 +69,7 @@ class VirtualMachineRestore(NamespacedResource):
             wait_timeout=timeout,
             sleep=1,
             exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
-            func=lambda: self.instance.get("status", {}).get("complete", None)
-            == status,
+            func=lambda: self.instance.get("status", {}).get("complete") == status,
         )
         for sample in samples:
             if sample:

--- a/ocp_resources/virtual_machine_snapshot.py
+++ b/ocp_resources/virtual_machine_snapshot.py
@@ -66,8 +66,7 @@ class VirtualMachineSnapshot(NamespacedResource):
             wait_timeout=timeout,
             sleep=1,
             exceptions_dict=PROTOCOL_ERROR_EXCEPTION_DICT,
-            func=lambda: self.instance.get("status", {}).get("readyToUse", None)
-            == status,
+            func=lambda: self.instance.get("status", {}).get("readyToUse") == status,
         )
         for sample in samples:
             if sample:


### PR DESCRIPTION
##### Short description:

##### More details:
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

ocp_resources/node.py:16:16: C419 Unnecessary list comprehension passed to any() prevents short-circuiting - rewrite as a generator.
ocp_resources/virtual_machine_restore.py:72:26: SIM910 Use 'self.instance.get('status', {}).get("complete")' instead of 'self.instance.get('status', {}).get('complete', None)'
ocp_resources/virtual_machine_snapshot.py:69:26: SIM910 Use 'self.instance.get('status', {}).get("readyToUse")' instead of 'self.instance.get('status', {}).get('readyToUse', None)'

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
