### PR TITLE
class-generator: Support resources with same kind

### DIFF
--- a/class_generator/class_generator.py
+++ b/class_generator/class_generator.py
@@ -4,15 +4,13 @@ import filecmp
 import json
 import shlex
 import os
-import shutil
 import sys
 from pathlib import Path
 
 import textwrap
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Tuple
 import click
 import re
-from jinja2.nodes import Impossible
 import requests
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 import cloup

--- a/class_generator/tests/test_class_generator.py
+++ b/class_generator/tests/test_class_generator.py
@@ -47,8 +47,9 @@ from class_generator.class_generator import TESTS_MANIFESTS_DIR, class_generator
 )
 def test_parse_explain(tmpdir_factory, kind, result_file):
     output_dir = tmpdir_factory.mktemp("output-dir")
-    output_file = class_generator(
+    output_files = class_generator(
         kind=kind,
         output_file=os.path.join(output_dir, f"{kind}.py"),
     )
-    assert filecmp.cmp(output_file, result_file)
+    for output_file in output_files:
+        assert filecmp.cmp(output_file, result_file)


### PR DESCRIPTION
Some kinds have multiple resources like `DNS` from different CRDs

``` oc api-resources  | grep -w DNS
dnses     config.openshift.io/v1             false       DNS
dnses     operator.openshift.io/v1         false        DNS
```

In this case, we generate two files
- operator_openshift_io_dns.py
- config_openshift_io_dns.py