### PR TITLE
Add suppress NotFoundError to resource create

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -701,7 +701,7 @@ class Resource:
         self.logger.info(f"Posting {hashed_res}")
         self.logger.debug(f"\n{yaml.dump(hashed_res)}")
         resource_ = self.api.create(body=self.res, namespace=self.namespace, dry_run=self.dry_run)
-        with contextlib.suppress(ForbiddenError, AttributeError):
+        with contextlib.suppress(ForbiddenError, AttributeError, NotFoundError):
             # some resources do not support get() (no instance) or the client do not have permissions
             self.initial_resource_version = self.instance.metadata.resourceVersion
 


### PR DESCRIPTION
##### Short description:
Some resources raise NotFoundError in `self.initial_resource_version = self.instance.metadata.resourceVersion`