### PR TITLE
Update `get_client` code

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -65,6 +65,10 @@ def get_client(config_file=None, config_dict=None, context=None, **kwargs):
     """
     Get a kubernetes client.
 
+
+    This function is a replica of `ocp_utilities.infra.get_client` which cannot be imported as ocp_utilities imports
+    from ocp_resources.
+
     Pass either config_file or config_dict.
     If none of them are passed, client will be created from default OS kubeconfig
     (environment variable or .kube folder).


### PR DESCRIPTION
kubernetes.config.kube_config.load_kube_config sets KUBE_CONFIG_DEFAULT_LOCATION during module import.
If `KUBECONFIG` environment variable is set via code, the `KUBE_CONFIG_DEFAULT_LOCATION` will be None since
is populated during import which comes before setting the variable in code.

Using `ocp_resources.infra.get_client` code