### PR TITLE
Update Model Registry check on grpc and rest spec

### DIFF
--- a/ocp_resources/model_registry.py
+++ b/ocp_resources/model_registry.py
@@ -56,10 +56,10 @@ class ModelRegistry(NamespacedResource):
         super().to_dict()
 
         if not self.kind_dict and not self.yaml_file:
-            if not self.grpc:
+            if not self.grpc and self.grpc != {}:
                 raise MissingRequiredArgumentError(argument="self.grpc")
 
-            if not self.rest:
+            if not self.rest and self.rest != {}:
                 raise MissingRequiredArgumentError(argument="self.rest")
 
             self.res["spec"] = {}


### PR DESCRIPTION
Passing in an empty dict should be allowed, the operator then takes care of filling out the missing bits of the resource.