### PR TITLE
Fix race in resource delete

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -806,18 +806,18 @@ class Resource:
     def delete(self, wait: bool = False, timeout: int = TIMEOUT_4MINUTES, body: Dict[str, Any] | None = None) -> bool:
         self.logger.info(f"Delete {self.kind} {self.name}")
 
-        try:
-            if self.exists:
+        if self.exists:
+            try:
                 hashed_data = self.hash_resource_dict(resource_dict=self.instance.to_dict())
                 self.logger.info(f"Deleting {hashed_data}")
                 self.logger.debug(f"\n{yaml.dump(hashed_data)}")
 
-            self.api.delete(name=self.name, namespace=self.namespace, body=body)
-            if wait:
-                self.client_wait_deleted(timeout=timeout)
+                self.api.delete(name=self.name, namespace=self.namespace, body=body)
+                if wait:
+                    self.client_wait_deleted(timeout=timeout)
 
-        except (NotFoundError, TimeoutExpiredError):
-            return False
+            except (NotFoundError, TimeoutExpiredError):
+                return False
 
         return True
 

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -806,12 +806,12 @@ class Resource:
     def delete(self, wait: bool = False, timeout: int = TIMEOUT_4MINUTES, body: Dict[str, Any] | None = None) -> bool:
         self.logger.info(f"Delete {self.kind} {self.name}")
 
-        if self.exists:
-            hashed_data = self.hash_resource_dict(resource_dict=self.instance.to_dict())
-            self.logger.info(f"Deleting {hashed_data}")
-            self.logger.debug(f"\n{yaml.dump(hashed_data)}")
-
         try:
+            if self.exists:
+                hashed_data = self.hash_resource_dict(resource_dict=self.instance.to_dict())
+                self.logger.info(f"Deleting {hashed_data}")
+                self.logger.debug(f"\n{yaml.dump(hashed_data)}")
+
             self.api.delete(name=self.name, namespace=self.namespace, body=body)
             if wait:
                 self.client_wait_deleted(timeout=timeout)

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -818,6 +818,8 @@ class Resource:
 
             except (NotFoundError, TimeoutExpiredError):
                 return False
+        else:
+            LOGGER.warning(f"Resource {self.kind} {self.name} does not exist")
 
         return True
 


### PR DESCRIPTION
##### Short description:
- `client_wait_deleted` now returns bool
- `wait_deleted` now returns bool
- in resource `delete`: moving the get `hashed_data` under `try/except`.

##### Reason:
When the object is in Terminating state, it passes the check` if self.exists:`, but then NotFoundError gets raised on `(resource_dict=self.instance...` because the object is already gone.

For example, when we delete a DV, PVC gets deleted automatically.

When some automation attempts to create a DV twice, and then attempts to delete this DV twice, we may hit this race.
