### PR TITLE
Split RHMI status from Resource.Status

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -189,7 +189,7 @@ class Resource:
         READY = "Ready"
         TERMINATING = "Terminating"
         ERROR = "Error"
-        COMPLETE = "complete"
+        COMPLETE = "Complete"
 
     class Condition:
         UPGRADEABLE = "Upgradeable"

--- a/ocp_resources/rhmi.py
+++ b/ocp_resources/rhmi.py
@@ -21,7 +21,9 @@ class RHMI(NamespacedResource):
             TimeoutExpiredError: If stage status is not complete.
 
         """
-        self.logger.info(f"Wait for {self.kind} {self.name} stage status to be {self.Status.COMPLETE}")
+        # TODO: Replace complete_status_str with self.Status.COMPLETE once RHMI `complete` status starts with uppercase
+        complete_status_str = "complete"
+        self.logger.info(f"Wait for {self.kind} {self.name} stage status to be {complete_status_str}")
         sample = None
         try:
             timeout_watcher = TimeoutWatch(timeout=timeout)
@@ -33,7 +35,7 @@ class RHMI(NamespacedResource):
                 sleep=1,
                 func=lambda: self.instance.status.stage,
             ):
-                if sample == self.Status.COMPLETE:
+                if sample == complete_status_str:
                     return
 
         except TimeoutExpiredError:


### PR DESCRIPTION
##### Short description:
RHMI status is `complete` instead of `Complete`

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
