### PR TITLE
Pass sleep_time as argument in wait_for_condition method

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -1027,7 +1027,7 @@ class Resource(ResourceConstants):
             resource_version=resource_version or self.initial_resource_version,
         )
 
-    def wait_for_condition(self, condition: str, status: str, timeout: int = 300) -> None:
+    def wait_for_condition(self, condition: str, status: str, timeout: int = 300, sleep_time: int = 1) -> None:
         """
         Wait for Resource condition to be in desire status.
 
@@ -1035,6 +1035,7 @@ class Resource(ResourceConstants):
             condition (str): Condition to query.
             status (str): Expected condition status.
             timeout (int): Time to wait for the resource.
+            sleep_time(int): Interval between each retry when checking the resource's condition.
 
         Raises:
             TimeoutExpiredError: If Resource condition in not in desire status.
@@ -1044,7 +1045,7 @@ class Resource(ResourceConstants):
         timeout_watcher = TimeoutWatch(timeout=timeout)
         for sample in TimeoutSampler(
             wait_timeout=timeout,
-            sleep=1,
+            sleep=sleep_time,
             func=lambda: self.exists,
         ):
             if sample:
@@ -1052,7 +1053,7 @@ class Resource(ResourceConstants):
 
         for sample in TimeoutSampler(
             wait_timeout=timeout_watcher.remaining_time(),
-            sleep=1,
+            sleep=sleep_time,
             func=lambda: self.instance,
         ):
             if sample:


### PR DESCRIPTION
##### Short description:
Add sleep_time as argument. Resources like pipeline,pipeline runs need more time and polling in '1s' is not needed.
##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `wait_for_condition` method with configurable sleep interval between retry attempts.
	- Added optional `sleep_time` parameter to control wait duration during resource condition checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->