### PR TITLE
Remove error log from _ensure_exists

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -439,7 +439,6 @@ class Resource:
         self._set_client_and_api_version()
 
     def _ensure_exists(self) -> None:
-        self.logger.error(self.namespace)
         if not self.exists:
             _name_for_raise = self.name if not self.namespace else f"{self.namespace}/{self.name}"
             raise ResourceNotFoundError(f"Resource `{self.kind}` `{_name_for_raise}` does not exist")


### PR DESCRIPTION

##### Short description:
Remove error log used during development in _ensure_exists

##### More details:

##### What this PR does / why we need it:
This error log causes confusion when calling _ensure_exists

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
