### PR TITLE
Update wait_for_dv_success to work without DV Garbage Collection enabled

### DIFF
--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -273,6 +273,7 @@ class DataVolume(NamespacedResource):
         self,
         timeout=TIMEOUT_10MINUTES,
         failure_timeout=TIMEOUT_2MINUTES,
+        dv_garbage_collection_enabled=False,
         stop_status_func=None,
         *stop_status_func_args,
         **stop_status_func_kwargs,
@@ -283,6 +284,7 @@ class DataVolume(NamespacedResource):
         Args:
             timeout (int):  Time to wait for the DataVolume to succeed.
             failure_timeout (int): Time to wait for the DataVolume to have not Pending/None status
+            dv_garbage_collection_enabled (bool, default: False): if True, expect that DV will disappear after success
             stop_status_func (function): function that is called inside the TimeoutSampler
                 if it returns True - stop the Sampler and raise TimeoutExpiredError
                 Example:
@@ -308,8 +310,10 @@ class DataVolume(NamespacedResource):
                 wait_timeout=timeout,
                 func=lambda: self.exists,
             ):
-                # DV reach to success if the status is succeeded or if the DV does not exist
-                if sample is None or sample.get("status", {}).get("phase") == self.Status.SUCCEEDED:
+                # DV reach success if the status is Succeeded, or if DV garbage collection enabled and the DV does not exist
+                if sample and sample.get("status", {}).get("phase") == self.Status.SUCCEEDED:
+                    break
+                elif sample is None and dv_garbage_collection_enabled:
                     break
                 elif stop_status_func and stop_status_func(*stop_status_func_args, **stop_status_func_kwargs):
                     raise TimeoutExpiredError(
@@ -319,7 +323,6 @@ class DataVolume(NamespacedResource):
                             f" {status_of_dv_str} {sample.status}"
                         )
                     )
-
         except TimeoutExpiredError:
             self.logger.error(f"{status_of_dv_str} {sample.status}")
             raise


### PR DESCRIPTION
##### Short description:
DataVolume Garbage Collection featureGate is no longer a default, so we can update the function to work without the DV Garbage Collection.

##### Which issue(s) this PR fixes:
If DV got created after the check `if sample is None` - we are not waiting for DV success, and only waiting for PVC to be Bound, but this is not correct behavior. 
