### PR TITLE
fix: Avoid race when removing interfaces via NNCP

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -58,6 +58,7 @@ fcn_exclude_functions =
     click,
     ast,
     filecmp,
+    datetime,
 
 enable-extensions =
     FCN,

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -333,7 +333,7 @@ class NodeNetworkConfigurationPolicy(Resource):
         if initial_success_status_time:
             self._wait_for_nncp_status_update(initial_transition_time=initial_success_status_time)
 
-    def _get_last_successful_transition_time(self) -> str:
+    def _get_last_successful_transition_time(self) -> str | None:
         for condition in self.instance.status.conditions:
             if (
                 condition["type"] == self.Conditions.Type.AVAILABLE
@@ -341,6 +341,7 @@ class NodeNetworkConfigurationPolicy(Resource):
                 and condition["reason"] == self.Conditions.Reason.SUCCESSFULLY_CONFIGURED
             ):
                 return condition["lastTransitionTime"]
+        return None
 
     @retry(
         wait_timeout=TIMEOUT_1MINUTE,
@@ -355,6 +356,7 @@ class NodeNetworkConfigurationPolicy(Resource):
                 and datetime.strptime(condition["lastTransitionTime"], date_format) > formatted_initial_transition_time
             ):
                 return True
+        return False
 
     @property
     def status(self):

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -464,12 +464,13 @@ class NodeNetworkConfigurationPolicy(Resource):
     )
     def _wait_for_nncp_with_different_transition_time(self, initial_transition_time):
         date_format = "%Y-%m-%dT%H:%M:%SZ"
+        formatted_initial_transition_time = datetime.strptime(initial_transition_time, date_format)
         for condition in self.instance.get("status", {}).get("conditions", []):
             if (
                 condition
                 and condition["type"] == NodeNetworkConfigurationPolicy.Conditions.Type.AVAILABLE
                 and datetime.strptime(condition["lastTransitionTime"], date_format)
-                > datetime.strptime(initial_transition_time, date_format)
+                > formatted_initial_transition_time
             ):
                 return True
         return False

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -323,15 +323,14 @@ class NodeNetworkConfigurationPolicy(Resource):
         if self.ports:
             self.add_ports()
 
-        # The time-stamp that is returned by _get_last_successful_transition_time() will change after the call to
-        # update(), therefore it must be fetched and stored before, and compared with the new time-stamp after.
+        # The current time-stamp of the NNCP's available status will change after the NNCP is updated, therefore
+        # it must be fetched and stored before the update, and compared with the new time-stamp after.
         initial_success_status_time = self._get_last_successful_transition_time()
         ResourceEditor(
             patches={self: {"spec": {"desiredState": {"interfaces": self.desired_state["interfaces"]}}}}
         ).update()
 
-        # If the NNCP failed on setup, then at this point it's not in AVAILABLE status, so the next time it will be in
-        # AVAILABLE status will necessarily be the updated one.
+        # If the NNCP failed on setup, then its tear-down AVAIALBLE status will necessarily be the first.
         if initial_success_status_time:
             self._wait_for_nncp_status_update(initial_transition_time=initial_success_status_time)
 

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -323,8 +323,8 @@ class NodeNetworkConfigurationPolicy(Resource):
         if self.ports:
             self.add_ports()
 
-        # The time-stamp that is returned by _get_last_successful_transition_time() will chnage after the call to
-        # update(), therefore it must be fetched and stored before, and comapred with the new time-stamp after.
+        # The time-stamp that is returned by _get_last_successful_transition_time() will change after the call to
+        # update(), therefore it must be fetched and stored before, and compared with the new time-stamp after.
         initial_success_status_time = self._get_last_successful_transition_time()
         ResourceEditor(
             patches={self: {"spec": {"desiredState": {"interfaces": self.desired_state["interfaces"]}}}}
@@ -355,6 +355,7 @@ class NodeNetworkConfigurationPolicy(Resource):
         for condition in self.instance.get("status", {}).get("conditions", []):
             if (
                 condition["type"] == self.Conditions.Type.AVAILABLE
+                and condition["status"] == Resource.Condition.Status.TRUE
                 and datetime.strptime(condition["lastTransitionTime"], date_format) > formatted_initial_transition_time
             ):
                 return True

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -323,6 +323,8 @@ class NodeNetworkConfigurationPolicy(Resource):
         if self.ports:
             self.add_ports()
 
+        # The time-stamp that is returned by _get_last_successful_transition_time() will chnage after the call to
+        # update(), therefore it must be fetched and stored before, and comapred with the new time-stamp after.
         initial_success_status_time = self._get_last_successful_transition_time()
         ResourceEditor(
             patches={self: {"spec": {"desiredState": {"interfaces": self.desired_state["interfaces"]}}}}

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -323,13 +323,10 @@ class NodeNetworkConfigurationPolicy(Resource):
         if self.ports:
             self.add_ports()
 
+        initial_transition_time = self._get_nncp_configured_last_transition_time()
         ResourceEditor(
             patches={self: {"spec": {"desiredState": {"interfaces": self.desired_state["interfaces"]}}}}
         ).update()
-
-    def update(self, resource_dict=None):
-        initial_transition_time = self._get_nncp_configured_last_transition_time()
-        super().update(resource_dict=resource_dict)
 
         # If the setup NNCP failed - we don't need to verify its teardown status time is updated.
         if initial_transition_time:


### PR DESCRIPTION
Remoivng an interface that was created using an NNCP, is done by editing the same NNCP. This sometimes resulted in a race, in which the NNCP success status actually presented the prvious status, leading to deleting the NNCP before the configuration was completed, leaving hanging interfaces in the cluster nodes, with node native interfaces occupied as the ports of these tests-created interfaces. A recent PR made this failed flow to always occur. This PR aims to assure that the timestamp of the AVAIALBLE status is updated for the recent change (the interface removal) and not the previous change (setup or modification).
This PR is based on the fix that was presented in
https://github.com/RedHatQE/openshift-virtualization-tests/pull/430.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved network configuration updates now include an added verification step that ensures changes are fully applied, enhancing reliability during updates.
- **Chores**
	- Updated Flake8 configuration to exclude the `datetime` function from certain checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->