### PR TITLE
[411] CP 1240 refactor node network configuration policy resources

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -11,6 +11,7 @@ from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.resource import Resource, ResourceEditor
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
 
+
 IPV4_STR = "ipv4"
 IPV6_STR = "ipv6"
 


### PR DESCRIPTION
- Refactor _ports_backup to include both IP families.
 - Add teardown_absent_ifaces parameter (default: True).
 - Add IP family global variables.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
