### PR TITLE
Add UDN layer3 class

### DIFF
--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -69,19 +69,6 @@ class UserDefinedNetwork(NamespacedResource):
     # End of generated code
 
 
-class TopologyType:
-    """
-    This class contains constants for different network topology types used in the UserDefinedNetwork configuration.
-
-    Attributes:
-        LAYER2 (str): Represents a Layer2 topology.
-        LAYER3 (str): Represents a Layer3 topology.
-    """
-
-    LAYER2 = "Layer2"
-    LAYER3 = "Layer3"
-
-
 class Layer2UserDefinedNetwork(UserDefinedNetwork):
     """
     UserDefinedNetwork layer2 object.
@@ -89,6 +76,8 @@ class Layer2UserDefinedNetwork(UserDefinedNetwork):
     API reference:
     https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/#layer2config
     """
+
+    LAYER2: str = "Layer2"
 
     def __init__(
         self,
@@ -110,7 +99,7 @@ class Layer2UserDefinedNetwork(UserDefinedNetwork):
             ipam_lifecycle (Optional[str]): ipam_lifecycle controls IP addresses management lifecycle.
         """
         super().__init__(
-            topology=TopologyType.LAYER2,
+            topology=self.LAYER2,
             **kwargs,
         )
         self.role = role
@@ -125,8 +114,8 @@ class Layer2UserDefinedNetwork(UserDefinedNetwork):
             if not self.role:
                 raise MissingRequiredArgumentError(argument="role")
 
-            self.res["spec"][TopologyType.LAYER2.lower()] = {"role": self.role}
-            _layer2 = self.res["spec"][TopologyType.LAYER2.lower()]
+            self.res["spec"][self.LAYER2.lower()] = {"role": self.role}
+            _layer2 = self.res["spec"][self.LAYER2.lower()]
 
             if self.mtu:
                 _layer2["mtu"] = self.mtu
@@ -173,6 +162,8 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
     https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/#layer3config
     """
 
+    LAYER3: str = "Layer3"
+
     def __init__(
         self,
         role: str,
@@ -191,7 +182,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
             join_subnets (Optional[List[str]]): join_subnets are used inside the OVN network topology.
         """
         super().__init__(
-            topology=TopologyType.LAYER3,
+            topology=self.LAYER3,
             **kwargs,
         )
         self.role = role
@@ -205,8 +196,8 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
             if not self.role:
                 raise MissingRequiredArgumentError(argument="role")
 
-            self.res["spec"][TopologyType.LAYER3.lower()] = {"role": self.role}
-            _layer3 = self.res["spec"][TopologyType.LAYER3.lower()]
+            self.res["spec"][self.LAYER3.lower()] = {"role": self.role}
+            _layer3 = self.res["spec"][self.LAYER3.lower()]
 
             if self.mtu:
                 _layer3["mtu"] = self.mtu

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -193,7 +193,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
     def to_dict(self) -> None:
         super().to_dict()
         if not self.kind_dict and not self.yaml_file:
-            if not self.role:
+            if not all([self.role, self.subnets]):
                 raise MissingRequiredArgumentError(argument="role")
 
             self.res["spec"][self.LAYER3.lower()] = {"role": self.role}

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -206,7 +206,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
                 _layer3["joinSubnets"] = self.join_subnets
 
             if self.subnets is not None:
-                _subnets = _layer3.setdefault("subnets", [])
+                _subnets = _layer3["subnets"]
 
                 for subnet in self.subnets:
                     subnet_dict = {

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -169,13 +169,10 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
     def to_dict(self) -> None:
         super().to_dict()
         if not self.kind_dict and not self.yaml_file:
-            missing = []
             if not self.role:
-                missing.append("role")
+                raise MissingRequiredArgumentError(argument="role")
             if not self.subnets:
-                missing.append("subnets")
-            if missing:
-                raise MissingRequiredArgumentError(argument=", ".join(missing))
+                raise MissingRequiredArgumentError(argument="subnets")
 
             self.res["spec"][self.LAYER3.lower()] = {"role": self.role}
             _layer3 = self.res["spec"][self.LAYER3.lower()]

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -205,7 +205,8 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
             if self.join_subnets:
                 _layer3["joinSubnets"] = self.join_subnets
 
-            if self.subnets is not None:
+            if self.subnets:
+                _layer3["subnets"] = []
                 _subnets = _layer3["subnets"]
 
                 for subnet in self.subnets:

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -144,7 +144,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
         self,
         role: Optional[str] = None,
         mtu: Optional[int] = None,
-        subnets: Optional[List[Dict]] = None,
+        subnets: Optional[List[Dict[str, Any]]] = None,
         join_subnets: Optional[List[str]] = None,
         **kwargs,
     ):

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -169,8 +169,13 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
     def to_dict(self) -> None:
         super().to_dict()
         if not self.kind_dict and not self.yaml_file:
-            if not all([self.role, self.subnets]):
-                raise MissingRequiredArgumentError(argument="role")
+            missing = []
+            if not self.role:
+                missing.append("role")
+            if not self.subnets:
+                missing.append("subnets")
+            if missing:
+                raise MissingRequiredArgumentError(argument=", ".join(missing))
 
             self.res["spec"][self.LAYER3.lower()] = {"role": self.role}
             _layer3 = self.res["spec"][self.LAYER3.lower()]

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -142,7 +142,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
 
     def __init__(
         self,
-        role: str,
+        role: Optional[str] = None,
         mtu: Optional[int] = None,
         subnets: Optional[List[Dict]] = None,
         join_subnets: Optional[List[str]] = None,

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -169,8 +169,13 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
     def to_dict(self) -> None:
         super().to_dict()
         if not self.kind_dict and not self.yaml_file:
-            if not all([self.role, self.subnets]):
-                raise MissingRequiredArgumentError(argument="'role', 'subnets'")
+            missing = []
+            if not self.role:
+                missing.append("role")
+            if not self.subnets:
+                missing.append("subnets")
+            if missing:
+                raise MissingRequiredArgumentError(argument=", ".join(missing))
 
             self.res["spec"][self.LAYER3.lower()] = {"role": self.role}
             _layer3 = self.res["spec"][self.LAYER3.lower()]

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -154,7 +154,11 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
         Args:
             role (Optional[str]): role describes the network role in the pod.
             mtu (Optional[int]): mtu is the maximum transmission unit for a network.
-            subnets (Optional[List[Dict]]): subnets are used for the pod network across the cluster.
+            subnets (Optional[List[Dict]]): subnets are used for the pod network across the cluster, each expecting:
+                - `cidr` (str): IP range in CIDR notation.
+                - `hostSubnet` (Optional[int]): Host-specific subnet.
+                API reference:
+                https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/#layer3subnet
             join_subnets (Optional[List[str]]): join_subnets are used inside the OVN network topology.
         """
         super().__init__(

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -152,7 +152,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
         Create and manage UserDefinedNetwork with layer3 configuration
 
         Args:
-            role (Optional[str]): role describes the network role in the pod. Required.
+            role (Optional[str]): role describes the network role in the pod.
             mtu (Optional[int]): mtu is the maximum transmission unit for a network.
             subnets (Optional[List[Dict]]): subnets are used for the pod network across the cluster.
             join_subnets (Optional[List[str]]): join_subnets are used inside the OVN network topology.

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -130,30 +130,6 @@ class Layer2UserDefinedNetwork(UserDefinedNetwork):
                 _layer2["ipamLifecycle"] = self.ipam_lifecycle
 
 
-class Layer3Subnets:
-    """
-    UserDefinedNetwork layer3 subnets object.
-
-    API reference:
-    https://ovn-kubernetes.io/api-reference/userdefinednetwork-api-spec/#layer3subnet
-    """
-
-    def __init__(
-        self,
-        cidr: Optional[str] = None,
-        host_subnet: Optional[int] = None,
-    ):
-        """
-        UserDefinedNetwork layer3 subnets object.
-
-        Args:
-            cidr (Optional[str]): CIDR specifies L3Subnet, which is split into smaller subnets for every node.
-            host_subnet (Optional[int]): host_subnet specifies the subnet size for every node.
-        """
-        self.cidr = cidr
-        self.host_subnet = host_subnet
-
-
 class Layer3UserDefinedNetwork(UserDefinedNetwork):
     """
     UserDefinedNetwork layer3 object.
@@ -168,7 +144,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
         self,
         role: str,
         mtu: Optional[int] = None,
-        subnets: Optional[List[Layer3Subnets]] = None,
+        subnets: Optional[List[Dict]] = None,
         join_subnets: Optional[List[str]] = None,
         **kwargs,
     ):
@@ -178,7 +154,7 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
         Args:
             role (Optional[str]): role describes the network role in the pod. Required.
             mtu (Optional[int]): mtu is the maximum transmission unit for a network.
-            subnets (Optional[List[Layer3Subnets]]): subnets are used for the pod network across the cluster.
+            subnets (Optional[List[Dict]]): subnets are used for the pod network across the cluster.
             join_subnets (Optional[List[str]]): join_subnets are used inside the OVN network topology.
         """
         super().__init__(
@@ -206,13 +182,4 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
                 _layer3["joinSubnets"] = self.join_subnets
 
             if self.subnets:
-                _layer3["subnets"] = []
-                _subnets = _layer3["subnets"]
-
-                for subnet in self.subnets:
-                    subnet_dict = {
-                        key: value
-                        for key, value in [("cidr", subnet.cidr), ("hostSubnet", subnet.host_subnet)]
-                        if value is not None
-                    }
-                    _subnets.append(subnet_dict)
+                _layer3["subnets"] = self.subnets

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -169,13 +169,8 @@ class Layer3UserDefinedNetwork(UserDefinedNetwork):
     def to_dict(self) -> None:
         super().to_dict()
         if not self.kind_dict and not self.yaml_file:
-            missing = []
-            if not self.role:
-                missing.append("role")
-            if not self.subnets:
-                missing.append("subnets")
-            if missing:
-                raise MissingRequiredArgumentError(argument=", ".join(missing))
+            if not all([self.role, self.subnets]):
+                raise MissingRequiredArgumentError(argument="'role', 'subnets'")
 
             self.res["spec"][self.LAYER3.lower()] = {"role": self.role}
             _layer3 = self.res["spec"][self.LAYER3.lower()]


### PR DESCRIPTION
##### Short description:
Add Layer3 topology class to manage Layer3 network configurations in UserDefinedNetwork.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `Layer3UserDefinedNetwork` class for Layer3-specific configurations, enhancing network setup options.

- **Improvements**
	- Updated `Layer2UserDefinedNetwork` to include additional parameters for improved flexibility.
	- Enhanced error handling in `to_dict` methods for both `Layer2UserDefinedNetwork` and `Layer3UserDefinedNetwork`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->