### PR TITLE
Fix camel case 

### DIFF
--- a/scripts/resource/class_generator.py
+++ b/scripts/resource/class_generator.py
@@ -173,16 +173,18 @@ def convert_camel_case_to_snake_case(string_: str) -> str:
                     if following_capital_chars:
                         formatted_str += f"_{char.lower()}"
                         last_capital_char = True
+                        continue
 
+                    remaining_str = "".join(string_[idx:])
                     # The 2 letters in the string; uppercase char followed by lowercase char.
                     # Example: `clusterIPs`, handle `Ps` at this point
-                    elif idx + 1 == str_len_for_idx_check:
-                        formatted_str += f"{''.join(string_[idx:]).lower()}"
+                    if idx + 1 == str_len_for_idx_check:
+                        formatted_str += remaining_str.lower()
                         break
 
                     # The last word in the string; uppercase followed by multiple lowercase chars
                     # Example: `dataVolumeTTLSeconds`, handle `Seconds` at this point
-                    elif (remaining_str := "".join(string_[idx:])).istitle():
+                    elif remaining_str.istitle():
                         formatted_str += f"_{remaining_str.lower()}"
                         break
 

--- a/scripts/resource/class_generator.py
+++ b/scripts/resource/class_generator.py
@@ -174,12 +174,14 @@ def convert_camel_case_to_snake_case(string_: str) -> str:
                         formatted_str += f"_{char.lower()}"
                         last_capital_char = True
 
-                    # The 2 letters in the string; uppercase char followed by lowercase char
+                    # The 2 letters in the string; uppercase char followed by lowercase char.
+                    # Example: `clusterIPs`, handle `Ps` at this point
                     elif idx + 1 == str_len_for_idx_check:
                         formatted_str += f"{''.join(string_[idx:]).lower()}"
                         break
 
                     # The last word in the string; uppercase followed by multiple lowercase chars
+                    # Example: `dataVolumeTTLSeconds`, handle `Seconds` at this point
                     elif (remaining_str := "".join(string_[idx:])).istitle():
                         formatted_str += f"_{remaining_str.lower()}"
                         break

--- a/scripts/resource/class_generator.py
+++ b/scripts/resource/class_generator.py
@@ -173,9 +173,21 @@ def convert_camel_case_to_snake_case(string_: str) -> str:
                     if following_capital_chars:
                         formatted_str += f"_{char.lower()}"
                         last_capital_char = True
+
+                    # The 2 letters in the string; uppercase char followed by lowercase char
+                    elif idx + 1 == str_len_for_idx_check:
+                        formatted_str += f"{''.join(string_[idx:]).lower()}"
+                        break
+
+                    # The last word in the string; uppercase followed by multiple lowercase chars
+                    elif (remaining_str := "".join(string_[idx:])).istitle():
+                        formatted_str += f"_{remaining_str.lower()}"
+                        break
+
                     else:
                         formatted_str += char.lower()
                         last_capital_char = True
+
                 else:
                     formatted_str += char.lower()
                     last_capital_char = True

--- a/scripts/resource/tests/test_class_generator.py
+++ b/scripts/resource/tests/test_class_generator.py
@@ -59,10 +59,21 @@ def test_parse_explain(tmpdir_factory, kind, debug_file, result_file):
         ),
         pytest.param("XMLHttpRequest", "xml_http_request", id="combined_uppercase_word_is_first"),
         pytest.param(
-            "additionalCORSAllowedOS", "additional_cors_allowed_os", id="combined_uppercase_word_in_the_middle"
+            "additionalCORSAllowedOS",
+            "additional_cors_allowed_os",
+            id="combined_uppercase_word_in_the_middle",
         ),
         pytest.param("hostIPC", "host_ipc", id="combined_uppercase_word_is_last"),
-        pytest.param("clusterIPs", "cluster_ips", id="combined_uppercase_word_is_last_ends_with_lowercase"),
+        pytest.param(
+            "clusterIPs",
+            "cluster_ips",
+            id="combined_uppercase_word_is_last_ends_with_one_lowercase_char",
+        ),
+        pytest.param(
+            "dataVolumeTTLSeconds",
+            "data_volume_ttl_seconds",
+            id="combined_uppercase_word_followed_by_uppercase_word_is_last_ends_with_lowercase",
+        ),
     ],
 )
 def test_convert_camel_case_to_snake_case(camel_case_str, expected):


### PR DESCRIPTION
Address cases where:
- last 2 words in string are: 1 uppercase followed by  1 title - e.g: `dataVolumeTTLSeconds`
- last wordsin string is with acronym and ends with lowercase - e.g:  `clusterIPs`