### PR TITLE
Fix for typings in ARQ resources

### DIFF
--- a/ocp_resources/application_aware_cluster_resource_quota.py
+++ b/ocp_resources/application_aware_cluster_resource_quota.py
@@ -1,5 +1,6 @@
 # API reference: https://github.com/kubevirt/application-aware-quota/tree/main/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1
 # TODO: update API reference when OCP doc is available
+from __future__ import annotations
 from typing import Dict, Any
 
 from ocp_resources.resource import MissingRequiredArgumentError, Resource

--- a/ocp_resources/application_aware_resource_quota.py
+++ b/ocp_resources/application_aware_resource_quota.py
@@ -1,5 +1,6 @@
 # API reference: https://github.com/kubevirt/application-aware-quota/tree/main/staging/src/kubevirt.io/application-aware-quota-api/pkg/apis/core/v1alpha1
 # TODO: update API reference when OCP doc is available
+from __future__ import annotations
 from typing import Dict, Any, List
 
 from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource


### PR DESCRIPTION
##### Short description:
 Adding import future/annotations for python3.9

##### More details:
There is an error in python3.9:

```
  .venv/lib/python3.9/site-packages/ocp_resources/application_aware_resource_quota.py:13: in ApplicationAwareResourceQuota
      hard: Dict[str, Any] | None = None,
  E   TypeError: unsupported operand type(s) for |: '_GenericAlias' and 'NoneType'

```
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
