### PR TITLE
Rename NETWORK_READY condition to NETWORK_CREATED

### DIFF
--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -68,18 +68,18 @@ class UserDefinedNetwork(NamespacedResource):
 
     # End of generated code
 
-    def wait_for_network_ready(self, timeout: int = 30) -> None:
+    def wait_for_network_created(self, timeout: int = 30) -> None:
         """
-        Wait for the network to be ready.
+        Wait for the network to be created.
 
         Args:
             timeout (int, optional): Maximum time to wait in seconds. Defaults to 30.
 
         Raises:
-            TimeoutExpiredError: If the network is not ready within the specified timeout.
+            TimeoutExpiredError: If the network is not created within the specified timeout.
         """
         self.wait_for_condition(
-            condition=self.Condition.NETWORK_READY,
+            condition=self.Condition.NETWORK_CREATED,
             status=self.Condition.Status.TRUE,
             timeout=timeout,
         )

--- a/ocp_resources/utils/resource_constants.py
+++ b/ocp_resources/utils/resource_constants.py
@@ -27,7 +27,7 @@ class ResourceConstants:
         RECONCILE_COMPLETE: str = "ReconcileComplete"
         READY: str = "Ready"
         FAILING: str = "Failing"
-        NETWORK_READY: str = "NetworkReady"
+        NETWORK_CREATED: str = "NetworkCreated"
         ARCHIVED: str = "Archived"
         CANCELED: str = "Canceled"
 


### PR DESCRIPTION
##### Short description:
Rename NETWORK_READY condition to NETWORK_CREATED
##### More details:
The condition NETWORK_READY is now NETWORK_CREATED to align with upstream changes in:
ovn-kubernetes PR[ #4884](https://github.com/ovn-kubernetes/ovn-kubernetes/pull/4884).

The method wait_for_network_ready is also renamed
to wait_for_network_created for clarity.

This ensures consistency with ovn-kubernetes and
avoids ambiguity in network status handling.
##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Refined the network initialization process to ensure that status messages and error feedback more accurately reflect the network creation phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->