### PR TITLE
update _nodes() call to work with dict format of node_selector()

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -112,7 +112,9 @@ class NodeNetworkConfigurationPolicy(Resource):
 
     def _nodes(self):
         if self.node_selector:
-            return list(Node.get(dyn_client=self.client, name=self.node_selector))
+            return list(
+                Node.get(dyn_client=self.client, name=self.node_selector[f"{self.ApiGroup.KUBERNETES_IO}/hostname"])
+            )
         if self.node_selector_labels:
             node_labels = ",".join([
                 f"{label_key}={label_value}" for label_key, label_value in self.node_selector_labels.items()


### PR DESCRIPTION
##### Short description: Since node_selector expects dict format, _nodes() call needs to be readjusted

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
