### PR TITLE
fix: get_client() client_configuration

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -131,10 +131,11 @@ def get_client(
                 )
             client_configuration.proxy = proxy
 
+        kwargs["client_configuration"] = client_configuration
+
         return kubernetes.dynamic.DynamicClient(
             client=kubernetes.config.new_client_from_config(
                 config_file=config_file,
-                client_configuration=client_configuration,
                 context=context or None,
                 **kwargs,
             )


### PR DESCRIPTION
Support client_configuration provided via kwargs

Currently, without this change, providing `client_configuration` to `get_client()` will pass `client_configuration` twice to the lower level kubernetes functions. Once through `client_configuration=` and a second time through `kwargs`. This results in a `TypeError`.
eg:
```
TypeError: "func()" got multiple values for keyword argument 'client_configuration'
```

This fix ensures `client_configuration` is only passed through once.


##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the management of configuration parameters during client setup, allowing for more flexible handling of additional parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->