### PR TITLE
fix wait_until_running() call if vmi object doesn't exist

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -708,6 +708,10 @@ class Resource:
                 self.logger.error(
                     f"Status of {self.kind} {self.name} is {current_status}"
                 )
+            else:
+                self.logger.error(
+                    f"{self.kind} {self.name}: status is None!/does not exist!"
+                )
             raise
 
     def create(self, wait=False):

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -708,10 +708,6 @@ class Resource:
                 self.logger.error(
                     f"Status of {self.kind} {self.name} is {current_status}"
                 )
-            else:
-                self.logger.error(
-                    f"{self.kind} {self.name}: status is None!/does not exist!"
-                )
             raise
 
     def create(self, wait=False):

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -127,7 +127,8 @@ class VirtualMachineInstance(NamespacedResource):
         except TimeoutExpiredError as sampler_ex:
             if not logs:
                 raise
-            self.logger.error(f"VMI {self.name} status: {self.instance.status.phase}")
+            if not self.exists:
+                self.logger.error(f"VMI {self.name} does not exist!")
             try:
                 virt_pod = self.virt_launcher_pod
                 self.logger.error(

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -117,10 +117,6 @@ class VirtualMachineInstance(NamespacedResource):
             TimeoutExpiredError: If VMI failed to run.
         """
         try:
-            self.wait(timeout=timeout)
-            self.logger.info(
-                f"VMI {self.name} status before wait: {self.instance.status.phase}"
-            )
             self.wait_for_status(
                 status=self.Status.RUNNING, timeout=timeout, stop_status=stop_status
             )

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -117,10 +117,10 @@ class VirtualMachineInstance(NamespacedResource):
             TimeoutExpiredError: If VMI failed to run.
         """
         try:
-            if self.exists:
-                self.logger.info(
-                    f"VMI {self.name} status before wait: {self.instance.status.phase}"
-                )
+            self.wait(timeout=timeout)
+            self.logger.info(
+                f"VMI {self.name} status before wait: {self.instance.status.phase}"
+            )
             self.wait_for_status(
                 status=self.Status.RUNNING, timeout=timeout, stop_status=stop_status
             )

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -123,8 +123,6 @@ class VirtualMachineInstance(NamespacedResource):
         except TimeoutExpiredError as sampler_ex:
             if not logs:
                 raise
-            if not self.exists:
-                self.logger.error(f"VMI {self.name} does not exist!")
             try:
                 virt_pod = self.virt_launcher_pod
                 self.logger.error(

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -117,9 +117,10 @@ class VirtualMachineInstance(NamespacedResource):
             TimeoutExpiredError: If VMI failed to run.
         """
         try:
-            self.logger.info(
-                f"VMI {self.name} status before wait: {self.instance.status.phase}"
-            )
+            if self.exists:
+                self.logger.info(
+                    f"VMI {self.name} status before wait: {self.instance.status.phase}"
+                )
             self.wait_for_status(
                 status=self.Status.RUNNING, timeout=timeout, stop_status=stop_status
             )


### PR DESCRIPTION
##### Short description:
fix error when calling wait_until_running() method while vmi still doesn't exist

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
