### PR TITLE
adding a restartCount class to resource

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -234,6 +234,9 @@ class Resource:
             INSTALL_READY = "InstallReady"
             SUCCEEDED = "Succeeded"
 
+        class restartCount:
+            restartCount = "restartCount"
+
         class Reason:
             ALL_REQUIREMENTS_MET = "AllRequirementsMet"
             INSTALL_SUCCEEDED = "InstallSucceeded"


### PR DESCRIPTION
##### Short description:
I'm adding a new class to ocp_resources/resource.py 

##### More details:
I need to track resource.instance.status.restartCount  which is not applied to the wrapper 

##### What this PR does / why we need it:
to get easy access to instance.status.restartCount 

##### Which issue(s) this PR fixes:
None
##### Special notes for reviewer:
None
##### Bug:
None