### PR TITLE
Fix deploy function of NNCP

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -301,7 +301,7 @@ class NodeNetworkConfigurationPolicy(Resource):
             return self
         except Exception as exp:
             self.logger.error(exp)
-            super().__exit__(exception_type=None, exception_value=None, traceback=None)
+            super().__exit__()
             raise
 
     def clean_up(self):


### PR DESCRIPTION
##### Short description:
If the the deploy func fails,  clean_up func of resource is called at the except section. But the args this call using wrong name.

##### More details:
This has to be fixed, because otherwise the NNCP resource doesn't get cleaned up upon failure.

##### Which issue(s) this PR fixes:
automation bug fix.

##### Bug:
automation bug fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in network configuration policy deployment process
	- Simplified method for handling exceptions during network policy deployment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->