### PR TITLE
Reduce DataVolume wait_deleted timeout to 1 minute

### DIFF
--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -202,7 +202,7 @@ class DataVolume(NamespacedResource):
                     f"{self.api_group}/storage.deleteAfterCompletion": (self.delete_after_completion)
                 })
 
-    def wait_deleted(self, timeout=TIMEOUT_4MINUTES):
+    def wait_deleted(self, timeout=TIMEOUT_1MINUTE):
         """
         Wait until DataVolume and the PVC created by it are deleted
 


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Reduced timeout periods for DataVolume deletion and success waiting processes to improve responsiveness
	- Adjusted waiting times for PVC status checks to be more efficient

<!-- end of auto-generated comment: release notes by coderabbit.ai -->