### PR TITLE
fix: class_generator: remove `please add description`

### DIFF
--- a/class_generator/class_generator.py
+++ b/class_generator/class_generator.py
@@ -34,7 +34,7 @@ LOGGER = get_logger(name="class_generator")
 TESTS_MANIFESTS_DIR: str = "class_generator/tests/manifests"
 SCHEMA_DIR: str = "class_generator/schema"
 RESOURCES_MAPPING_FILE: str = os.path.join(SCHEMA_DIR, "__resources-mappings.json")
-MISSING_DESCRIPTION_STR: str = "No field description from API; please add description"
+MISSING_DESCRIPTION_STR: str = "No field description from API"
 
 
 def _is_kind_and_namespaced(

--- a/class_generator/tests/manifests/Pipeline/pipeline.py
+++ b/class_generator/tests/manifests/Pipeline/pipeline.py
@@ -8,7 +8,7 @@ from ocp_resources.resource import NamespacedResource
 
 class Pipeline(NamespacedResource):
     """
-    No field description from API; please add description
+    No field description from API
     """
 
     api_group: str = NamespacedResource.ApiGroup.TEKTON_DEV

--- a/class_generator/tests/manifests/ServiceMeshMember/service_mesh_member.py
+++ b/class_generator/tests/manifests/ServiceMeshMember/service_mesh_member.py
@@ -8,7 +8,7 @@ from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentEr
 
 class ServiceMeshMember(NamespacedResource):
     """
-    No field description from API; please add description
+    No field description from API
     """
 
     api_group: str = NamespacedResource.ApiGroup.MAISTRA_IO
@@ -20,7 +20,7 @@ class ServiceMeshMember(NamespacedResource):
     ) -> None:
         r"""
         Args:
-            control_plane_ref (dict[str, Any]): No field description from API; please add description
+            control_plane_ref (dict[str, Any]): No field description from API
 
         """
         super().__init__(**kwargs)

--- a/class_generator/tests/manifests/ServingRuntime/serving_runtime.py
+++ b/class_generator/tests/manifests/ServingRuntime/serving_runtime.py
@@ -8,7 +8,7 @@ from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentEr
 
 class ServingRuntime(NamespacedResource):
     """
-    No field description from API; please add description
+    No field description from API
     """
 
     api_group: str = NamespacedResource.ApiGroup.SERVING_KSERVE_IO
@@ -37,41 +37,41 @@ class ServingRuntime(NamespacedResource):
     ) -> None:
         r"""
         Args:
-            affinity (dict[str, Any]): No field description from API; please add description
+            affinity (dict[str, Any]): No field description from API
 
-            spec_annotations (dict[str, Any]): No field description from API; please add description
+            spec_annotations (dict[str, Any]): No field description from API
 
-            built_in_adapter (dict[str, Any]): No field description from API; please add description
+            built_in_adapter (dict[str, Any]): No field description from API
 
-            containers (list[Any]): No field description from API; please add description
+            containers (list[Any]): No field description from API
 
-            disabled (bool): No field description from API; please add description
+            disabled (bool): No field description from API
 
-            grpc_data_endpoint (str): No field description from API; please add description
+            grpc_data_endpoint (str): No field description from API
 
-            grpc_endpoint (str): No field description from API; please add description
+            grpc_endpoint (str): No field description from API
 
-            http_data_endpoint (str): No field description from API; please add description
+            http_data_endpoint (str): No field description from API
 
-            image_pull_secrets (list[Any]): No field description from API; please add description
+            image_pull_secrets (list[Any]): No field description from API
 
-            spec_labels (dict[str, Any]): No field description from API; please add description
+            spec_labels (dict[str, Any]): No field description from API
 
-            multi_model (bool): No field description from API; please add description
+            multi_model (bool): No field description from API
 
-            node_selector (dict[str, Any]): No field description from API; please add description
+            node_selector (dict[str, Any]): No field description from API
 
-            protocol_versions (list[Any]): No field description from API; please add description
+            protocol_versions (list[Any]): No field description from API
 
-            replicas (int): No field description from API; please add description
+            replicas (int): No field description from API
 
-            storage_helper (dict[str, Any]): No field description from API; please add description
+            storage_helper (dict[str, Any]): No field description from API
 
-            supported_model_formats (list[Any]): No field description from API; please add description
+            supported_model_formats (list[Any]): No field description from API
 
-            tolerations (list[Any]): No field description from API; please add description
+            tolerations (list[Any]): No field description from API
 
-            volumes (list[Any]): No field description from API; please add description
+            volumes (list[Any]): No field description from API
 
         """
         super().__init__(**kwargs)


### PR DESCRIPTION
If no description for resource from the API we should leave it empty, we do not want the user to edit the resource manually.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Streamlined all user-facing messages for missing field descriptions by removing extraneous instructions. These concise messages now offer a cleaner, more consistent presentation across the application, enhancing clarity without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->