### PR TITLE
add more logging to vmi.wait_until_running()

### DIFF
--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -105,7 +105,10 @@ class VirtualMachineInstance(NamespacedResource):
 
     @property
     def vm(self):
-        return list(VirtualMachine.get(name=self.name, namespace=self.namespace))[0]
+        vms = list(VirtualMachine.get(name=self.name, namespace=self.namespace))
+        if vms:
+            return vms[0]
+        raise ResourceNotFoundError
 
     def wait_until_running(self, timeout=TIMEOUT_4MINUTES, logs=True, stop_status=None):
         """

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -115,7 +115,9 @@ class VirtualMachineInstance(NamespacedResource):
             TimeoutExpiredError: If VMI failed to run.
         """
         try:
-            self.logger.info(f"VMI status before wait: {self.instance.status.phase}")
+            self.logger.info(
+                f"VMI {self.name} status before wait: {self.instance.status.phase}"
+            )
             self.wait_for_status(
                 status=self.Status.RUNNING, timeout=timeout, stop_status=stop_status
             )

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -115,6 +115,7 @@ class VirtualMachineInstance(NamespacedResource):
             TimeoutExpiredError: If VMI failed to run.
         """
         try:
+            self.logger.info(f"VMI status before wait: {self.instance.status.phase}")
             self.wait_for_status(
                 status=self.Status.RUNNING, timeout=timeout, stop_status=stop_status
             )
@@ -124,6 +125,9 @@ class VirtualMachineInstance(NamespacedResource):
 
             virt_pod = self.virt_launcher_pod
             if virt_pod:
+                self.logger.error(
+                    f"Status of virt-launcher pod {virt_pod.name}: {virt_pod.status}"
+                )
                 self.logger.debug(f"{virt_pod.name} *****LOGS*****")
                 self.logger.debug(virt_pod.log(container="compute"))
 

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -8,6 +8,7 @@ from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.resource import NamespacedResource
 from ocp_resources.utils import TimeoutExpiredError, TimeoutSampler
+from ocp_resources.virtual_machine import VirtualMachine
 
 
 class VirtualMachineInstance(NamespacedResource):
@@ -102,6 +103,10 @@ class VirtualMachineInstance(NamespacedResource):
 
         raise ResourceNotFoundError
 
+    @property
+    def vm(self):
+        return list(VirtualMachine.get(name=self.name, namespace=self.namespace))[0]
+
     def wait_until_running(self, timeout=TIMEOUT_4MINUTES, logs=True, stop_status=None):
         """
         Wait until VMI is running
@@ -115,6 +120,9 @@ class VirtualMachineInstance(NamespacedResource):
             TimeoutExpiredError: If VMI failed to run.
         """
         try:
+            self.logger.info(
+                f"VM {self.vm.name} status before wait: {self.vm.printable_status}"
+            )
             self.logger.info(
                 f"VMI {self.name} status before wait: {self.instance.status.phase}"
             )


### PR DESCRIPTION
##### Short description:
Add more logging to VirtualMachineInstance.wait_until_running()

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
