### PR TITLE
fix source setting `KeyError: 'spec'` in to_dict() method

### DIFF
--- a/ocp_resources/data_source.py
+++ b/ocp_resources/data_source.py
@@ -28,7 +28,7 @@ class DataSource(NamespacedResource):
             if not self._source:
                 raise ValueError("Passing yaml_file or parameter 'source' is required")
 
-            self.res["spec"]["source"] = self._source
+            self.res.update({"spec": {"source": self._source}})
 
     @property
     def pvc(self):


### PR DESCRIPTION
##### Short description:
Fix the issue in `DataSource` `to_dict()` method when setting `source` value in `self.res` if `self.res` doesn't have any `spec`

##### Which issue(s) this PR fixes:
Fixes issue introduced in https://github.com/RedHatQE/openshift-python-wrapper/pull/1601 
