### PR TITLE
Add update method to handle consecutive updates safely

### DIFF
--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -12,6 +12,7 @@ from ocp_resources.node_network_configuration_enactment import (
 from ocp_resources.node_network_state import NodeNetworkState
 from ocp_resources.resource import Resource, ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, TimeoutWatch, retry
+from typing import Any
 
 IPV4_STR = "ipv4"
 IPV6_STR = "ipv6"
@@ -359,6 +360,12 @@ class NodeNetworkConfigurationPolicy(Resource):
             ):
                 return True
         return False
+
+    def update(self, resource_dict: dict[str, Any]) -> None:
+        initial_success_status_time = self._get_last_successful_transition_time()
+        super().update(resource_dict=resource_dict)
+        if resource_dict["spec"] and initial_success_status_time:
+            self._wait_for_nncp_status_update(initial_transition_time=initial_success_status_time)
 
     @property
     def status(self):

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -324,16 +324,9 @@ class NodeNetworkConfigurationPolicy(Resource):
         if self.ports:
             self.add_ports()
 
-        # The current time-stamp of the NNCP's available status will change after the NNCP is updated, therefore
-        # it must be fetched and stored before the update, and compared with the new time-stamp after.
-        initial_success_status_time = self._get_last_successful_transition_time()
         ResourceEditor(
             patches={self: {"spec": {"desiredState": {"interfaces": self.desired_state["interfaces"]}}}}
         ).update()
-
-        # If the NNCP failed on setup, then its tear-down AVAIALBLE status will necessarily be the first.
-        if initial_success_status_time:
-            self._wait_for_nncp_status_update(initial_transition_time=initial_success_status_time)
 
     def _get_last_successful_transition_time(self) -> str | None:
         for condition in self.instance.status.conditions:

--- a/ocp_resources/node_network_configuration_policy.py
+++ b/ocp_resources/node_network_configuration_policy.py
@@ -364,7 +364,7 @@ class NodeNetworkConfigurationPolicy(Resource):
     def update(self, resource_dict: dict[str, Any]) -> None:
         initial_success_status_time = self._get_last_successful_transition_time()
         super().update(resource_dict=resource_dict)
-        if resource_dict["spec"] and initial_success_status_time:
+        if resource_dict.get("spec") and initial_success_status_time:
             self._wait_for_nncp_status_update(initial_transition_time=initial_success_status_time)
 
     @property


### PR DESCRIPTION
##### Short description:
Add update method to handle consecutive updates safely
##### More details:
Add update method to handle consecutive updates safely
    
    Added an update method in NodeNetworkConfigurationPolicy to wait for
    NNCP status updates before applying changes. This prevents API failures
    caused by the admission webhook rejecting updates while NNCP is still
    in progress.
##### What this PR does / why we need it:
Example of failure:
```
failed on teardown with "kubernetes.dynamic.exceptions.ForbiddenError: 403
Reason: Forbidden
HTTP response headers: HTTPHeaderDict({'Audit-Id': 'f10ebbbc-01e8-456d-a1c5-e55298504ece', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': '559d612b-12c3-4f4d-9114-023ee53b8190', 'X-Kubernetes-Pf-Prioritylevel-Uid': '205f5378-334e-481f-94f3-6ad523816633', 'Date': 'Mon, 24 Mar 2025 09:41:26 GMT', 'Content-Length': '475'})
HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \\"nodenetworkconfigurationpolicies-update-validate.nmstate.io\\" denied the request: failed to admit NodeNetworkConfigurationPolicy dhcp-vlan-client-2-nncp: message: policy dhcp-vlan-client-2-nncp is still in progress. ","reason":"failed to admit NodeNetworkConfigurationPolicy dhcp-vlan-client-2-nncp: message: policy dhcp-vlan-client-2-nncp is still in progress. ","code":403}\n'
```
##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the network configuration update process with integrated status monitoring to ensure reliable and accurate policy updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->