### PR TITLE
Deprecate node selector type

### DIFF
--- a/ocp_resources/ingress_controller.py
+++ b/ocp_resources/ingress_controller.py
@@ -141,7 +141,7 @@ class IngressController(NamespacedResource):
         self.endpoint_publishing_strategy = endpoint_publishing_strategy
         self.default_certificate = default_certificate
         self.namespace_selector = namespace_selector
-        self.node_selector = node_selector  # type: ignore
+        self.node_selector = node_selector
         self.route_selector = route_selector
         self.tls_security_profile = tls_security_profile
         self.logging = logging

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -466,7 +466,7 @@ class Resource:
                 return self.node_selector
             else:
                 warn(
-                    "node_selector `str` will be deprecated in next release, pass `dict` instead",
+                    "node_selector `str` will be deprecated in next release (4.17), pass `dict` instead",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from collections.abc import Callable, Generator
+from warnings import warn
 import contextlib
 import copy
 import json
@@ -364,7 +365,7 @@ class Resource:
         yaml_file: str = "",
         delete_timeout: int = TIMEOUT_4MINUTES,
         dry_run: bool = False,
-        node_selector: str = "",
+        node_selector: Dict[str, Any] | None = None,
         node_selector_labels: Dict[str, str] | None = None,
         config_file: str = "",
         config_dict: Dict[str, Any] | None = None,
@@ -461,9 +462,19 @@ class Resource:
 
     def _prepare_node_selector_spec(self) -> Dict[str, str]:
         if self.node_selector:
-            return {f"{self.ApiGroup.KUBERNETES_IO}/hostname": self.node_selector}
+            if isinstance(self.node_selector, dict):
+                return self.node_selector
+            else:
+                warn(
+                    "node_selector `str` will be deprecated in next release, pass `dict` instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                return {f"{self.ApiGroup.KUBERNETES_IO}/hostname": self.node_selector}
+
         elif self.node_selector_labels:
             return self.node_selector_labels
+
         else:
             return {}
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,5 @@ commands =
     poetry run pytest tests/test_validate_resources.py
 allowlist_externals =
    poetry
+
+[testenv:resource_class_generator]


### PR DESCRIPTION
In Resource class, `node_selector` type should be `Dict` and not str.
Add deprecation warning about accept `Dict` and not `str` for next release (4.17)