### PR TITLE
Add wait for stage complete method for RHMI

### DIFF
--- a/ocp_resources/installplan.py
+++ b/ocp_resources/installplan.py
@@ -3,6 +3,3 @@ from ocp_resources.resource import NamespacedResource
 
 class InstallPlan(NamespacedResource):
     api_group = NamespacedResource.ApiGroup.OPERATORS_COREOS_COM
-
-    class Status(NamespacedResource.Status):
-        COMPLETE = "Complete"

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -189,6 +189,8 @@ class Resource:
         READY = "Ready"
         TERMINATING = "Terminating"
         ERROR = "Error"
+        INSTALLATION = "installation"
+        COMPLETE = "complete"
 
     class Condition:
         UPGRADEABLE = "Upgradeable"

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -189,7 +189,6 @@ class Resource:
         READY = "Ready"
         TERMINATING = "Terminating"
         ERROR = "Error"
-        INSTALLATION = "installation"
         COMPLETE = "complete"
 
     class Condition:

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -1,4 +1,5 @@
 from ocp_resources.resource import NamespacedResource
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler, TimeoutWatch
 
 
 class RHMI(NamespacedResource):
@@ -8,3 +9,43 @@ class RHMI(NamespacedResource):
     """
 
     api_group = NamespacedResource.ApiGroup.INTEGREATLY_ORG
+
+    class Status:
+        INSTALLATION = "installation"
+        COMPLETE = "complete"
+
+    def wait_for_status_complete(self, timeout):
+        """
+        Wait until RHMI stage status is complete.
+
+        Args:
+            timeout (int): Time to wait for installation status.
+
+        Raises:
+            TimeoutExpiredError: If stage status is not complete.
+
+        """
+        self.logger.info(f"Wait for {self.kind} {self.name} installation status to be {RHMI.Status.COMPLETE}")
+        try:
+            timeout_watcher = TimeoutWatch(timeout=timeout)
+            for sample in TimeoutSampler(
+                wait_timeout=timeout,
+                sleep=1,
+                func=lambda: self.exists,
+            ):
+                if sample:
+                    break
+
+            for sample in TimeoutSampler(
+                wait_timeout=timeout_watcher.remaining_time(),
+                sleep=3,
+                func=lambda: self.instance.status.stage,
+            ):
+                if sample == RHMI.Status.COMPLETE:
+                    return
+
+        except TimeoutExpiredError:
+            self.logger.error(
+                f"after {timeout} seconds, {self.kind} {self.name} stage status is {self.instance.status.stage}"
+            )
+            raise

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -22,6 +22,7 @@ class RHMI(NamespacedResource):
 
         """
         self.logger.info(f"Wait for {self.kind} {self.name} installation status to be {RHMI.Status.COMPLETE}")
+        sample = None
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
             self.wait(timeout=timeout_watcher.remaining_time())

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -21,7 +21,7 @@ class RHMI(NamespacedResource):
             TimeoutExpiredError: If stage status is not complete.
 
         """
-        self.logger.info(f"Wait for {self.kind} {self.name} stage status to be {RHMI.Status.COMPLETE}")
+        self.logger.info(f"Wait for {self.kind} {self.name} stage status to be {self.Status.COMPLETE}")
         sample = None
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
@@ -32,7 +32,7 @@ class RHMI(NamespacedResource):
                 sleep=1,
                 func=lambda: self.instance.status.stage,
             ):
-                if sample == RHMI.Status.COMPLETE:
+                if sample == self.Status.COMPLETE:
                     return
 
         except TimeoutExpiredError:

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -25,10 +25,11 @@ class RHMI(NamespacedResource):
         sample = None
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
-            self.wait(timeout=timeout_watcher.remaining_time())
+            timeout_remain = timeout_watcher.remaining_time()
+            self.wait(timeout=timeout_remain)
 
             for sample in TimeoutSampler(
-                wait_timeout=timeout_watcher.remaining_time(),
+                wait_timeout=timeout_remain,
                 sleep=1,
                 func=lambda: self.instance.status.stage,
             ):

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -10,18 +10,18 @@ class RHMI(NamespacedResource):
 
     api_group = NamespacedResource.ApiGroup.INTEGREATLY_ORG
 
-    def wait_for_install_status_complete(self, timeout):
+    def wait_for_stage_status_complete(self, timeout):
         """
         Wait until RHMI stage status is complete.
 
         Args:
-            timeout (int): Time to wait for installation status.
+            timeout (int): Time in seconds to wait for installation status.
 
         Raises:
             TimeoutExpiredError: If stage status is not complete.
 
         """
-        self.logger.info(f"Wait for {self.kind} {self.name} installation status to be {RHMI.Status.COMPLETE}")
+        self.logger.info(f"Wait for {self.kind} {self.name} stage status to be {RHMI.Status.COMPLETE}")
         sample = None
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
@@ -29,7 +29,7 @@ class RHMI(NamespacedResource):
 
             for sample in TimeoutSampler(
                 wait_timeout=timeout_watcher.remaining_time(),
-                sleep=3,
+                sleep=1,
                 func=lambda: self.instance.status.stage,
             ):
                 if sample == RHMI.Status.COMPLETE:

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -25,8 +25,8 @@ class RHMI(NamespacedResource):
         sample = None
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
+            self.wait(timeout=timeout_watcher.remaining_time())
             timeout_remain = timeout_watcher.remaining_time()
-            self.wait(timeout=timeout_remain)
 
             for sample in TimeoutSampler(
                 wait_timeout=timeout_remain,

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -15,7 +15,7 @@ class RHMI(NamespacedResource):
         Wait until RHMI stage status is complete.
 
         Args:
-            timeout (int): Time in seconds to wait for installation status.
+            timeout (int): Time in seconds to wait for stage status.
 
         Raises:
             TimeoutExpiredError: If stage status is not complete.

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -24,7 +24,7 @@ class RHMI(NamespacedResource):
         self.logger.info(f"Wait for {self.kind} {self.name} installation status to be {RHMI.Status.COMPLETE}")
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
-            self.wait(timeout=timeout)
+            self.wait(timeout=timeout_watcher.remaining_time())
 
             for sample in TimeoutSampler(
                 wait_timeout=timeout_watcher.remaining_time(),

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -10,11 +10,7 @@ class RHMI(NamespacedResource):
 
     api_group = NamespacedResource.ApiGroup.INTEGREATLY_ORG
 
-    class Status:
-        INSTALLATION = "installation"
-        COMPLETE = "complete"
-
-    def wait_for_status_complete(self, timeout):
+    def wait_for_install_status_complete(self, timeout):
         """
         Wait until RHMI stage status is complete.
 
@@ -28,13 +24,7 @@ class RHMI(NamespacedResource):
         self.logger.info(f"Wait for {self.kind} {self.name} installation status to be {RHMI.Status.COMPLETE}")
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
-            for sample in TimeoutSampler(
-                wait_timeout=timeout,
-                sleep=1,
-                func=lambda: self.exists,
-            ):
-                if sample:
-                    break
+            self.wait(timeout=timeout)
 
             for sample in TimeoutSampler(
                 wait_timeout=timeout_watcher.remaining_time(),
@@ -45,7 +35,5 @@ class RHMI(NamespacedResource):
                     return
 
         except TimeoutExpiredError:
-            self.logger.error(
-                f"after {timeout} seconds, {self.kind} {self.name} stage status is {self.instance.status.stage}"
-            )
+            self.logger.error(f"after {timeout} seconds, {self.kind} {self.name} stage status is {sample}")
             raise


### PR DESCRIPTION
##### Short description: Add wait for stage complete method for RHMI

##### More details: Status of RHMI:
```
status:
  lastError: ""
  preflightMessage: preflight checks passed
  preflightStatus: successful
  quota: 100K
  stage: complete
  stages:
    bootstrap:
      name: bootstrap
      phase: completed
    installation:
      name: installation
      phase: completed
```

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
