### PR TITLE
TimeoutSampler: always raise TimeoutExpiredError

### DIFF
--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -136,7 +136,7 @@ class TimeoutSampler:
 
                 time.sleep(self.sleep)
 
-            except self._exceptions as exp:
+            except Exception as exp:
                 last_exp = exp
                 last_exp_log = self._get_exception_log(exp=last_exp)
                 if self._is_raisable_exception(exp=last_exp):

--- a/ocp_resources/utils.py
+++ b/ocp_resources/utils.py
@@ -141,7 +141,7 @@ class TimeoutSampler:
                 last_exp_log = self._get_exception_log(exp=last_exp)
                 if self._is_raisable_exception(exp=last_exp):
                     LOGGER.error(last_exp_log)
-                    raise exp
+                    raise TimeoutExpiredError(self._get_exception_log(exp=last_exp))
 
                 self.elapsed_time = None
                 time.sleep(self.sleep)

--- a/tests/unittests/test_utils.py
+++ b/tests/unittests/test_utils.py
@@ -23,7 +23,7 @@ class TestTimeoutSampler:
             continue
 
     @pytest.mark.parametrize(
-        "test_params, expected",
+        "test_params",
         [
             pytest.param(
                 {
@@ -31,9 +31,6 @@ class TestTimeoutSampler:
                         KeyError: [],
                     },
                     "runtime_exception": ValueError(),
-                },
-                {
-                    "raises": ValueError,
                 },
                 id="init_keyerror_raise_valueerror_with_no_msg",
             ),
@@ -43,9 +40,6 @@ class TestTimeoutSampler:
                         ValueError: ["allowed exception text"],
                     },
                     "runtime_exception": ValueError("test"),
-                },
-                {
-                    "raises": ValueError,
                 },
                 id="init_valueerror_with_msg_raise_valueerror_with_invalid_msg",
             ),
@@ -58,15 +52,12 @@ class TestTimeoutSampler:
                     },
                     "runtime_exception": IndexError("test"),
                 },
-                {
-                    "raises": IndexError,
-                },
                 id="init_multi_exceptions_raise_allowed_with_invalid_msg",
             ),
         ],
     )
-    def test_timeout_sampler_raises(self, test_params, expected):
-        with pytest.raises(expected["raises"]):
+    def test_timeout_sampler_raises(self, test_params):
+        with pytest.raises(TimeoutExpiredError):
             self._trigger_func_exception_during_iter(
                 exceptions_dict=test_params.get("init_exceptions_dict"),
                 runtime_exception=test_params.get("runtime_exception"),


### PR DESCRIPTION
TimeoutSampler should always raise the same exception (TimeoutExpiredError)