### PR TITLE
fix: escape docstring with `r` for generated resources using class-generator

### DIFF
--- a/class_generator/manifests/class_generator_template.j2
+++ b/class_generator/manifests/class_generator_template.j2
@@ -30,7 +30,7 @@ class {{ kind }}({{ base_class }}):
         **kwargs: Any,
     ) -> None:
         {% if all_types_for_class_args %}
-        """
+        r"""
         Args:
             {% for value in all_names_types_for_docstring %}
             {{ value }}

--- a/class_generator/tests/manifests/APIServer/api_server.py
+++ b/class_generator/tests/manifests/APIServer/api_server.py
@@ -27,7 +27,7 @@ class APIServer(Resource):
         tls_security_profile: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             additional_cors_allowed_origins (list[Any]): additionalCORSAllowedOrigins lists additional, user-defined regular
               expressions describing hosts for which the API server allows

--- a/class_generator/tests/manifests/ConfigMap/config_map.py
+++ b/class_generator/tests/manifests/ConfigMap/config_map.py
@@ -20,7 +20,7 @@ class ConfigMap(NamespacedResource):
         immutable: bool | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             binary_data (dict[str, Any]): BinaryData contains the binary data. Each key must consist of
               alphanumeric characters, '-', '_' or '.'. BinaryData can contain

--- a/class_generator/tests/manifests/DNS/dns_config_openshift_io.py
+++ b/class_generator/tests/manifests/DNS/dns_config_openshift_io.py
@@ -23,7 +23,7 @@ class DNS(Resource):
         public_zone: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             base_domain (str): baseDomain is the base domain of the cluster. All managed DNS records
               will be sub-domains of this base.  For example, given the base

--- a/class_generator/tests/manifests/DNS/dns_operator_openshift_io.py
+++ b/class_generator/tests/manifests/DNS/dns_operator_openshift_io.py
@@ -27,7 +27,7 @@ class DNS(Resource):
         upstream_resolvers: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             cache (dict[str, Any]): cache describes the caching configuration that applies to all server
               blocks listed in the Corefile. This field allows a cluster admin

--- a/class_generator/tests/manifests/Deployment/deployment.py
+++ b/class_generator/tests/manifests/Deployment/deployment.py
@@ -25,7 +25,7 @@ class Deployment(NamespacedResource):
         template: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             min_ready_seconds (int): Minimum number of seconds for which a newly created pod should be
               ready without any of its container crashing, for it to be

--- a/class_generator/tests/manifests/Image/image_config_openshift_io.py
+++ b/class_generator/tests/manifests/Image/image_config_openshift_io.py
@@ -28,7 +28,7 @@ class Image(Resource):
         registry_sources: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             additional_trusted_ca (dict[str, Any]): additionalTrustedCA is a reference to a ConfigMap containing
               additional CAs that should be trusted during imagestream import,

--- a/class_generator/tests/manifests/Image/image_image_openshift_io.py
+++ b/class_generator/tests/manifests/Image/image_image_openshift_io.py
@@ -29,7 +29,7 @@ class Image(Resource):
         signatures: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             docker_image_config (str): DockerImageConfig is a JSON blob that the runtime uses to set up the
               container. This is a part of manifest schema v2. Will not be set

--- a/class_generator/tests/manifests/ImageContentSourcePolicy/image_content_source_policy.py
+++ b/class_generator/tests/manifests/ImageContentSourcePolicy/image_content_source_policy.py
@@ -21,7 +21,7 @@ class ImageContentSourcePolicy(Resource):
         repository_digest_mirrors: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             repository_digest_mirrors (list[Any]): repositoryDigestMirrors allows images referenced by image digests in
               pods to be pulled from alternative mirrored repository locations.

--- a/class_generator/tests/manifests/Machine/machine.py
+++ b/class_generator/tests/manifests/Machine/machine.py
@@ -23,7 +23,7 @@ class Machine(NamespacedResource):
         taints: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             lifecycle_hooks (dict[str, Any]): LifecycleHooks allow users to pause operations on the machine at
               certain predefined points within the machine lifecycle.

--- a/class_generator/tests/manifests/NMState/nm_state.py
+++ b/class_generator/tests/manifests/NMState/nm_state.py
@@ -24,7 +24,7 @@ class NMState(Resource):
         tolerations: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             affinity (dict[str, Any]): Affinity is an optional affinity selector that will be added to
               handler DaemonSet manifest.

--- a/class_generator/tests/manifests/OAuth/oauth.py
+++ b/class_generator/tests/manifests/OAuth/oauth.py
@@ -24,7 +24,7 @@ class OAuth(Resource):
         token_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             identity_providers (list[Any]): identityProviders is an ordered list of ways for a user to identify
               themselves. When this list is empty, no identities are provisioned

--- a/class_generator/tests/manifests/Pod/pod.py
+++ b/class_generator/tests/manifests/Pod/pod.py
@@ -56,7 +56,7 @@ class Pod(NamespacedResource):
         volumes: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             active_deadline_seconds (int): Optional duration in seconds the pod may be active on the node
               relative to StartTime before the system will actively try to mark

--- a/class_generator/tests/manifests/Secret/secret.py
+++ b/class_generator/tests/manifests/Secret/secret.py
@@ -21,7 +21,7 @@ class Secret(NamespacedResource):
         type: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             data (dict[str, Any]): Data contains the secret data. Each key must consist of alphanumeric
               characters, '-', '_' or '.'. The serialized form of the secret

--- a/class_generator/tests/manifests/ServiceMeshMember/service_mesh_member.py
+++ b/class_generator/tests/manifests/ServiceMeshMember/service_mesh_member.py
@@ -18,7 +18,7 @@ class ServiceMeshMember(NamespacedResource):
         control_plane_ref: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             control_plane_ref (dict[str, Any]): No field description from API; please add description
 

--- a/class_generator/tests/manifests/ServingRuntime/serving_runtime.py
+++ b/class_generator/tests/manifests/ServingRuntime/serving_runtime.py
@@ -35,7 +35,7 @@ class ServingRuntime(NamespacedResource):
         volumes: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             affinity (dict[str, Any]): No field description from API; please add description
 

--- a/ocp_resources/pod.py
+++ b/ocp_resources/pod.py
@@ -1,16 +1,13 @@
 # Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
 
+from __future__ import annotations
 import json
-
-from typing import Any, Dict, List, Optional
-
+from typing import Any, Dict, List
 import kubernetes
 from timeout_sampler import TimeoutWatch
-
 from ocp_resources.utils.constants import TIMEOUT_5SEC
 from ocp_resources.exceptions import ExecOnPodError
 from ocp_resources.node import Node
-
 from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentError
 
 
@@ -23,64 +20,64 @@ class Pod(NamespacedResource):
 
     def __init__(
         self,
-        active_deadline_seconds: Optional[int] = None,
-        affinity: Optional[Dict[str, Any]] = None,
-        automount_service_account_token: Optional[bool] = None,
-        containers: Optional[List[Any]] = None,
-        dns_config: Optional[Dict[str, Any]] = None,
-        dns_policy: Optional[str] = "",
-        enable_service_links: Optional[bool] = None,
-        ephemeral_containers: Optional[List[Any]] = None,
-        host_aliases: Optional[List[Any]] = None,
-        host_ipc: Optional[bool] = None,
-        host_network: Optional[bool] = None,
-        host_pid: Optional[bool] = None,
-        host_users: Optional[bool] = None,
-        hostname: Optional[str] = "",
-        image_pull_secrets: Optional[List[Any]] = None,
-        init_containers: Optional[List[Any]] = None,
-        node_name: Optional[str] = "",
-        node_selector: Optional[Dict[str, Any]] = None,
-        os: Optional[Dict[str, Any]] = None,
-        overhead: Optional[Dict[str, Any]] = None,
-        preemption_policy: Optional[str] = "",
-        priority: Optional[int] = None,
-        priority_class_name: Optional[str] = "",
-        readiness_gates: Optional[List[Any]] = None,
-        resource_claims: Optional[List[Any]] = None,
-        restart_policy: Optional[str] = "",
-        runtime_class_name: Optional[str] = "",
-        scheduler_name: Optional[str] = "",
-        scheduling_gates: Optional[List[Any]] = None,
-        security_context: Optional[Dict[str, Any]] = None,
-        service_account: Optional[str] = "",
-        service_account_name: Optional[str] = "",
-        set_hostname_as_fqdn: Optional[bool] = None,
-        share_process_namespace: Optional[bool] = None,
-        subdomain: Optional[str] = "",
-        termination_grace_period_seconds: Optional[int] = None,
-        tolerations: Optional[List[Any]] = None,
-        topology_spread_constraints: Optional[List[Any]] = None,
-        volumes: Optional[List[Any]] = None,
+        active_deadline_seconds: int | None = None,
+        affinity: dict[str, Any] | None = None,
+        automount_service_account_token: bool | None = None,
+        containers: list[Any] | None = None,
+        dns_config: dict[str, Any] | None = None,
+        dns_policy: str | None = None,
+        enable_service_links: bool | None = None,
+        ephemeral_containers: list[Any] | None = None,
+        host_aliases: list[Any] | None = None,
+        host_ipc: bool | None = None,
+        host_network: bool | None = None,
+        host_pid: bool | None = None,
+        host_users: bool | None = None,
+        hostname: str | None = None,
+        image_pull_secrets: list[Any] | None = None,
+        init_containers: list[Any] | None = None,
+        node_name: str | None = None,
+        node_selector: dict[str, Any] | None = None,
+        os: dict[str, Any] | None = None,
+        overhead: dict[str, Any] | None = None,
+        preemption_policy: str | None = None,
+        priority: int | None = None,
+        priority_class_name: str | None = None,
+        readiness_gates: list[Any] | None = None,
+        resource_claims: list[Any] | None = None,
+        restart_policy: str | None = None,
+        runtime_class_name: str | None = None,
+        scheduler_name: str | None = None,
+        scheduling_gates: list[Any] | None = None,
+        security_context: dict[str, Any] | None = None,
+        service_account: str | None = None,
+        service_account_name: str | None = None,
+        set_hostname_as_fqdn: bool | None = None,
+        share_process_namespace: bool | None = None,
+        subdomain: str | None = None,
+        termination_grace_period_seconds: int | None = None,
+        tolerations: list[Any] | None = None,
+        topology_spread_constraints: list[Any] | None = None,
+        volumes: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             active_deadline_seconds (int): Optional duration in seconds the pod may be active on the node
               relative to StartTime before the system will actively try to mark
               it failed and kill associated containers. Value must be a positive
               integer.
 
-            affinity (Dict[str, Any]): Affinity is a group of affinity scheduling rules.
+            affinity (dict[str, Any]): Affinity is a group of affinity scheduling rules.
 
             automount_service_account_token (bool): AutomountServiceAccountToken indicates whether a service account token
               should be automatically mounted.
 
-            containers (List[Any]): List of containers belonging to the pod. Containers cannot currently
+            containers (list[Any]): List of containers belonging to the pod. Containers cannot currently
               be added or removed. There must be at least one container in a
               Pod. Cannot be updated.
 
-            dns_config (Dict[str, Any]): PodDNSConfig defines the DNS parameters of a pod in addition to those
+            dns_config (dict[str, Any]): PodDNSConfig defines the DNS parameters of a pod in addition to those
               generated from DNSPolicy.
 
             dns_policy (str): Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values
@@ -104,14 +101,14 @@ class Pod(NamespacedResource):
               be injected into pod's environment variables, matching the syntax
               of Docker links. Optional: Defaults to true.
 
-            ephemeral_containers (List[Any]): List of ephemeral containers run in this pod. Ephemeral containers may
+            ephemeral_containers (list[Any]): List of ephemeral containers run in this pod. Ephemeral containers may
               be run in an existing pod to perform user-initiated actions such
               as debugging. This list cannot be specified when creating a pod,
               and it cannot be modified by updating the pod spec. In order to
               add an ephemeral container to an existing pod, use the pod's
               ephemeralcontainers subresource.
 
-            host_aliases (List[Any]): HostAliases is an optional list of hosts and IPs that will be injected
+            host_aliases (list[Any]): HostAliases is an optional list of hosts and IPs that will be injected
               into the pod's hosts file if specified.
 
             host_ipc (bool): Use the host's ipc namespace. Optional: Default to false.
@@ -136,14 +133,14 @@ class Pod(NamespacedResource):
             hostname (str): Specifies the hostname of the Pod If not specified, the pod's hostname
               will be set to a system-defined value.
 
-            image_pull_secrets (List[Any]): ImagePullSecrets is an optional list of references to secrets in the
+            image_pull_secrets (list[Any]): ImagePullSecrets is an optional list of references to secrets in the
               same namespace to use for pulling any of the images used by this
               PodSpec. If specified, these secrets will be passed to individual
               puller implementations for them to use. More info:
               https://kubernetes.io/docs/concepts/containers/images#specifying-
               imagepullsecrets-on-a-pod
 
-            init_containers (List[Any]): List of initialization containers belonging to the pod. Init
+            init_containers (list[Any]): List of initialization containers belonging to the pod. Init
               containers are executed in order prior to containers being
               started. If any init container fails, the pod is considered to
               have failed and is handled according to its restartPolicy. The
@@ -159,18 +156,23 @@ class Pod(NamespacedResource):
               https://kubernetes.io/docs/concepts/workloads/pods/init-
               containers/
 
-            node_name (str): NodeName is a request to schedule this pod onto a specific node. If it
-              is non-empty, the scheduler simply schedules this pod onto that
-              node, assuming that it fits resource requirements.
+            node_name (str): NodeName indicates in which node this pod is scheduled. If empty, this
+              pod is a candidate for scheduling by the scheduler defined in
+              schedulerName. Once this field is set, the kubelet for this node
+              becomes responsible for the lifecycle of this pod. This field
+              should not be used to express a desire for the pod to be scheduled
+              on a specific node.
+              https://kubernetes.io/docs/concepts/scheduling-eviction/assign-
+              pod-node/#nodename
 
-            node_selector (Dict[str, Any]): NodeSelector is a selector which must be true for the pod to fit on a
+            node_selector (dict[str, Any]): NodeSelector is a selector which must be true for the pod to fit on a
               node. Selector which must match a node's labels for the pod to be
               scheduled on that node. More info:
               https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
 
-            os (Dict[str, Any]): PodOS defines the OS parameters of a pod.
+            os (dict[str, Any]): PodOS defines the OS parameters of a pod.
 
-            overhead (Dict[str, Any]): Overhead represents the resource overhead associated with running a
+            overhead (dict[str, Any]): Overhead represents the resource overhead associated with running a
               pod for a given RuntimeClass. This field will be autopopulated at
               admission time by the RuntimeClass admission controller. If the
               RuntimeClass admission controller is enabled, overhead must not be
@@ -202,13 +204,13 @@ class Pod(NamespacedResource):
               with that name. If not specified, the pod priority will be default
               or zero if there is no default.
 
-            readiness_gates (List[Any]): If specified, all readiness gates will be evaluated for pod readiness.
+            readiness_gates (list[Any]): If specified, all readiness gates will be evaluated for pod readiness.
               A pod is ready when all its containers are ready AND all
               conditions specified in the readiness gates have status equal to
               "True" More info: https://git.k8s.io/enhancements/keps/sig-
               network/580-pod-readiness-gates
 
-            resource_claims (List[Any]): ResourceClaims defines which ResourceClaims must be allocated and
+            resource_claims (list[Any]): ResourceClaims defines which ResourceClaims must be allocated and
               reserved before the Pod is allowed to start. The resources will be
               made available to those containers which consume them by name.
               This is an alpha field and requires enabling the
@@ -232,13 +234,13 @@ class Pod(NamespacedResource):
             scheduler_name (str): If specified, the pod will be dispatched by specified scheduler. If
               not specified, the pod will be dispatched by default scheduler.
 
-            scheduling_gates (List[Any]): SchedulingGates is an opaque list of values that if specified will
+            scheduling_gates (list[Any]): SchedulingGates is an opaque list of values that if specified will
               block scheduling the pod. If schedulingGates is not empty, the pod
               will stay in the SchedulingGated state and the scheduler will not
               attempt to schedule the pod.  SchedulingGates can only be set at
               pod creation time, and be removed only afterwards.
 
-            security_context (Dict[str, Any]): PodSecurityContext holds pod-level security attributes and common
+            security_context (dict[str, Any]): PodSecurityContext holds pod-level security attributes and common
               container settings. Some fields are also present in
               container.securityContext.  Field values of
               container.securityContext take precedence over field values of
@@ -281,14 +283,14 @@ class Pod(NamespacedResource):
               forcibly halted with a kill signal. Set this value longer than the
               expected cleanup time for your process. Defaults to 30 seconds.
 
-            tolerations (List[Any]): If specified, the pod's tolerations.
+            tolerations (list[Any]): If specified, the pod's tolerations.
 
-            topology_spread_constraints (List[Any]): TopologySpreadConstraints describes how a group of pods ought to
+            topology_spread_constraints (list[Any]): TopologySpreadConstraints describes how a group of pods ought to
               spread across topology domains. Scheduler will schedule pods in a
               way which abides by the constraints. All topologySpreadConstraints
               are ANDed.
 
-            volumes (List[Any]): List of volumes that can be mounted by containers belonging to the
+            volumes (list[Any]): List of volumes that can be mounted by containers belonging to the
               pod. More info:
               https://kubernetes.io/docs/concepts/storage/volumes
 
@@ -339,7 +341,7 @@ class Pod(NamespacedResource):
         super().to_dict()
 
         if not self.kind_dict and not self.yaml_file:
-            if not self.containers:
+            if self.containers is None:
                 raise MissingRequiredArgumentError(argument="self.containers")
 
             self.res["spec"] = {}
@@ -347,28 +349,28 @@ class Pod(NamespacedResource):
 
             _spec["containers"] = self.containers
 
-            if self.active_deadline_seconds:
+            if self.active_deadline_seconds is not None:
                 _spec["activeDeadlineSeconds"] = self.active_deadline_seconds
 
-            if self.affinity:
+            if self.affinity is not None:
                 _spec["affinity"] = self.affinity
 
             if self.automount_service_account_token is not None:
                 _spec["automountServiceAccountToken"] = self.automount_service_account_token
 
-            if self.dns_config:
+            if self.dns_config is not None:
                 _spec["dnsConfig"] = self.dns_config
 
-            if self.dns_policy:
+            if self.dns_policy is not None:
                 _spec["dnsPolicy"] = self.dns_policy
 
             if self.enable_service_links is not None:
                 _spec["enableServiceLinks"] = self.enable_service_links
 
-            if self.ephemeral_containers:
+            if self.ephemeral_containers is not None:
                 _spec["ephemeralContainers"] = self.ephemeral_containers
 
-            if self.host_aliases:
+            if self.host_aliases is not None:
                 _spec["hostAliases"] = self.host_aliases
 
             if self.host_ipc is not None:
@@ -383,61 +385,61 @@ class Pod(NamespacedResource):
             if self.host_users is not None:
                 _spec["hostUsers"] = self.host_users
 
-            if self.hostname:
+            if self.hostname is not None:
                 _spec["hostname"] = self.hostname
 
-            if self.image_pull_secrets:
+            if self.image_pull_secrets is not None:
                 _spec["imagePullSecrets"] = self.image_pull_secrets
 
-            if self.init_containers:
+            if self.init_containers is not None:
                 _spec["initContainers"] = self.init_containers
 
-            if self.node_name:
+            if self.node_name is not None:
                 _spec["nodeName"] = self.node_name
 
-            if self.node_selector:
+            if self.node_selector is not None:
                 _spec["nodeSelector"] = self.node_selector
 
-            if self.os:
+            if self.os is not None:
                 _spec["os"] = self.os
 
-            if self.overhead:
+            if self.overhead is not None:
                 _spec["overhead"] = self.overhead
 
-            if self.preemption_policy:
+            if self.preemption_policy is not None:
                 _spec["preemptionPolicy"] = self.preemption_policy
 
-            if self.priority:
+            if self.priority is not None:
                 _spec["priority"] = self.priority
 
-            if self.priority_class_name:
+            if self.priority_class_name is not None:
                 _spec["priorityClassName"] = self.priority_class_name
 
-            if self.readiness_gates:
+            if self.readiness_gates is not None:
                 _spec["readinessGates"] = self.readiness_gates
 
-            if self.resource_claims:
+            if self.resource_claims is not None:
                 _spec["resourceClaims"] = self.resource_claims
 
-            if self.restart_policy:
+            if self.restart_policy is not None:
                 _spec["restartPolicy"] = self.restart_policy
 
-            if self.runtime_class_name:
+            if self.runtime_class_name is not None:
                 _spec["runtimeClassName"] = self.runtime_class_name
 
-            if self.scheduler_name:
+            if self.scheduler_name is not None:
                 _spec["schedulerName"] = self.scheduler_name
 
-            if self.scheduling_gates:
+            if self.scheduling_gates is not None:
                 _spec["schedulingGates"] = self.scheduling_gates
 
-            if self.security_context:
+            if self.security_context is not None:
                 _spec["securityContext"] = self.security_context
 
-            if self.service_account:
+            if self.service_account is not None:
                 _spec["serviceAccount"] = self.service_account
 
-            if self.service_account_name:
+            if self.service_account_name is not None:
                 _spec["serviceAccountName"] = self.service_account_name
 
             if self.set_hostname_as_fqdn is not None:
@@ -446,19 +448,19 @@ class Pod(NamespacedResource):
             if self.share_process_namespace is not None:
                 _spec["shareProcessNamespace"] = self.share_process_namespace
 
-            if self.subdomain:
+            if self.subdomain is not None:
                 _spec["subdomain"] = self.subdomain
 
-            if self.termination_grace_period_seconds:
+            if self.termination_grace_period_seconds is not None:
                 _spec["terminationGracePeriodSeconds"] = self.termination_grace_period_seconds
 
-            if self.tolerations:
+            if self.tolerations is not None:
                 _spec["tolerations"] = self.tolerations
 
-            if self.topology_spread_constraints:
+            if self.topology_spread_constraints is not None:
                 _spec["topologySpreadConstraints"] = self.topology_spread_constraints
 
-            if self.volumes:
+            if self.volumes is not None:
                 _spec["volumes"] = self.volumes
 
     # End of generated code

--- a/ocp_resources/pod.py
+++ b/ocp_resources/pod.py
@@ -1,14 +1,17 @@
 # Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
 
 from __future__ import annotations
+
 import json
-from typing import Any, Dict, List
+from typing import Any
+
 import kubernetes
 from timeout_sampler import TimeoutWatch
-from ocp_resources.utils.constants import TIMEOUT_5SEC
+
 from ocp_resources.exceptions import ExecOnPodError
 from ocp_resources.node import Node
-from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentError
+from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource
+from ocp_resources.utils.constants import TIMEOUT_5SEC
 
 
 class Pod(NamespacedResource):
@@ -465,7 +468,7 @@ class Pod(NamespacedResource):
 
     # End of generated code
 
-    def execute(self, command: List[str], timeout: int = 60, container: str = "", ignore_rc: bool = False) -> str:
+    def execute(self, command: list[str], timeout: int = 60, container: str = "", ignore_rc: bool = False) -> str:
         """
         Run command on Pod
 
@@ -481,7 +484,7 @@ class Pod(NamespacedResource):
         Raises:
             ExecOnPodError: If the command failed.
         """
-        error_channel: Dict[Any, Any] = {}
+        error_channel: dict[Any, Any] = {}
         stream_closed_error: str = "stream resp is closed"
         self.logger.info(f"Execute {command} on {self.name} ({self.node.name})")
         resp = kubernetes.stream.stream(


### PR DESCRIPTION
This fix warnings like:
`SyntaxWarning: invalid escape sequence '\S'` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Converted documentation strings in various components to raw string literals to ensure special characters are handled correctly.
  - Updated type annotations and parameter checks to improve consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->