### PR TITLE
Add wait_for_resource parameter for Resource

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -380,6 +380,7 @@ class Resource:
         hash_log_data: bool = True,
         ensure_exists: bool = False,
         kind_dict: Dict[Any, Any] | None = None,
+        wait_for_resource: bool = False,
     ):
         """
         Create an API resource
@@ -407,6 +408,7 @@ class Resource:
                 (example: Secret resource)
             ensure_exists (bool): Whether to check if the resource exists before when initializing the resource, raise if not.
             kind_dict (dict): dict which represents the resource object
+            wait_for_resource (bool): Waits for the resource to be created
         """
         if yaml_file and kind_dict:
             raise ValueError("yaml_file and resource_dict are mutually exclusive")
@@ -448,6 +450,7 @@ class Resource:
         self.yaml_file_contents: str = ""
         self.initial_resource_version: str = ""
         self.logger = self._set_logger()
+        self.wait_for_resource = wait_for_resource
 
         if ensure_exists:
             self._ensure_exists()
@@ -524,7 +527,7 @@ class Resource:
 
     def __enter__(self) -> "Resource":
         signal(SIGINT, self._sigint_handler)
-        return self.deploy()
+        return self.deploy(wait=self.wait_for_resource)
 
     def __exit__(
         self,


### PR DESCRIPTION
##### Short description:
the `deploy`/`create` methods expect a `wait` parameter which would wait for the resource being deployed/created, but this is never passed down from `__init__` or `__enter__` and thus always defaults to `False`. Adding the parameter in these two functions allows us to use this while creating resources. 

##### More details:
Tested with Namespace creation
```
In [7]: ns = Namespace(name="my-test", wait_for_resource=True, client=client)

In [8]: ns
Out[8]: <ocp_resources.namespace.Namespace at 0x117f31190>

In [9]: ns.deploy()
2024-10-14T16:35:51.243289 ocp_resources Namespace INFO Create Namespace my-test
2024-10-14T16:35:51.243795 ocp_resources Namespace INFO Posting {'apiVersion': 'v1', 'kind': 'Namespace', 'metadata': {'name': 'my-test'}, 'spec': {}}
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
Out[9]: <ocp_resources.namespace.Namespace at 0x117f31190>

In [10]: ns.delete()
2024-10-14T16:36:34.376997 ocp_resources Namespace INFO Delete Namespace my-test
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
2024-10-14T16:36:34.649673 ocp_resources Namespace INFO Deleting {'kind': 'Namespace', 'apiVersion': 'v1', 'metadata': {'name': 'my-test', 'uid': 'a6003107-f7b6-4b24-ac6a-aaf6d1b7b004', 'resourceVersion': '89029295', 'creationTimestamp': '2024-10-14T14:34:17Z', 'labels': {'kubernetes.io/metadata.name': 'my-test', 'pod-security.kubernetes.io/audit': 'restricted', 'pod-security.kubernetes.io/audit-version': 'v1.24', 'pod-security.kubernetes.io/warn': 'restricted', 'pod-security.kubernetes.io/warn-version': 'v1.24'}, 'annotations': {'openshift.io/sa.scc.mcs': 's0:c28,c7', 'openshift.io/sa.scc.supplemental-groups': '1000770000/10000', 'openshift.io/sa.scc.uid-range': '1000770000/10000'}, 'managedFields': [{'manager': 'pod-security-admission-label-synchronization-controller', 'operation': 'Apply', 'apiVersion': 'v1', 'time': '2024-10-14T14:35:24Z', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:metadata': {'f:labels': {'f:pod-security.kubernetes.io/audit': {}, 'f:pod-security.kubernetes.io/audit-version': {}, 'f:pod-security.kubernetes.io/warn': {}, 'f:pod-security.kubernetes.io/warn-version': {}}}}}, {'manager': 'OpenAPI-Generator', 'operation': 'Update', 'apiVersion': 'v1', 'time': '2024-10-14T14:34:17Z', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:metadata': {'f:labels': {'.': {}, 'f:kubernetes.io/metadata.name': {}}}}}, {'manager': 'cluster-policy-controller', 'operation': 'Update', 'apiVersion': 'v1', 'time': '2024-10-14T14:35:23Z', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:metadata': {'f:annotations': {'.': {}, 'f:openshift.io/sa.scc.mcs': {}, 'f:openshift.io/sa.scc.supplemental-groups': {}, 'f:openshift.io/sa.scc.uid-range': {}}}}}]}, 'spec': {'finalizers': ['kubernetes']}, 'status': {'phase': 'Active'}}
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
Out[10]: True

In [11]: ns2 = Namespace(name="my-test", client=client)

In [12]: ns2.deploy()
2024-10-14T16:39:38.362860 ocp_resources Namespace INFO Create Namespace my-test
2024-10-14T16:39:38.363149 ocp_resources Namespace INFO Posting {'apiVersion': 'v1', 'kind': 'Namespace', 'metadata': {'name': 'my-test'}, 'spec': {}}
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
Out[12]: <ocp_resources.namespace.Namespace at 0x117b71950>

In [13]: ns2.delete()
2024-10-14T17:33:51.088265 ocp_resources Namespace INFO Delete Namespace my-test
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
2024-10-14T17:33:51.723735 ocp_resources Namespace INFO Deleting {'kind': 'Namespace', 'apiVersion': 'v1', 'metadata': {'name': 'my-test', 'uid': '0b8a3872-8492-4a70-b05c-cc298b2cc889', 'resourceVersion': '89032573', 'creationTimestamp': '2024-10-14T14:38:04Z', 'labels': {'kubernetes.io/metadata.name': 'my-test', 'pod-security.kubernetes.io/audit': 'restricted', 'pod-security.kubernetes.io/audit-version': 'v1.24', 'pod-security.kubernetes.io/warn': 'restricted', 'pod-security.kubernetes.io/warn-version': 'v1.24'}, 'annotations': {'openshift.io/sa.scc.mcs': 's0:c28,c22', 'openshift.io/sa.scc.supplemental-groups': '1000800000/10000', 'openshift.io/sa.scc.uid-range': '1000800000/10000'}, 'managedFields': [{'manager': 'pod-security-admission-label-synchronization-controller', 'operation': 'Apply', 'apiVersion': 'v1', 'time': '2024-10-14T14:39:11Z', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:metadata': {'f:labels': {'f:pod-security.kubernetes.io/audit': {}, 'f:pod-security.kubernetes.io/audit-version': {}, 'f:pod-security.kubernetes.io/warn': {}, 'f:pod-security.kubernetes.io/warn-version': {}}}}}, {'manager': 'OpenAPI-Generator', 'operation': 'Update', 'apiVersion': 'v1', 'time': '2024-10-14T14:38:04Z', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:metadata': {'f:labels': {'.': {}, 'f:kubernetes.io/metadata.name': {}}}}}, {'manager': 'cluster-policy-controller', 'operation': 'Update', 'apiVersion': 'v1', 'time': '2024-10-14T14:39:11Z', 'fieldsType': 'FieldsV1', 'fieldsV1': {'f:metadata': {'f:annotations': {'.': {}, 'f:openshift.io/sa.scc.mcs': {}, 'f:openshift.io/sa.scc.supplemental-groups': {}, 'f:openshift.io/sa.scc.uid-range': {}}}}}]}, 'spec': {'finalizers': ['kubernetes']}, 'status': {'phase': 'Active'}}
/Users/lgiorgi/Desktop/Work/openshift-python-wrapper/.venv/lib/python3.11/site-packages/urllib3/connectionpool.py:1099: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-psi-04.osp.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
Out[13]: True
```

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `wait_for_resource` parameter for more control over resource deployment and cleanup.
	- Enhanced `deploy` and `clean_up` methods to conditionally wait for resource creation and deletion based on user preference.

These changes provide users with improved flexibility during resource management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->