### PR TITLE
feat: add SelfSubjectReview resource

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -317,6 +317,7 @@ class Resource(ResourceConstants):
         APIREGISTRATION_K8S_IO: str = "apiregistration.k8s.io"
         APP_KUBERNETES_IO: str = "app.kubernetes.io"
         APPS: str = "apps"
+        AUTHENTICATION_K8S_IO: str = "authentication.k8s.io"
         BATCH: str = "batch"
         BITNAMI_COM: str = "bitnami.com"
         CACHING_INTERNAL_KNATIVE_DEV: str = "caching.internal.knative.dev"

--- a/ocp_resources/self_subject_review.py
+++ b/ocp_resources/self_subject_review.py
@@ -1,0 +1,22 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+from __future__ import annotations
+
+from typing import Any
+from ocp_resources.resource import Resource
+
+
+class SelfSubjectReview(Resource):
+    """
+    SelfSubjectReview contains the user information that the kube-apiserver has about the user making this request. When using impersonation, users will receive the user info of the user being impersonated.  If impersonation or request header authentication is used, any extra keys will have their case ignored and returned as lowercase.
+    """
+
+    api_group: str = Resource.ApiGroup.AUTHENTICATION_K8S_IO
+
+    def __init__(
+        self,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+
+    # End of generated code


### PR DESCRIPTION
##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced support for the Kubernetes "SelfSubjectReview" resource, enabling users to access information about their own identity as recognized by the cluster.
- **Chores**
  - Expanded the list of available Kubernetes API groups with the addition of the "authentication.k8s.io" group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->