### PR TITLE
feat: VolumeSnapshot and VolumeSnapshotClass implement

### DIFF
--- a/ocp_resources/volume_snapshot.py
+++ b/ocp_resources/volume_snapshot.py
@@ -1,9 +1,59 @@
-from ocp_resources.resource import NamespacedResource
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+from typing import Any, Dict, Optional
+from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentError
 
 
 class VolumeSnapshot(NamespacedResource):
     """
-    VolumeSnapshot object.
+    VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
     """
 
-    api_group = NamespacedResource.ApiGroup.SNAPSHOT_STORAGE_K8S_IO
+    api_group: str = NamespacedResource.ApiGroup.SNAPSHOT_STORAGE_K8S_IO
+
+    def __init__(
+        self,
+        source: Optional[Dict[str, Any]] = None,
+        volume_snapshot_class_name: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Args:
+            source (Dict[str, Any]): source specifies where a snapshot will be created from. This field is
+              immutable after creation. Required.
+
+            volume_snapshot_class_name (str): VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+              requested by the VolumeSnapshot. VolumeSnapshotClassName may be
+              left nil to indicate that the default SnapshotClass should be
+              used. A given cluster may have multiple default Volume
+              SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot
+              does not specify a SnapshotClass, VolumeSnapshotSource will be
+              checked to figure out what the associated CSI Driver is, and the
+              default VolumeSnapshotClass associated with that CSI Driver will
+              be used. If more than one VolumeSnapshotClass exist for a given
+              CSI Driver and more than one have been marked as default,
+              CreateSnapshot will fail and generate an event. Empty string is
+              not allowed for this field.
+
+        """
+        super().__init__(**kwargs)
+
+        self.source = source
+        self.volume_snapshot_class_name = volume_snapshot_class_name
+
+    def to_dict(self) -> None:
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if not self.source:
+                raise MissingRequiredArgumentError(argument="self.source")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["source"] = self.source
+
+            if self.volume_snapshot_class_name is not None:
+                _spec["volumeSnapshotClassName"] = self.volume_snapshot_class_name
+
+    # End of generated code

--- a/ocp_resources/volume_snapshot_class.py
+++ b/ocp_resources/volume_snapshot_class.py
@@ -1,9 +1,60 @@
-from ocp_resources.resource import Resource
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+from typing import Any, Dict, Optional
+from ocp_resources.resource import Resource, MissingRequiredArgumentError
 
 
 class VolumeSnapshotClass(Resource):
     """
-    VolumeSnapshotClass object.
+    VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
     """
 
-    api_group = Resource.ApiGroup.SNAPSHOT_STORAGE_K8S_IO
+    api_group: str = Resource.ApiGroup.SNAPSHOT_STORAGE_K8S_IO
+
+    def __init__(
+        self,
+        deletion_policy: Optional[str] = "",
+        driver: Optional[str] = "",
+        parameters: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Args:
+            deletion_policy (str): deletionPolicy determines whether a VolumeSnapshotContent created
+              through the VolumeSnapshotClass should be deleted when its bound
+              VolumeSnapshot is deleted. Supported values are "Retain" and
+              "Delete". "Retain" means that the VolumeSnapshotContent and its
+              physical snapshot on underlying storage system are kept. "Delete"
+              means that the VolumeSnapshotContent and its physical snapshot on
+              underlying storage system are deleted. Required.
+
+            driver (str): driver is the name of the storage driver that handles this
+              VolumeSnapshotClass. Required.
+
+            parameters (Dict[str, Any]): parameters is a key-value map with storage driver specific parameters
+              for creating snapshots. These values are opaque to Kubernetes.
+
+        """
+        super().__init__(**kwargs)
+
+        self.deletion_policy = deletion_policy
+        self.driver = driver
+        self.parameters = parameters
+
+    def to_dict(self) -> None:
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if not self.deletion_policy:
+                raise MissingRequiredArgumentError(argument="self.deletion_policy")
+
+            if not self.driver:
+                raise MissingRequiredArgumentError(argument="self.driver")
+
+            self.res["deletionPolicy"] = self.deletion_policy
+            self.res["driver"] = self.driver
+
+            if self.parameters:
+                self.res["parameters"] = self.parameters
+
+    # End of generated code


### PR DESCRIPTION
Update VolumeSnapshotClass class, add DeletionPolicy type, also add support for resource creation.

Refs: https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes

##### Short description:
Add support for VolumeSnapshotClass resource creation

##### More details:
The current code does not support creating VolumeSnapshotClass, only pointing to the api_group.

##### What this PR does / why we need it:
This PR aims to support VolumeSnapshotClass creation. It added the DeletionPolicy type and supports key arguments during class initialization, referring to https://kubernetes.io/docs/concepts/storage/volume-snapshot-classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `VolumeSnapshotClass` with additional optional parameters: `deletion_policy`, `driver`, and `parameters`.
	- Introduced `VolumeSnapshot` class with new parameters: `source` and `volume_snapshot_class_name` for improved snapshot management.

- **Bug Fixes**
	- Improved error handling for required parameters in the `to_dict` method, ensuring better user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->