### PR TITLE
fix IndexError if no virt-launcher pod

### DIFF
--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -75,6 +75,9 @@ class VirtualMachineInstance(NamespacedResource):
                 label_selector=f"kubevirt.io=virt-launcher,kubevirt.io/created-by={self.instance.metadata.uid}",
             )
         )
+        if not pods:
+            raise ResourceNotFoundError(f"VIRT launcher POD not found for {self.kind}:{self.name}")
+
         migration_state = self.instance.status.migrationState
         if migration_state:
             #  After VM migration there are two pods, one in Completed status and one in Running status.
@@ -84,8 +87,6 @@ class VirtualMachineInstance(NamespacedResource):
                     return pod
         else:
             return pods[0]
-
-        raise ResourceNotFoundError(f"VIRT launcher POD not found for {self.kind}:{self.name}")
 
     @property
     def virt_handler_pod(self):


### PR DESCRIPTION
##### Short description:
raise `ResourceNotFoundError` with meaningful message instead of `IndexError`

##### More details:
Encountered issue when calling for `wait_until_running()` method
```
03:33:36  2024-12-04T01:33:36.613602 ocp_resources VirtualMachineInstance INFO Wait for VirtualMachineInstance windows-efi-secureboot-1733276010-0263808 status to be Running
03:33:36  2024-12-04T01:33:36.613914 timeout_sampler INFO Waiting for 240 seconds [0:04:00], retry every 1 seconds. (Function: kubernetes.dynamic.client.get Kwargs: {'field_selector': 'metadata.name==windows-efi-secureboot-1733276010-0263808', 'namespace': 'virt-general-efi-secureboot-test-vm-with-efi-secureboot'})
03:33:36  2024-12-04T01:33:36.618097 ocp_resources VirtualMachineInstance INFO Status of VirtualMachineInstance windows-efi-secureboot-1733276010-0263808 is Pending
03:37:43  2024-12-04T01:37:36.784198 ocp_resources VirtualMachineInstance ERROR Status of VirtualMachineInstance windows-efi-secureboot-1733276010-0263808 is Pending
```
...
```
03:37:43    File "/cnv-tests/utilities/virt.py", line 1646, in running_vm
03:37:43      wait_for_running_vm(
03:37:43    File "/cnv-tests/utilities/virt.py", line 1579, in wait_for_running_vm
03:37:43      vm.vmi.wait_until_running(timeout=wait_until_running_timeout)
03:37:43    File "/cnv-tests/.venv/lib/python3.9/site-packages/ocp_resources/virtual_machine_instance.py", line 122, in wait_until_running
03:37:43      virt_pod = self.virt_launcher_pod
03:37:43    File "/cnv-tests/.venv/lib/python3.9/site-packages/ocp_resources/virtual_machine_instance.py", line 86, in virt_launcher_pod
03:37:43      return pods[0]
03:37:43  IndexError: list index out of range
```

##### What this PR does / why we need it:


##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for pod retrieval, providing clearer exceptions when no pods are found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->