### PR TITLE
create(): add AttributeError to contextlib.suppress

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -733,7 +733,7 @@ class Resource:
         resource_ = self.api.create(
             body=self.res, namespace=self.namespace, dry_run=self.dry_run
         )
-        with contextlib.suppress(TimeoutExpiredError):
+        with contextlib.suppress(TimeoutExpiredError, AttributeError):
             # some resources do not support get() (no instance) or the client do not have permissions
             self.initial_resource_version = self.instance.metadata.resourceVersion
 


### PR DESCRIPTION
In `create()` function we suppress `TimeoutExpiredError` exceptions, we need also `AttributeError` since `self.instance` can be None