### PR TITLE
Update scratch pvc name

### DIFF
--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -256,7 +256,7 @@ class DataVolume(NamespacedResource):
         scratch_pvc_prefix = (
             f"prime-{pvc_metadata.uid}"
             if pvc_metadata.annotations.get(
-                f"{NamespacedResource.ApiGroup.CDI_KUBEVIRT_IO}/storage.usePopulator"
+                f"{self.ApiGroup.CDI_KUBEVIRT_IO}/storage.usePopulator"
             )
             == "true"
             else self.name

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -252,9 +252,15 @@ class DataVolume(NamespacedResource):
 
     @property
     def scratch_pvc(self):
-        scratch_pvc_prefix = f"prime-{self.pvc.instance.metadata.uid}" \
-            if self.pvc.instance.metadata.annotations.get("cdi.kubevirt.io/storage.usePopulator") == "true" \
+        pvc_metadata = self.pvc.instance.metadata
+        scratch_pvc_prefix = (
+            f"prime-{pvc_metadata.uid}"
+            if pvc_metadata.annotations.get(
+                f"{NamespacedResource.ApiGroup.CDI_KUBEVIRT_IO}/storage.usePopulator"
+            )
+            == "true"
             else self.name
+        )
         return PersistentVolumeClaim(
             name=f"{scratch_pvc_prefix}-scratch",
             namespace=self.namespace,

--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -252,8 +252,11 @@ class DataVolume(NamespacedResource):
 
     @property
     def scratch_pvc(self):
+        scratch_pvc_prefix = f"prime-{self.pvc.instance.metadata.uid}" \
+            if self.pvc.instance.metadata.annotations.get("cdi.kubevirt.io/storage.usePopulator") == "true" \
+            else self.name
         return PersistentVolumeClaim(
-            name=f"{self.name}-scratch",
+            name=f"{scratch_pvc_prefix}-scratch",
             namespace=self.namespace,
             client=self.client,
         )


### PR DESCRIPTION
##### Short description:
  When DV deployment done with populators the scratch PVC name is prime-<pvc_uid>-scratch

##### What this PR does / why we need it:
Fix scratch_pvc to work with both DV's deployed with populators and not. 

