### PR TITLE
Add support to set client with cluster proxy

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -13,7 +13,7 @@ from types import TracebackType
 from typing import Optional, Any, Dict, List
 
 import kubernetes
-from kubernetes import config, client
+from kubernetes import client
 from kubernetes.dynamic import DynamicClient, ResourceInstance
 import yaml
 from benedict import benedict
@@ -79,7 +79,11 @@ def _get_api_version(dyn_client: DynamicClient, api_group: str, kind: str) -> st
 
 
 def get_client(
-    config_file: str = "", config_dict: Dict[str, Any] | None = None, context: str = "", proxy: str = "", **kwargs: Any
+    config_file: str = "",
+    config_dict: Dict[str, Any] | None = None,
+    context: str = "",
+    proxy: Optional[str] = "",
+    **kwargs: Any,
 ) -> DynamicClient:
     """
     Get a kubernetes client.
@@ -124,7 +128,9 @@ def get_client(
         LOGGER.info("Trying to get client via new_client_from_config")
 
         return kubernetes.dynamic.DynamicClient(
-            client=kubernetes.config.new_client_from_config(config_file=config_file, client_configuration=client_configuration, context=context or None, **kwargs)
+            client=kubernetes.config.new_client_from_config(
+                config_file=config_file, client_configuration=client_configuration, context=context or None, **kwargs
+            )
         )
     except MaxRetryError:
         # Ref: https://github.com/kubernetes-client/python/blob/v26.1.0/kubernetes/base/config/incluster_config.py

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -118,9 +118,6 @@ def get_client(
         if proxy:
             LOGGER.info(f"Trying to get client using proxy {proxy}")
             client_configuration = client.Configuration()
-            config.load_kube_config(
-                config_file=config_file, client_configuration=client_configuration, persist_config=True
-            )
             client_configuration.proxy = proxy
 
             return kubernetes.dynamic.DynamicClient(

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -121,9 +121,10 @@ def get_client(
                 config_file=config_file, client_configuration=client_configuration, persist_config=True
             )
             client_configuration.proxy = proxy
-            api_client = client.ApiClient(configuration=client_configuration)
 
-            return kubernetes.dynamic.DynamicClient(client=api_client)
+            return kubernetes.dynamic.DynamicClient(
+                client=kubernetes.config.new_client_from_config(config_file=config_file, client_configuration=client_configuration, context=context or None, **kwargs)
+            )
 
         # Ref: https://github.com/kubernetes-client/python/blob/v26.1.0/kubernetes/base/config/__init__.py
         LOGGER.info("Trying to get client via new_client_from_config")

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -114,26 +114,17 @@ def get_client(
         # is populated during import which comes before setting the variable in code.
         config_file = config_file or os.environ.get("KUBECONFIG", "~/.kube/config")
         proxy = proxy or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+        client_configuration = client.Configuration()
 
         if proxy:
             LOGGER.info(f"Trying to get client using proxy {proxy}")
-            client_configuration = client.Configuration()
             client_configuration.proxy = proxy
-
-            return kubernetes.dynamic.DynamicClient(
-                client=kubernetes.config.new_client_from_config(
-                    config_file=config_file,
-                    client_configuration=client_configuration,
-                    context=context or None,
-                    **kwargs,
-                )
-            )
 
         # Ref: https://github.com/kubernetes-client/python/blob/v26.1.0/kubernetes/base/config/__init__.py
         LOGGER.info("Trying to get client via new_client_from_config")
 
         return kubernetes.dynamic.DynamicClient(
-            client=kubernetes.config.new_client_from_config(config_file=config_file, context=context or None, **kwargs)
+            client=kubernetes.config.new_client_from_config(config_file=config_file, client_configuration=client_configuration, context=context or None, **kwargs)
         )
     except MaxRetryError:
         # Ref: https://github.com/kubernetes-client/python/blob/v26.1.0/kubernetes/base/config/incluster_config.py

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -115,7 +115,7 @@ def get_client(
         proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
 
         if proxy:
-            LOGGER.info("Trying to get client using proxy %s", proxy)
+            LOGGER.info(f"Trying to get client using proxy {proxy}")
             client_configuration = client.Configuration()
             config.load_kube_config(
                 config_file=config_file, client_configuration=client_configuration, persist_config=True

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -81,8 +81,8 @@ def _get_api_version(dyn_client: DynamicClient, api_group: str, kind: str) -> st
 def get_client(
     config_file: str = "",
     config_dict: Dict[str, Any] | None = None,
+    client_configuration: client.Configuration | None = None,
     context: str = "",
-    proxy: Optional[str] = "",
     **kwargs: Any,
 ) -> DynamicClient:
     """
@@ -99,8 +99,8 @@ def get_client(
     Args:
         config_file (str): path to a kubeconfig file.
         config_dict (dict): dict with kubeconfig configuration.
+        client_configuration: The kubernetes.client.Configuration to set configs to.
         context (str): name of the context to use.
-        proxy (str): the URL to the proxy to be used for all requests made by this client.
 
     Returns:
         DynamicClient: a kubernetes client.
@@ -117,8 +117,8 @@ def get_client(
         # If `KUBECONFIG` environment variable is set via code, the `KUBE_CONFIG_DEFAULT_LOCATION` will be None since
         # is populated during import which comes before setting the variable in code.
         config_file = config_file or os.environ.get("KUBECONFIG", "~/.kube/config")
-        proxy = proxy or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
-        client_configuration = client.Configuration()
+        client_configuration = client_configuration or client.Configuration()
+        proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
 
         if proxy:
             LOGGER.info(f"Trying to get client using proxy {proxy}")

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -112,7 +112,7 @@ def get_client(
         # If `KUBECONFIG` environment variable is set via code, the `KUBE_CONFIG_DEFAULT_LOCATION` will be None since
         # is populated during import which comes before setting the variable in code.
         config_file = config_file or os.environ.get("KUBECONFIG", "~/.kube/config")
-        proxy = kwargs.pop("proxy", None) or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+        proxy: Optional[str] = kwargs.pop("proxy", None) or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
 
         if proxy:
             LOGGER.info(f"Trying to get client using proxy {proxy}")

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -79,7 +79,7 @@ def _get_api_version(dyn_client: DynamicClient, api_group: str, kind: str) -> st
 
 
 def get_client(
-    config_file: str = "", config_dict: Dict[str, Any] | None = None, context: str = "", **kwargs: Any
+    config_file: str = "", config_dict: Dict[str, Any] | None = None, context: str = "", proxy: str = "", **kwargs: Any
 ) -> DynamicClient:
     """
     Get a kubernetes client.
@@ -96,6 +96,7 @@ def get_client(
         config_file (str): path to a kubeconfig file.
         config_dict (dict): dict with kubeconfig configuration.
         context (str): name of the context to use.
+        proxy (str): the URL to the proxy to be used for all requests made by this client.
 
     Returns:
         DynamicClient: a kubernetes client.
@@ -112,7 +113,7 @@ def get_client(
         # If `KUBECONFIG` environment variable is set via code, the `KUBE_CONFIG_DEFAULT_LOCATION` will be None since
         # is populated during import which comes before setting the variable in code.
         config_file = config_file or os.environ.get("KUBECONFIG", "~/.kube/config")
-        proxy: Optional[str] = kwargs.pop("proxy", None) or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+        proxy = proxy or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
 
         if proxy:
             LOGGER.info(f"Trying to get client using proxy {proxy}")

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -123,7 +123,12 @@ def get_client(
             client_configuration.proxy = proxy
 
             return kubernetes.dynamic.DynamicClient(
-                client=kubernetes.config.new_client_from_config(config_file=config_file, client_configuration=client_configuration, context=context or None, **kwargs)
+                client=kubernetes.config.new_client_from_config(
+                    config_file=config_file,
+                    client_configuration=client_configuration,
+                    context=context or None,
+                    **kwargs,
+                )
             )
 
         # Ref: https://github.com/kubernetes-client/python/blob/v26.1.0/kubernetes/base/config/__init__.py

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -112,7 +112,7 @@ def get_client(
         # If `KUBECONFIG` environment variable is set via code, the `KUBE_CONFIG_DEFAULT_LOCATION` will be None since
         # is populated during import which comes before setting the variable in code.
         config_file = config_file or os.environ.get("KUBECONFIG", "~/.kube/config")
-        proxy = os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
+        proxy = kwargs.pop("proxy", None) or os.environ.get("HTTPS_PROXY") or os.environ.get("HTTP_PROXY")
 
         if proxy:
             LOGGER.info(f"Trying to get client using proxy {proxy}")


### PR DESCRIPTION
##### Short description:
Add support to set client with cluster proxy
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:
https://issues.redhat.com/browse/CNV-46351
##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced Kubernetes client configuration to support proxy settings, improving flexibility for users connecting through proxies.

- **Bug Fixes**
	- Ensured proper logging of proxy settings for better transparency and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->