### PR TITLE
Fix test regex for proxy error message

### DIFF
--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -128,6 +128,6 @@ class TestResource:
         with pytest.raises(
             ValueError,
             match="Conflicting proxy settings: client_configuration.proxy=http://not-env-proxy.com, "
-            "but the environment variable 'OPENSHIFT_PYTHON_WRAPPER_CLIENT_USE_PROXY' defines proxy as http://env-proxy.com.",
+            "but the environment variable 'HTTPS_PROXY/HTTP_PROXY' defines proxy as http://env-proxy.com.",
         ):
             get_client(client_configuration=client_configuration)


### PR DESCRIPTION
##### Short description:
Fix test regex for proxy error message
##### More details:
The test was failing due to an incorrect regex
pattern in the expected error message.
The regex has been updated to match the correct
proxy-related error message format.
This ensures the test properly validates conflicting proxy settings and prevents false failures.
##### What this PR does / why we need it:
The test needs this update due to a previous PR that changed the log message format:
#2305 
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**  
  - Improved the clarity of error messaging for proxy configuration conflicts by specifying the relevant proxy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->