### PR TITLE
Fix invalid api group

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -300,7 +300,7 @@ class Resource:
         INTEGREATLY_ORG: str = "integreatly.org"
         K8S_CNI_CNCF_IO: str = "k8s.cni.cncf.io"
         K8S_MARIADB_COM: str = "k8s.mariadb.com"
-        K8S_OVN_ORG: str = "k8s.ovn.org/v1"
+        K8S_OVN_ORG: str = "k8s.ovn.org"
         K8S_V1_CNI_CNCF_IO: str = "k8s.v1.cni.cncf.io"
         KUBERNETES_IO: str = "kubernetes.io"
         KUBEVIRT_IO: str = "kubevirt.io"


### PR DESCRIPTION
##### Short description:
Update K8S_OVN_ORG API group definition to use the correct group string
##### More details:

##### What this PR does / why we need it:
Fix API group definition for K8S_OVN_ORG to resolve:
'NotImplementedError: Couldn't find UserDefinedNetwork in k8s.ovn.org/v1 api group.
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:
