### PR TITLE
feat: allow resource.get to accept Namespace instance instead

### DIFF
--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -38,3 +38,14 @@ class Namespace(Resource):
                 _spec["finalizers"] = self.finalizers
 
     # End of generated code
+
+    def __str__(self) -> str:
+        """Return human-readable string "name" rather than default __repr__.
+
+        Calling str, format or print on a Namespace object will result in it being resolved
+        to its name attribute if found else the repr will be returned.
+
+        Returns:
+            str: Human-readable string "name" or the output of __repr__.
+        """
+        return name if (name := getattr(self, "name", None)) else self.__repr__()

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -1368,7 +1368,7 @@ class NamespacedResource(Resource):
                         yield cls(
                             client=dyn_client,
                             name=resource_field.metadata.name,
-                            namespace=resource_field.metadata.namespace,
+                            namespace=str(resource_field.metadata.namespace),
                         )
             except TypeError:
                 if raw:
@@ -1377,7 +1377,7 @@ class NamespacedResource(Resource):
                     yield cls(
                         client=dyn_client,
                         name=_resources.metadata.name,
-                        namespace=_resources.metadata.namespace,
+                        namespace=str(_resources.metadata.namespace),
                     )
 
         return Resource.retry_cluster_exceptions(func=_get, exceptions_dict=exceptions_dict)


### PR DESCRIPTION

##### Short description:
This feature allows Namespace objects to be passed into the get function of NamespacedResources. Pod.get is an example which can directly accept a namespace avoiding confusion of where Namespace exists as a string.

##### More details:
It's annoying to juggle between namespaces as strings and namespace objects. If the Namespace is passed into a function such as Pod.get it results in the field resolving to __repr__ which is the default behavior. 

##### What this PR does / why we need it:
I think this fixes two things but the implementation is mostly a suggestion. 
- When str, format or print is called on a Namespace instance, it resolves to a human-readable string.
- When a namespace is passed into a getter function, the name is used rather than the repr.

##### Special notes for reviewer:
I'm quite new to the team so I hope you can give me more detailed guidance and steps to improve.
I really appreciate detailed, honest feedback!
