### PR TITLE
change context param default value back to None

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -360,7 +360,7 @@ class Resource:
         node_selector_labels: Dict[str, str] | None = None,
         config_file: str = "",
         config_dict: Dict[str, Any] | None = None,
-        context: str = "",
+        context: str | None = None,
         label: Dict[str, str] | None = None,
         timeout_seconds: int = TIMEOUT_1MINUTE,
         api_group: str = "",
@@ -864,7 +864,7 @@ class Resource:
     def get(
         cls,
         config_file: str = "",
-        context: str = "",
+        context: str | None = None,
         singular_name: str = "",
         exceptions_dict: Dict[type[Exception], List[str]] = DEFAULT_CLUSTER_RETRY_EXCEPTIONS,
         raw: bool = False,
@@ -1077,7 +1077,11 @@ class Resource:
 
     @staticmethod
     def get_all_cluster_resources(
-        config_file: str = "", context: str = "", config_dict: Dict[str, Any] | None = None, *args: Any, **kwargs: Any
+        config_file: str = "",
+        context: str | None = None,
+        config_dict: Dict[str, Any] | None = None,
+        *args: Any,
+        **kwargs: Any,
     ) -> Generator[ResourceField, None, None]:
         """
         Get all cluster resources
@@ -1208,7 +1212,7 @@ class NamespacedResource(Resource):
     def get(
         cls,
         config_file: str = "",
-        context: str = "",
+        context: str | None = None,
         singular_name: str = "",
         exceptions_dict: Dict[type[Exception], List[str]] = DEFAULT_CLUSTER_RETRY_EXCEPTIONS,
         raw: bool = False,

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -360,7 +360,7 @@ class Resource:
         node_selector_labels: Dict[str, str] | None = None,
         config_file: str = "",
         config_dict: Dict[str, Any] | None = None,
-        context: str | None = None,
+        context: str = "",
         label: Dict[str, str] | None = None,
         timeout_seconds: int = TIMEOUT_1MINUTE,
         api_group: str = "",
@@ -405,7 +405,7 @@ class Resource:
             raise ValueError("config_file must be a string")
 
         self.config_dict = config_dict or {}
-        self.context = context
+        self.context = context if context else None
         self.label = label
         self.timeout_seconds = timeout_seconds
         self.client: DynamicClient = client or get_client(


### PR DESCRIPTION
##### Short description:
change `context` param default value back to `None`

##### More details:
moving default value from `None` to `""` causes problems as there are multiple checks for `content == None`

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:
```
tests/compute/ssp/supported_os/common_templates/golden_images/update_boot_source/conftest.py:57: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/ocp_resources/resource.py:1234: in get
    dyn_client = get_client(config_file=config_file, context=context)
../../.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/ocp_resources/resource.py:114: in get_client
    client=kubernetes.config.new_client_from_config(config_file=config_file, context=context, **kwargs)
../../.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/kubernetes/config/kube_config.py:872: in new_client_from_config
    load_kube_config(config_file=config_file, context=context,
../../.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/kubernetes/config/kube_config.py:815: in load_kube_config
    loader = _get_kube_config_loader(
../../.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/kubernetes/config/kube_config.py:775: in _get_kube_config_loader
    return KubeConfigLoader(
../../.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/kubernetes/config/kube_config.py:206: in __init__
    self.set_active_context(active_context)
../../.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/kubernetes/config/kube_config.py:259: in set_active_context
    self._current_context = self._config['contexts'].get_with_name(

```

```
> /.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/kubernetes/config/kube_config.py(662)get_with_name()
-> raise ConfigException(
(Pdb) ll
633  	    def get_with_name(self, name, safe=False):
634  	        if not isinstance(self.value, list):
635  	            raise ConfigException(
636  	                'Invalid kube-config file. Expected %s to be a list'
637  	                % self.name)
638  	        result = None
639  	        for v in self.value:
640  	            if 'name' not in v:
641  	                raise ConfigException(
642  	                    'Invalid kube-config file. '
643  	                    'Expected all values in %s list to have \'name\' key'
644  	                    % self.name)
645  	            if v['name'] == name:
646  	                if result is None:
647  	                    result = v
648  	                else:
649  	                    raise ConfigException(
650  	                        'Invalid kube-config file. '
651  	                        'Expected only one object with name %s in %s list'
652  	                        % (name, self.name))
653  	        if result is not None:
654  	            if isinstance(result, ConfigNode):
655  	                return result
656  	            else:
657  	                return ConfigNode(
658  	                    '%s[name=%s]' %
659  	                    (self.name, name), result, self.path)
660  	        if safe:
661  	            return None
662  ->	        raise ConfigException(
663  	            'Invalid kube-config file. '
664  	            'Expected object with name %s in %s list' % (name, self.name))
(Pdb) name
''
(Pdb) self.name
'virt-vk-416/auth/kubeconfig/contexts'
(Pdb) up
> /.cache/pypoetry/virtualenvs/cnv-tests-4-16-zcRGEpk1-py3.8/lib/python3.8/site-packages/kubernetes/config/kube_config.py(259)set_active_context()
-> self._current_context = self._config['contexts'].get_with_name(
(Pdb) ll
256  	    def set_active_context(self, context_name=None):
257  	        if context_name is None:
258  	            context_name = self._config['current-context']
259  ->	        self._current_context = self._config['contexts'].get_with_name(
260  	            context_name)
261  	        if (self._current_context['context'].safe_get('user') and
262  	                self._config.safe_get('users')):
263  	            user = self._config['users'].get_with_name(
264  	                self._current_context['context']['user'], safe=True)
265  	            if user:
266  	                self._user = user['user']
267  	            else:
268  	                self._user = None
269  	        else:
270  	            self._user = None
271  	        self._cluster = self._config['clusters'].get_with_name(
272  	            self._current_context['context']['cluster'])['cluster']
(Pdb) self._config['current-context']
'admin'
(Pdb) context_name
''
(Pdb) context_name is None
False
(Pdb) not context_name
True
```
##### Special notes for reviewer:

##### Bug:
