### PR TITLE
fix: Update virtual_machine.py example

### DIFF
--- a/examples/virtual_machine.py
+++ b/examples/virtual_machine.py
@@ -1,22 +1,35 @@
+from kubernetes import config
 from ocp_resources.virtual_machine import VirtualMachine
 
-# Create a VM
-with VirtualMachine(
+config.load_kube_config()
+
+# Define a VM
+vm = VirtualMachine(
     name="vm-example",
     namespace="namespace-example",
-    node_selector="worker-node-example",
-) as vm:
-    vm.start()
+    body={
+        "spec": {
+            "runStrategy": "Halted",
+            "template": {
+                "spec": {
+                    "domain": {
+                        "devices": {"disks": [{"name": "disk0", "disk": {"bus": "virtio"}}]},
+                        "resources": {"requests": {"memory": "64Mi"}},
+                    },
+                    "volumes": [
+                        {
+                            "name": "disk0",
+                            "containerDisk": {"image": "kubevirt/cirros-container-disk-demo"},
+                        }
+                    ],
+                },
+            },
+        }
+    },
+)
 
 # VM operations
+vm.create()
+vm.start()
+vm.vmi.wait_until_running(timeout=180)
 vm.stop()
-vm.restart()
-
-# Get VM VMI
-test_vmi = vm.vmi
-
-# After having a VMI, we can wait until VMI is in running state:
-test_vmi.wait_until_running()
-
-# Then, we can get the virt launcher Pod and execute a command on it:
-command_output = test_vmi.virt_launcher_pod.execute(command="command-example")


### PR DESCRIPTION

##### Short description:

The original example did not work. This patch replaces it with one that does, using the body attribute to provide a clear self-contained example.

##### More details:

##### What this PR does / why we need it:

Old example does not work, this one does.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a streamlined workflow for managing virtual machines in Kubernetes, featuring explicit steps for creation, startup, and readiness verification with a 180-second timeout.

- **Refactor**
  - Updated the virtual machine instantiation process for enhanced clarity and control, ensuring a more robust and predictable lifecycle management approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->