### PR TITLE
Add arguments to MariadbOperator class

### DIFF
--- a/ocp_resources/mariadb_operator.py
+++ b/ocp_resources/mariadb_operator.py
@@ -138,5 +138,5 @@ class MariadbOperator(NamespacedResource):
                 _spec["tolerations"] = self.tolerations
             if self.webhook is not None:
                 _spec["webhook"] = self.webhook
-                
+
     # End of generated code


### PR DESCRIPTION
##### Short description:
Add missing arguments to MariadbOperator

##### More details:
MariadbOperator is created through Helm, so class_generator wasn't able to pick up its arguments.

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration options for the MariaDB operator, allowing users to specify various parameters for improved customization.
	- Introduced a method to convert the operator's configuration into a dictionary format for easier management and integration.

These changes provide users with greater flexibility and control over the MariaDB operator's behavior and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->