### PR TITLE
Update DataImportCron required fields from pull_method

### DIFF
--- a/ocp_resources/data_import_cron.py
+++ b/ocp_resources/data_import_cron.py
@@ -59,8 +59,8 @@ class DataImportCron(NamespacedResource):
             if self.image_stream and self.url:
                 raise ValueError("imageStream and url cannot coexist")
 
-            if not self.pull_method:
-                raise MissingRequiredArgumentError(argument="pull_method")
+            if not (self.schedule and self.managed_data_source):
+                raise MissingRequiredArgumentError(argument="'schedule' and 'managedDataSource'")
 
             self.res.update({
                 "spec": {


### PR DESCRIPTION
##### Short description:
Change the object required fields from `pull_method` to `schedule and managedDataSource`

##### More details:
The DataImportCron resource definition says that the required fields are `schedule` and `managedDataSource`, the pull_method is not required.

##### What this PR does / why we need it:
Fix the resource required fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for data import cron job configuration.
  - Updated validation logic to require both schedule and managed data source parameters.
  - Enhanced error messaging for missing required arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->