### PR TITLE
class-generator: remove minimum cluster version in update-schema

### DIFF
--- a/class_generator/class_generator.py
+++ b/class_generator/class_generator.py
@@ -7,7 +7,6 @@ import os
 import sys
 import requests
 from pathlib import Path
-from packaging.version import Version
 
 import textwrap
 from typing import Any, Dict, List, Tuple
@@ -149,20 +148,9 @@ def get_client_binary() -> str:
         sys.exit(1)
 
 
-def check_minimum_cluster_version(client) -> None:
-    cluster_version = get_server_version(client=client)
-    minimum_server_version = "v1.30.0"
-    if Version(cluster_version) < Version(minimum_server_version):
-        LOGGER.error(
-            f"Server version {cluster_version} is not supported. Minimum supported version is {minimum_server_version}"
-        )
-        sys.exit(1)
-
-
 def update_kind_schema():
     openapi2jsonschema_str: str = "openapi2jsonschema"
     client = get_client_binary()
-    check_minimum_cluster_version(client=client)
 
     if not run_command(command=shlex.split("which openapi2jsonschema"), check=False, log_errors=False)[0]:
         LOGGER.error(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed the version check that could have caused errors if the server version was below the required threshold.

- **New Features**
	- Improved flow in the `update_kind_schema` function by eliminating unnecessary version validation, allowing for smoother operations.

Please proceed with caution as this change may lead to compatibility issues with unsupported server versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->