### PR TITLE
VirtualMachineExport - update with class_generator

### DIFF
--- a/ocp_resources/virtual_machine_export.py
+++ b/ocp_resources/virtual_machine_export.py
@@ -1,10 +1,7 @@
 # Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
 
 from __future__ import annotations
-from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource
-from ocp_resources.virtual_machine import VirtualMachine
-from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
 
 from typing import Any
 
@@ -63,8 +60,3 @@ class VirtualMachineExport(NamespacedResource):
                 _spec["ttlDuration"] = self.ttl_duration
 
     # End of generated code
-
-    class SourceKind:
-        VM = VirtualMachine.kind
-        VM_SNAPSHOT = VirtualMachineSnapshot.kind
-        PVC = PersistentVolumeClaim.kind

--- a/ocp_resources/virtual_machine_export.py
+++ b/ocp_resources/virtual_machine_export.py
@@ -1,39 +1,32 @@
-# -*- coding: utf-8 -*-
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
 
-from ocp_resources.utils.constants import TIMEOUT_1MINUTE
+from __future__ import annotations
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource
 from ocp_resources.virtual_machine import VirtualMachine
 from ocp_resources.virtual_machine_snapshot import VirtualMachineSnapshot
 
+from typing import Any
+
 
 class VirtualMachineExport(NamespacedResource):
     """
-    VirtualMachineExport object.
+    VirtualMachineExport defines the operation of exporting a VM source
     """
 
     api_group: str = NamespacedResource.ApiGroup.EXPORT_KUBEVIRT_IO
 
-    class SourceKind:
-        VM = VirtualMachine.kind
-        VM_SNAPSHOT = VirtualMachineSnapshot.kind
-        PVC = PersistentVolumeClaim.kind
-
     def __init__(
         self,
-        source_api_group: str | None = None,
-        source_kind: str | None = None,
-        source_name: str | None = None,
+        source: dict[str, Any] | None = None,
         token_secret_ref: str | None = None,
         ttl_duration: str | None = None,
-        delete_timeout: int = TIMEOUT_1MINUTE,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """
         Args:
-            source_api_group (str): Api group of the exported resource
-            source_kind (str): Kind of the exported resource
-            source_name (str): Name of the exported resource inside the same namespace
+            source (dict[str, Any]): TypedLocalObjectReference contains enough information to let you
+              locate the typed referenced object inside the same namespace.
 
             token_secret_ref (str): TokenSecretRef is the name of the custom-defined secret that contains
               the token used by the export server pod
@@ -43,14 +36,11 @@ class VirtualMachineExport(NamespacedResource):
               CreationTimestamp, the export is eligible to be automatically
               deleted. If this field is omitted, a reasonable default is
               applied.
+
         """
-        super().__init__(
-            delete_timeout=delete_timeout,
-            **kwargs,
-        )
-        self.source_api_group = source_api_group
-        self.source_kind = source_kind
-        self.source_name = source_name
+        super().__init__(**kwargs)
+
+        self.source = source
         self.token_secret_ref = token_secret_ref
         self.ttl_duration = ttl_duration
 
@@ -58,20 +48,23 @@ class VirtualMachineExport(NamespacedResource):
         super().to_dict()
 
         if not self.kind_dict and not self.yaml_file:
-            if not (self.source_kind and self.source_name):
-                raise MissingRequiredArgumentError(argument="'source_kind' and 'source_name'")
+            if self.source is None:
+                raise MissingRequiredArgumentError(argument="self.source")
 
             self.res["spec"] = {}
             _spec = self.res["spec"]
 
-            _spec["source"] = {
-                "apiGroup": self.source_api_group,
-                "kind": self.source_kind,
-                "name": self.source_name,
-            }
+            _spec["source"] = self.source
 
             if self.token_secret_ref:
                 _spec["tokenSecretRef"] = self.token_secret_ref
 
             if self.ttl_duration:
                 _spec["ttlDuration"] = self.ttl_duration
+
+    # End of generated code
+
+    class SourceKind:
+        VM = VirtualMachine.kind
+        VM_SNAPSHOT = VirtualMachineSnapshot.kind
+        PVC = PersistentVolumeClaim.kind


### PR DESCRIPTION
##### Short description:
VirtualMachineExport - update with class_generator
- remove timeout arg and all other parent args
- remove `source_api_group`, `source_kind`, and `source_name`

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced structure and clarity of the VirtualMachineExport class.
	- Simplified parameter handling in the constructor.
	- Improved logic for generating the specification dictionary in the to_dict method.

- **Documentation**
	- Expanded constructor docstring with detailed descriptions for new parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->