### PR TITLE
fix: Do not set signal when not in main thread

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import sys
+import threading
 from collections.abc import Callable, Generator
 from io import StringIO
 from signal import SIGINT, signal
@@ -582,7 +583,8 @@ class Resource(ResourceConstants):
         self._base_body()
 
     def __enter__(self) -> Any:
-        signal(SIGINT, self._sigint_handler)
+        if threading.current_thread().native_id == threading.main_thread().native_id:
+            signal(SIGINT, self._sigint_handler)
         return self.deploy(wait=self.wait_for_resource)
 
     def __exit__(


### PR DESCRIPTION
`Resource.__enter__` calls signal which
cannot be called when in a different
thread from main.

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event handling stability by ensuring that specific operations are executed exclusively in the main thread. This update prevents potential misbehavior during concurrent operations, enhancing overall system reliability and providing a smoother, more predictable experience for users during multi-threaded activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->