### PR TITLE
feat: Update GuardrailsOrchestrator resource

### DIFF
--- a/class_generator/class_generator.py
+++ b/class_generator/class_generator.py
@@ -204,9 +204,9 @@ def update_kind_schema():
     cluster_version = cluster_version.split("+")[0]
     ocp_openapi_json_file = Path(gettempdir()) / f"__k8s-openapi-{cluster_version}__.json"
 
-    newer_version: bool = Version(cluster_version) > Version(last_cluster_version_generated)
+    same_or_newer_version: bool = Version(cluster_version) >= Version(last_cluster_version_generated)
 
-    if newer_version:
+    if same_or_newer_version:
         with open(cluster_version_file, "w") as fd:
             fd.write(cluster_version)
 
@@ -219,7 +219,7 @@ def update_kind_schema():
         LOGGER.error("Failed to generate schema.")
         sys.exit(1)
 
-    if newer_version:
+    if same_or_newer_version:
         # copy all files from tmp_schema_dir to schema dir
         shutil.copytree(src=tmp_schema_dir, dst=SCHEMA_DIR, dirs_exist_ok=True)
 
@@ -236,7 +236,7 @@ def update_kind_schema():
                     sys.exit(1)
 
     map_kind_to_namespaced(
-        client=client, newer_cluster_version=newer_version, schema_definition_file=ocp_openapi_json_file
+        client=client, newer_cluster_version=same_or_newer_version, schema_definition_file=ocp_openapi_json_file
     )
 
 

--- a/class_generator/schema/__not-kind.txt
+++ b/class_generator/schema/__not-kind.txt
@@ -793,3 +793,4 @@ com.jhouse.cache.v1alpha1.NFSProvisionerList
 io.openshift.nfd.v1alpha1.NodeFeatureGroupList
 io.opendatahub.platform.components.v1alpha1.FeastOperatorList
 io.kuadrant.authorino.v1beta3.AuthConfigList
+dev.feast.v1alpha1.FeatureStoreList

--- a/class_generator/schema/account.json
+++ b/class_generator/schema/account.json
@@ -30,7 +30,42 @@
               "type": "string"
             },
             "fieldPath": {
-              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+              "type": "string"
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "modelListConfig": {
+          "description": "A reference to the ConfigMap containing the list of NIM models that are allowed to be deployed.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
               "type": "string"
             },
             "kind": {
@@ -65,7 +100,7 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -108,7 +143,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
@@ -125,7 +160,7 @@
               "type": "string"
             },
             "fieldPath": {
-              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
               "type": "string"
             },
             "kind": {
@@ -160,7 +195,7 @@
               "type": "string"
             },
             "fieldPath": {
-              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
               "type": "string"
             },
             "kind": {
@@ -195,7 +230,7 @@
               "type": "string"
             },
             "fieldPath": {
-              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.\nTODO: this design is not final and this field is subject to change in the future.",
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
               "type": "string"
             },
             "kind": {

--- a/class_generator/schema/admissioncheck.json
+++ b/class_generator/schema/admissioncheck.json
@@ -61,7 +61,7 @@
           }
         },
         "retryDelayMinutes": {
-          "description": "RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after\na failed check (after it transitioned to False). When the delay period has passed, the check\nstate goes to \"Unknown\". The default is 15 min.\nThe default is 15 min.",
+          "description": "RetryDelayMinutes specifies how long to keep the workload suspended after\na failed check (after it transitioned to False). When the delay period has passed, the check\nstate goes to \"Unknown\". The default is 15 min.\nDeprecated: retryDelayMinutes has already been deprecated since v0.8 and will be removed in v1beta2.",
           "type": "integer",
           "format": "int64"
         }
@@ -75,7 +75,7 @@
           "description": "conditions hold the latest available observations of the AdmissionCheck\ncurrent state.",
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -118,7 +118,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"

--- a/class_generator/schema/alertrelabelconfig.json
+++ b/class_generator/schema/alertrelabelconfig.json
@@ -184,7 +184,11 @@
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
               }
             }
-          }
+          },
+          "x-kubernetes-list-map-keys": [
+            "type"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }

--- a/class_generator/schema/all.json
+++ b/class_generator/schema/all.json
@@ -763,34 +763,142 @@
       "$ref": "_definitions.json#/definitions/com.github.operator-framework.operator-lifecycle-manager.pkg.package-server.apis.operators.v1.PackageManifestStatus"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.CephConnection"
+      "$ref": "_definitions.json#/definitions/dev.codeflare.workload.v1beta2.AppWrapper"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.CephConnectionList"
+      "$ref": "_definitions.json#/definitions/dev.codeflare.workload.v1beta2.AppWrapperList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.ClientProfile"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.autoscaling.v1alpha1.Metric"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.ClientProfileList"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.autoscaling.v1alpha1.MetricList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.ClientProfileMapping"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.autoscaling.v1alpha1.PodAutoscaler"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.ClientProfileMappingList"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.autoscaling.v1alpha1.PodAutoscalerList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.Driver"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.caching.v1alpha1.Image"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.DriverList"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.caching.v1alpha1.ImageList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.OperatorConfig"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.Certificate"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.ceph.csi.v1alpha1.OperatorConfigList"
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.CertificateList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.ClusterDomainClaim"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.ClusterDomainClaimList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.Ingress"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.IngressList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.ServerlessService"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.internal.networking.v1alpha1.ServerlessServiceList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.operator.v1beta1.KnativeEventing"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.operator.v1beta1.KnativeEventingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.operator.v1beta1.KnativeServing"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.operator.v1beta1.KnativeServingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.Configuration"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.ConfigurationList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.Revision"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.RevisionList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.Route"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.RouteList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.Service"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.ServiceList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1beta1.DomainMapping"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.knative.serving.v1beta1.DomainMappingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.ClusterWorkflowTemplate"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.ClusterWorkflowTemplateList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.CronWorkflow"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.CronWorkflowList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.Workflow"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowArtifactGCTask"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowArtifactGCTaskList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowEventBinding"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowEventBindingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowTaskResult"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowTaskResultList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowTaskSet"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowTaskSetList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowTemplate"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.WorkflowTemplateList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.cncf.cni.k8s.v1.NetworkAttachmentDefinition"
@@ -821,6 +929,144 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.cncf.cni.whereabouts.v1alpha1.OverlappingRangeIPReservationList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.extensions.v1alpha1.WasmPlugin"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.extensions.v1alpha1.WasmPluginList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.DestinationRule"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.DestinationRuleList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.EnvoyFilter"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.EnvoyFilterList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.Gateway"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.GatewayList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.ServiceEntry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.ServiceEntryList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.Sidecar"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.SidecarList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.VirtualService"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.VirtualServiceList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.WorkloadEntry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.WorkloadEntryList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.WorkloadGroup"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.WorkloadGroupList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.DestinationRule"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.DestinationRuleList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.Gateway"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.GatewayList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.ProxyConfig"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.ProxyConfigList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.ServiceEntry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.ServiceEntryList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.Sidecar"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.SidecarList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.VirtualService"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.VirtualServiceList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.WorkloadEntry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.WorkloadEntryList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.WorkloadGroup"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1beta1.WorkloadGroupList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1.AuthorizationPolicy"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1.AuthorizationPolicyList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1.RequestAuthentication"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1.RequestAuthenticationList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1beta1.AuthorizationPolicy"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1beta1.AuthorizationPolicyList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1beta1.PeerAuthentication"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1beta1.PeerAuthenticationList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1beta1.RequestAuthentication"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1beta1.RequestAuthenticationList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.telemetry.v1alpha1.Telemetry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.telemetry.v1alpha1.TelemetryList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.k8s.api.admissionregistration.v1.AuditAnnotation"
@@ -2704,6 +2950,12 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.version.Info"
     },
     {
+      "$ref": "_definitions.json#/definitions/io.k8s.app.v1beta1.Application"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.k8s.app.v1beta1.ApplicationList"
+    },
+    {
       "$ref": "_definitions.json#/definitions/io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService"
     },
     {
@@ -2779,394 +3031,124 @@
       "$ref": "_definitions.json#/definitions/io.k8s.storage.snapshot.v1.VolumeSnapshotList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.ForkliftController"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.ClusterLocalModel"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.ForkliftControllerList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.ClusterLocalModelList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.Hook"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.ClusterStorageContainer"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.HookList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.ClusterStorageContainerList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.Host"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.InferenceGraph"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.HostList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.InferenceGraphList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.Migration"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.LocalModelNodeGroup"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.MigrationList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.LocalModelNodeGroupList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.NetworkMap"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.Predictor"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.NetworkMapList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.PredictorList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.OpenstackVolumePopulator"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.ServingRuntime"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.OpenstackVolumePopulatorList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.ServingRuntimeList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.OvirtVolumePopulator"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.TrainedModel"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.OvirtVolumePopulatorList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1alpha1.TrainedModelList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.Plan"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1beta1.InferenceService"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.PlanList"
+      "$ref": "_definitions.json#/definitions/io.kserve.serving.v1beta1.InferenceServiceList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.Provider"
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.operator.v1beta1.Authorino"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.ProviderList"
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.operator.v1beta1.AuthorinoList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.StorageMap"
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta1.AuthConfig"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.konveyor.forklift.v1beta1.StorageMapList"
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta1.AuthConfigList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.aaq.v1alpha1.AAQ"
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta2.AuthConfig"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.aaq.v1alpha1.AAQList"
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta2.AuthConfigList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.forklift.v1beta1.OpenstackVolumePopulator"
+      "$ref": "_definitions.json#/definitions/io.maistra.authentication.v1.ServiceMeshPolicy"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.forklift.v1beta1.OpenstackVolumePopulatorList"
+      "$ref": "_definitions.json#/definitions/io.maistra.authentication.v1.ServiceMeshPolicyList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.forklift.v1beta1.OvirtVolumePopulator"
+      "$ref": "_definitions.json#/definitions/io.maistra.federation.v1.ExportedServiceSet"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.forklift.v1beta1.OvirtVolumePopulatorList"
+      "$ref": "_definitions.json#/definitions/io.maistra.federation.v1.ExportedServiceSetList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.CDI"
+      "$ref": "_definitions.json#/definitions/io.maistra.federation.v1.ImportedServiceSet"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.CDIConfig"
+      "$ref": "_definitions.json#/definitions/io.maistra.federation.v1.ImportedServiceSetList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.CDIConfigList"
+      "$ref": "_definitions.json#/definitions/io.maistra.federation.v1.ServiceMeshPeer"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.CDIList"
+      "$ref": "_definitions.json#/definitions/io.maistra.federation.v1.ServiceMeshPeerList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.DataImportCron"
+      "$ref": "_definitions.json#/definitions/io.maistra.rbac.v1.ServiceMeshRbacConfig"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.DataImportCronList"
+      "$ref": "_definitions.json#/definitions/io.maistra.rbac.v1.ServiceMeshRbacConfigList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.DataSource"
+      "$ref": "_definitions.json#/definitions/io.maistra.v1.ServiceMeshControlPlane"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.DataSourceList"
+      "$ref": "_definitions.json#/definitions/io.maistra.v1.ServiceMeshControlPlaneList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.DataVolume"
+      "$ref": "_definitions.json#/definitions/io.maistra.v1.ServiceMeshMember"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.DataVolumeList"
+      "$ref": "_definitions.json#/definitions/io.maistra.v1.ServiceMeshMemberList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.ObjectTransfer"
+      "$ref": "_definitions.json#/definitions/io.maistra.v1.ServiceMeshMemberRoll"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.ObjectTransferList"
+      "$ref": "_definitions.json#/definitions/io.maistra.v1.ServiceMeshMemberRollList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.StorageProfile"
+      "$ref": "_definitions.json#/definitions/io.maistra.v2.ServiceMeshControlPlane"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.StorageProfileList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.VolumeCloneSource"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.VolumeCloneSourceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.VolumeImportSource"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.VolumeImportSourceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.VolumeUploadSource"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.cdi.v1beta1.VolumeUploadSourceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.clone.v1alpha1.VirtualMachineClone"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.clone.v1alpha1.VirtualMachineCloneList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.clone.v1beta1.VirtualMachineClone"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.clone.v1beta1.VirtualMachineCloneList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.export.v1alpha1.VirtualMachineExport"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.export.v1alpha1.VirtualMachineExportList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.export.v1beta1.VirtualMachineExport"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.export.v1beta1.VirtualMachineExportList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.hco.v1beta1.HyperConverged"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.hco.v1beta1.HyperConvergedList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.hostpathprovisioner.v1beta1.HostPathProvisioner"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.hostpathprovisioner.v1beta1.HostPathProvisionerList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachineClusterInstancetype"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachineClusterInstancetypeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachineClusterPreference"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachineClusterPreferenceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachineInstancetype"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachineInstancetypeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachinePreference"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha1.VirtualMachinePreferenceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachineClusterInstancetype"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachineClusterInstancetypeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachineClusterPreference"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachineClusterPreferenceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachineInstancetype"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachineInstancetypeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachinePreference"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1alpha2.VirtualMachinePreferenceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachineClusterInstancetype"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachineClusterInstancetypeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachineClusterPreference"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachineClusterPreferenceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachineInstancetype"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachineInstancetypeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachinePreference"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.instancetype.v1beta1.VirtualMachinePreferenceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.migrations.v1alpha1.MigrationPolicy"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.migrations.v1alpha1.MigrationPolicyList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.network.networkaddonsoperator.v1.NetworkAddonsConfig"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.network.networkaddonsoperator.v1.NetworkAddonsConfigList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.network.networkaddonsoperator.v1alpha1.NetworkAddonsConfig"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.network.networkaddonsoperator.v1alpha1.NetworkAddonsConfigList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.pool.v1alpha1.VirtualMachinePool"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.pool.v1alpha1.VirtualMachinePoolList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1alpha1.VirtualMachineRestore"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1alpha1.VirtualMachineRestoreList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1alpha1.VirtualMachineSnapshot"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1alpha1.VirtualMachineSnapshotContent"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1alpha1.VirtualMachineSnapshotContentList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1alpha1.VirtualMachineSnapshotList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1beta1.VirtualMachineRestore"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1beta1.VirtualMachineRestoreList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1beta1.VirtualMachineSnapshot"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1beta1.VirtualMachineSnapshotContent"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1beta1.VirtualMachineSnapshotContentList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.snapshot.v1beta1.VirtualMachineSnapshotList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.ssp.v1beta2.SSP"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.ssp.v1beta2.SSPList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.ssp.v1beta3.SSP"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.ssp.v1beta3.SSPList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.KubeVirt"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.KubeVirtList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachine"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstance"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstanceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstanceMigration"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstanceMigrationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstancePreset"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstancePresetList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstanceReplicaSet"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineInstanceReplicaSetList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1.VirtualMachineList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.KubeVirt"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.KubeVirtList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachine"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstance"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstanceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstanceMigration"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstanceMigrationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstancePreset"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstancePresetList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstanceReplicaSet"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineInstanceReplicaSetList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kubevirt.v1alpha3.VirtualMachineList"
+      "$ref": "_definitions.json#/definitions/io.maistra.v2.ServiceMeshControlPlaneList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.metal3.v1alpha1.BMCEventSubscription"
@@ -3229,136 +3211,190 @@
       "$ref": "_definitions.json#/definitions/io.metal3.v1alpha1.ProvisioningList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1.NMState"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1.AcceleratorProfile"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1.NMStateList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1.AcceleratorProfileList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1.NodeNetworkConfigurationPolicy"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1.OdhApplication"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1.NodeNetworkConfigurationPolicyList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1.OdhApplicationList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NMState"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1.OdhDocument"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NMStateList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1.OdhDocumentList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NodeNetworkConfigurationEnactment"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1alpha.AcceleratorProfile"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NodeNetworkConfigurationEnactmentList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1alpha.AcceleratorProfileList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NodeNetworkConfigurationPolicy"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1alpha1.HardwareProfile"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NodeNetworkConfigurationPolicyList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1alpha1.HardwareProfileList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NodeNetworkState"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.datasciencecluster.v1.DataScienceCluster"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.nmstate.v1beta1.NodeNetworkStateList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.datasciencecluster.v1.DataScienceClusterList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Backup"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.datasciencepipelinesapplications.v1.DataSciencePipelinesApplication"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.BackupList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.datasciencepipelinesapplications.v1.DataSciencePipelinesApplicationList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Cluster"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.datasciencepipelinesapplications.v1alpha1.DataSciencePipelinesApplication"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.ClusterImageCatalog"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.datasciencepipelinesapplications.v1alpha1.DataSciencePipelinesApplicationList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.ClusterImageCatalogList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dscinitialization.v1.DSCInitialization"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.ClusterList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.dscinitialization.v1.DSCInitializationList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Database"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.features.v1.FeatureTracker"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.DatabaseList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.features.v1.FeatureTrackerList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.ImageCatalog"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.modelregistry.v1alpha1.ModelRegistry"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.ImageCatalogList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.modelregistry.v1alpha1.ModelRegistryList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Pooler"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.nim.v1.Account"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.PoolerList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.nim.v1.AccountList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Publication"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.CodeFlare"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.PublicationList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.CodeFlareList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.ScheduledBackup"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.Dashboard"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.ScheduledBackupList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.DashboardList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Subscription"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.DataSciencePipelines"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.SubscriptionList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.DataSciencePipelinesList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.BackingStore"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.FeastOperator"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.BackingStoreList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.FeastOperatorList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.BucketClass"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.Kserve"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.BucketClassList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.KserveList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.NamespaceStore"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.Kueue"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.NamespaceStoreList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.KueueList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.NooBaa"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.ModelController"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.NooBaaAccount"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.ModelControllerList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.NooBaaAccountList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.ModelMeshServing"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.noobaa.v1alpha1.NooBaaList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.ModelMeshServingList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.objectbucket.v1alpha1.ObjectBucket"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.ModelRegistry"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.objectbucket.v1alpha1.ObjectBucketClaim"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.ModelRegistryList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.objectbucket.v1alpha1.ObjectBucketClaimList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.Ray"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.objectbucket.v1alpha1.ObjectBucketList"
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.RayList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.TrainingOperator"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.TrainingOperatorList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.TrustyAI"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.TrustyAIList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.Workbenches"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.WorkbenchesList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.services.v1alpha1.Auth"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.services.v1alpha1.AuthList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.services.v1alpha1.Monitoring"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.platform.services.v1alpha1.MonitoringList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.trustyai.v1alpha1.GuardrailsOrchestrator"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.trustyai.v1alpha1.GuardrailsOrchestratorList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.trustyai.v1alpha1.LMEvalJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.trustyai.v1alpha1.LMEvalJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.trustyai.v1alpha1.TrustyAIService"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.trustyai.v1alpha1.TrustyAIServiceList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.v1alpha.OdhDashboardConfig"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.opendatahub.v1alpha.OdhDashboardConfigList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.openshift.apiserver.v1.APIRequestCount"
@@ -3565,46 +3601,10 @@
       "$ref": "_definitions.json#/definitions/io.openshift.console.v1.ConsoleYAMLSampleList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.CSIAddonsNode"
+      "$ref": "_definitions.json#/definitions/io.openshift.console.v1.OdhQuickStart"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.CSIAddonsNodeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.EncryptionKeyRotationCronJob"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.EncryptionKeyRotationCronJobList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.EncryptionKeyRotationJob"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.EncryptionKeyRotationJobList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.NetworkFence"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.NetworkFenceClass"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.NetworkFenceClassList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.NetworkFenceList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.ReclaimSpaceCronJob"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.ReclaimSpaceCronJobList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.ReclaimSpaceJob"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.csiaddons.v1alpha1.ReclaimSpaceJobList"
+      "$ref": "_definitions.json#/definitions/io.openshift.console.v1.OdhQuickStartList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.openshift.helm.v1beta1.HelmChartRepository"
@@ -3679,72 +3679,6 @@
       "$ref": "_definitions.json#/definitions/io.openshift.machineconfiguration.v1.MachineConfigPoolList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectImageMigration"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectImageMigrationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectImageStreamMigration"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectImageStreamMigrationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectVolumeMigration"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectVolumeMigrationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectVolumeMigrationProgress"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.DirectVolumeMigrationProgressList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigAnalytic"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigAnalyticList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigCluster"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigClusterList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigHook"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigHookList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigMigration"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigMigrationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigPlan"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigPlanList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigStorage"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigStorageList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigrationController"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.migration.v1alpha1.MigrationControllerList"
-    },
-    {
       "$ref": "_definitions.json#/definitions/io.openshift.monitoring.v1.AlertRelabelConfig"
     },
     {
@@ -3761,66 +3695,6 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.openshift.network.cloud.v1.CloudPrivateIPConfigList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.oadp.v1alpha1.CloudStorage"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.oadp.v1alpha1.CloudStorageList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.oadp.v1alpha1.DataProtectionApplication"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.oadp.v1alpha1.DataProtectionApplicationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1.OCSInitialization"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1.OCSInitializationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1.StorageCluster"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1.StorageClusterList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1.StorageClusterPeer"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1.StorageClusterPeerList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageClaim"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageClaimList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageClient"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageClientList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageConsumer"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageConsumerList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageRequest"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ocs.v1alpha1.StorageRequestList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.odf.v1alpha1.StorageSystem"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.odf.v1alpha1.StorageSystemList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.openshift.operator.controlplane.v1alpha1.PodNetworkConnectivityCheck"
@@ -4021,70 +3895,16 @@
       "$ref": "_definitions.json#/definitions/io.openshift.quota.v1.ClusterResourceQuotaList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.openshift.ramendr.v1alpha1.Recipe"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.ramendr.v1alpha1.RecipeList"
-    },
-    {
       "$ref": "_definitions.json#/definitions/io.openshift.security.v1.SecurityContextConstraints"
     },
     {
       "$ref": "_definitions.json#/definitions/io.openshift.security.v1.SecurityContextConstraintsList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1.LocalVolume"
+      "$ref": "_definitions.json#/definitions/io.openshift.serverless.operator.v1alpha1.KnativeKafka"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1.LocalVolumeList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1alpha1.LocalVolumeDiscovery"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1alpha1.LocalVolumeDiscoveryList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1alpha1.LocalVolumeDiscoveryResult"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1alpha1.LocalVolumeDiscoveryResultList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1alpha1.LocalVolumeSet"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.local.v1alpha1.LocalVolumeSetList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeGroupReplication"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeGroupReplicationClass"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeGroupReplicationClassList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeGroupReplicationContent"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeGroupReplicationContentList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeGroupReplicationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeReplication"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeReplicationClass"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeReplicationClassList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.openshift.storage.replication.v1alpha1.VolumeReplicationList"
+      "$ref": "_definitions.json#/definitions/io.openshift.serverless.operator.v1alpha1.KnativeKafkaList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.openshift.tuned.v1.Profile"
@@ -4111,184 +3931,40 @@
       "$ref": "_definitions.json#/definitions/io.operatorframework.olm.v1.ClusterExtensionList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBlockPool"
+      "$ref": "_definitions.json#/definitions/io.ray.v1.RayCluster"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBlockPoolList"
+      "$ref": "_definitions.json#/definitions/io.ray.v1.RayClusterList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBlockPoolRadosNamespace"
+      "$ref": "_definitions.json#/definitions/io.ray.v1.RayJob"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBlockPoolRadosNamespaceList"
+      "$ref": "_definitions.json#/definitions/io.ray.v1.RayJobList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBucketNotification"
+      "$ref": "_definitions.json#/definitions/io.ray.v1.RayService"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBucketNotificationList"
+      "$ref": "_definitions.json#/definitions/io.ray.v1.RayServiceList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBucketTopic"
+      "$ref": "_definitions.json#/definitions/io.ray.v1alpha1.RayCluster"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephBucketTopicList"
+      "$ref": "_definitions.json#/definitions/io.ray.v1alpha1.RayClusterList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephCOSIDriver"
+      "$ref": "_definitions.json#/definitions/io.ray.v1alpha1.RayJob"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephCOSIDriverList"
+      "$ref": "_definitions.json#/definitions/io.ray.v1alpha1.RayJobList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephClient"
+      "$ref": "_definitions.json#/definitions/io.ray.v1alpha1.RayService"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephClientList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephCluster"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephClusterList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephFilesystem"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephFilesystemList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephFilesystemMirror"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephFilesystemMirrorList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephFilesystemSubVolumeGroup"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephFilesystemSubVolumeGroupList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephNFS"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephNFSList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectRealm"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectRealmList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectStore"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectStoreList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectStoreUser"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectStoreUserList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectZone"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectZoneGroup"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectZoneGroupList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephObjectZoneList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephRBDMirror"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.rook.ceph.v1.CephRBDMirrorList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.Backup"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.BackupList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.BackupRepository"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.BackupRepositoryList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.BackupStorageLocation"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.BackupStorageLocationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.DeleteBackupRequest"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.DeleteBackupRequestList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.DownloadRequest"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.DownloadRequestList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.PodVolumeBackup"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.PodVolumeBackupList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.PodVolumeRestore"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.PodVolumeRestoreList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.Restore"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.RestoreList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.Schedule"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.ScheduleList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.ServerStatusRequest"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.ServerStatusRequestList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.VolumeSnapshotLocation"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v1.VolumeSnapshotLocationList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v2alpha1.DataDownload"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v2alpha1.DataDownloadList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v2alpha1.DataUpload"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.velero.v2alpha1.DataUploadList"
+      "$ref": "_definitions.json#/definitions/io.ray.v1alpha1.RayServiceList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.x-k8s.cluster.infrastructure.v1alpha5.Metal3Remediation"
@@ -4339,19 +4015,136 @@
       "$ref": "_definitions.json#/definitions/io.x-k8s.cluster.ipam.v1beta1.IPAddressList"
     },
     {
-      "$ref": "_definitions.json#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResource"
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1alpha1.Cohort"
     },
     {
-      "$ref": "_definitions.json#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResourceList"
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1alpha1.CohortList"
     },
     {
-      "$ref": "_definitions.json#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Duration"
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1alpha1.Topology"
     },
     {
-      "$ref": "_definitions.json#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta"
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1alpha1.TopologyList"
     },
     {
-      "$ref": "_definitions.json#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.AdmissionCheck"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.AdmissionCheckList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.ClusterQueue"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.ClusterQueueList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.LocalQueue"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.LocalQueueList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.MultiKueueCluster"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.MultiKueueClusterList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.MultiKueueConfig"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.MultiKueueConfigList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.ProvisioningRequestConfig"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.ProvisioningRequestConfigList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.ResourceFlavor"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.ResourceFlavorList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.Workload"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.WorkloadList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.WorkloadPriorityClass"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.WorkloadPriorityClassList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.JAXJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.JAXJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.MPIJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.MPIJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.Notebook"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.NotebookList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.PaddleJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.PaddleJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.PyTorchJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.PyTorchJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.TFJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.TFJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.XGBoostJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1.XGBoostJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1alpha1.Notebook"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1alpha1.NotebookList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1beta1.Notebook"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1beta1.NotebookList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1beta1.ScheduledWorkflow"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1beta1.ScheduledWorkflowList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1beta1.Viewer"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/org.kubeflow.v1beta1.ViewerList"
     },
     {
       "$ref": "_definitions.json#/definitions/org.ovn.k8s.v1.AdminPolicyBasedExternalRoute"
@@ -4394,105 +4187,6 @@
     },
     {
       "$ref": "_definitions.json#/definitions/org.ovn.k8s.v1.UserDefinedNetworkList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.AddVolumeOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.BlockSize"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.CDRomTarget"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.CustomBlockSize"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.DataVolumeSource"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.Disk"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.DiskTarget"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.FeatureState"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.FreezeUnfreezeTimeout"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.GuestAgentCommandInfo"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.HotplugVolumeSource"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.LunTarget"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.MigrateOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.PauseOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.PersistentVolumeClaimVolumeSource"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.RemoveVolumeOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.RestartOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.SEVMeasurementInfo"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.SEVPlatformInfo"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.SEVSecretOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.SEVSessionOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.StartOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.StopOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.UnpauseOptions"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceFileSystem"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceFileSystemDisk"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceFileSystemInfo"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceFileSystemList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceGuestAgentInfo"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceGuestOSInfo"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceGuestOSUser"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineInstanceGuestOSUserList"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/v1.VirtualMachineMemoryDumpRequest"
     }
   ]
 }

--- a/class_generator/schema/apiresource.json
+++ b/class_generator/schema/apiresource.json
@@ -13,8 +13,7 @@
       "description": "categories is a list of the grouped resources this resource belongs to (e.g. 'all')",
       "type": "array",
       "items": {
-        "type": "string",
-        "default": ""
+        "type": "string"
       },
       "x-kubernetes-list-type": "atomic"
     },
@@ -24,32 +23,27 @@
     },
     "kind": {
       "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "name": {
       "description": "name is the plural name of the resource.",
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "namespaced": {
       "description": "namespaced indicates if a resource is namespaced or not.",
-      "type": "boolean",
-      "default": false
+      "type": "boolean"
     },
     "shortNames": {
       "description": "shortNames is a list of suggested short names of the resource.",
       "type": "array",
       "items": {
-        "type": "string",
-        "default": ""
+        "type": "string"
       },
       "x-kubernetes-list-type": "atomic"
     },
     "singularName": {
       "description": "singularName is the singular name of the resource.  This allows clients to handle plural and singular opaquely. The singularName is more correct for reporting status on a single item and both singular and plural are allowed from the kubectl CLI interface.",
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "storageVersionHash": {
       "description": "The hash value of the storage version, the version this resource is converted to when written to the data store. Value must be treated as opaque by clients. Only equality comparison on the value is valid. This is an alpha feature and may change or be removed in the future. The field is populated by the apiserver only if the StorageVersionHash feature gate is enabled. This field will remain optional even if it graduates.",
@@ -59,8 +53,7 @@
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
       "type": "array",
       "items": {
-        "type": "string",
-        "default": ""
+        "type": "string"
       }
     },
     "version": {

--- a/class_generator/schema/apiresourcelist.json
+++ b/class_generator/schema/apiresourcelist.json
@@ -12,8 +12,7 @@
     },
     "groupVersion": {
       "description": "groupVersion is the group and version this APIResourceList is for.",
-      "type": "string",
-      "default": ""
+      "type": "string"
     },
     "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
@@ -23,11 +22,17 @@
       "description": "resources contains the name of the resources and if they are namespaced.",
       "type": "array",
       "items": {
-        "default": {},
-        "$ref": "_definitions.json#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.APIResource"
+        "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"
       },
       "x-kubernetes-list-type": "atomic"
     }
   },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "",
+      "kind": "APIResourceList",
+      "version": "v1"
+    }
+  ],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/appwrapper.json
+++ b/class_generator/schema/appwrapper.json
@@ -66,6 +66,23 @@
                         "type": "string"
                       }
                     },
+                    "schedulingGates": {
+                      "description": "SchedulingGates to be added to the PodSpecTemplate",
+                      "type": "array",
+                      "items": {
+                        "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name of the scheduling gate.\nEach scheduling gate must have a unique name field.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "tolerations": {
                       "description": "Tolerations to be added to the PodSpecTemplate",
                       "type": "array",
@@ -110,6 +127,13 @@
                     "path"
                   ],
                   "properties": {
+                    "annotations": {
+                      "description": "Annotations is an unstructured key value map that may be used to store and retrieve\narbitrary metadata about the PodSet to customize its treatment by the AppWrapper controller.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
                     "path": {
                       "description": "Path is the path Component.Template to the PodTemplateSpec for this PodSet",
                       "type": "string"
@@ -162,10 +186,10 @@
                 "type": "string"
               },
               "conditions": {
-                "description": "Conditions hold the latest available observations of the Component's current state.\n\n\nThe type of the condition could be:\n\n\n- ResourcesDeployed: The component is deployed on the cluster",
+                "description": "Conditions hold the latest available observations of the Component's current state.\n\nThe type of the condition could be:\n\n- ResourcesDeployed: The component is deployed on the cluster",
                 "type": "array",
                 "items": {
-                  "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+                  "description": "Condition contains details for one aspect of the current state of this API Resource.",
                   "type": "object",
                   "required": [
                     "lastTransitionTime",
@@ -208,7 +232,7 @@
                       ]
                     },
                     "type": {
-                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                      "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                       "type": "string",
                       "maxLength": 316,
                       "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
@@ -238,6 +262,13 @@
                     "path"
                   ],
                   "properties": {
+                    "annotations": {
+                      "description": "Annotations is an unstructured key value map that may be used to store and retrieve\narbitrary metadata about the PodSet to customize its treatment by the AppWrapper controller.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
                     "path": {
                       "description": "Path is the path Component.Template to the PodTemplateSpec for this PodSet",
                       "type": "string"
@@ -254,10 +285,10 @@
           }
         },
         "conditions": {
-          "description": "Conditions hold the latest available observations of the AppWrapper current state.\n\n\nThe type of the condition could be:\n\n\n- QuotaReserved: The AppWrapper was admitted by Kueue and has quota allocated to it\n- ResourcesDeployed: The contained resources are deployed (or being deployed) on the cluster\n- PodsReady: All pods of the contained resources are in the Ready or Succeeded state\n- Unhealthy: One or more of the contained resources is unhealthy\n- DeletingResources: The contained resources are in the process of being deleted from the cluster",
+          "description": "Conditions hold the latest available observations of the AppWrapper current state.\n\nThe type of the condition could be:\n\n- QuotaReserved: The AppWrapper was admitted by Kueue and has quota allocated to it\n- ResourcesDeployed: The contained resources are deployed (or being deployed) on the cluster\n- PodsReady: All pods of the contained resources are in the Ready or Succeeded state\n- Unhealthy: One or more of the contained resources is unhealthy\n- DeletingResources: The contained resources are in the process of being deleted from the cluster",
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -300,7 +331,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"

--- a/class_generator/schema/auth.json
+++ b/class_generator/schema/auth.json
@@ -43,38 +43,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -93,12 +94,10 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
@@ -115,6 +114,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "Auth name must be auth",

--- a/class_generator/schema/authconfig.json
+++ b/class_generator/schema/authconfig.json
@@ -22,7 +22,7 @@
       ],
       "properties": {
         "authentication": {
-          "description": "Authentication configs. At least one config MUST evaluate to a valid identity object for the auth request to be successful.",
+          "description": "Authentication configs.\nAt least one config MUST evaluate to a valid identity object for the auth request to be successful.",
           "type": "object",
           "additionalProperties": {
             "type": "object",
@@ -39,7 +39,7 @@
                 ],
                 "properties": {
                   "allNamespaces": {
-                    "description": "Whether Authorino should look for API key secrets in all namespaces or only in the same namespace as the AuthConfig. Enabling this option in namespaced Authorino instances has no effect.",
+                    "description": "Whether Authorino should look for API key secrets in all namespaces or only in the same namespace as the AuthConfig.\nEnabling this option in namespaced Authorino instances has no effect.",
                     "type": "boolean"
                   },
                   "selector": {
@@ -50,7 +50,7 @@
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "type": "array",
                         "items": {
-                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                           "type": "object",
                           "required": [
                             "key",
@@ -62,11 +62,11 @@
                               "type": "string"
                             },
                             "operator": {
-                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
-                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                               "type": "array",
                               "items": {
                                 "type": "string"
@@ -76,29 +76,30 @@
                         }
                       },
                       "matchLabels": {
-                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object",
                         "additionalProperties": {
                           "type": "string"
                         }
                       }
-                    }
+                    },
+                    "x-kubernetes-map-type": "atomic"
                   }
                 }
               },
               "cache": {
-                "description": "Caching options for the resolved object returned when applying this config. Omit it to avoid caching objects for this config.",
+                "description": "Caching options for the resolved object returned when applying this config.\nOmit it to avoid caching objects for this config.",
                 "type": "object",
                 "required": [
                   "key"
                 ],
                 "properties": {
                   "key": {
-                    "description": "Key used to store the entry in the cache. The resolved key must be unique within the scope of this particular config.",
+                    "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -114,7 +115,7 @@
                 }
               },
               "credentials": {
-                "description": "Defines where credentials are required to be passed in the request for authentication based on this config. If omitted, it defaults to credentials passed in the HTTP Authorization header and the \"Bearer\" prefix prepended to the secret credential value.",
+                "description": "Defines where credentials are required to be passed in the request for authentication based on this config.\nIf omitted, it defaults to credentials passed in the HTTP Authorization header and the \"Bearer\" prefix prepended to the secret credential value.",
                 "type": "object",
                 "properties": {
                   "authorizationHeader": {
@@ -161,13 +162,13 @@
                 }
               },
               "defaults": {
-                "description": "Set default property values (claims) for the resolved identity object, that are set before appending the object to the authorization JSON. If the property is already present in the resolved identity object, the default value is ignored. It requires the resolved identity object to always be a JSON object. Do not use this option with identity objects of other JSON types (array, string, etc).",
+                "description": "Set default property values (claims) for the resolved identity object, that are set before appending the object to\nthe authorization JSON. If the property is already present in the resolved identity object, the default value is ignored.\nIt requires the resolved identity object to always be a JSON object.\nDo not use this option with identity objects of other JSON types (array, string, etc).",
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
                     "selector": {
-                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
                     },
                     "value": {
@@ -182,11 +183,11 @@
                 "type": "object",
                 "properties": {
                   "issuerUrl": {
-                    "description": "URL of the issuer of the JWT. If `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint (i.e. \"/.well-known/openid-configuration\") to this URL, to discover the OIDC configuration where to obtain the \"jkws_uri\" claim from. The value must coincide with the value of  the \"iss\" (issuer) claim of the discovered OpenID Connect configuration.",
+                    "description": "URL of the issuer of the JWT.\nIf `jwksUrl` is omitted, Authorino will append the path to the OpenID Connect Well-Known Discovery endpoint\n(i.e. \"/.well-known/openid-configuration\") to this URL, to discover the OIDC configuration where to obtain\nthe \"jkws_uri\" claim from.\nThe value must coincide with the value of  the \"iss\" (issuer) claim of the discovered OpenID Connect configuration.",
                     "type": "string"
                   },
                   "ttl": {
-                    "description": "Decides how long to wait before refreshing the JWKS (in seconds). If omitted, Authorino will never refresh the JWKS.",
+                    "description": "Decides how long to wait before refreshing the JWKS (in seconds).\nIf omitted, Authorino will never refresh the JWKS.",
                     "type": "integer"
                   }
                 }
@@ -196,7 +197,7 @@
                 "type": "object",
                 "properties": {
                   "audiences": {
-                    "description": "The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino. If omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.",
+                    "description": "The list of audiences (scopes) that must be claimed in a Kubernetes authentication token supplied in the request, and reviewed by Authorino.\nIf omitted, Authorino will review tokens expecting the host name of the requested protected service amongst the audiences.",
                     "type": "array",
                     "items": {
                       "type": "string"
@@ -221,29 +222,30 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                         "type": "string"
                       }
-                    }
+                    },
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "endpoint": {
                     "description": "The full URL of the token introspection endpoint.",
                     "type": "string"
                   },
                   "tokenTypeHint": {
-                    "description": "The token type hint for the token introspection. If omitted, it defaults to \"access_token\".",
+                    "description": "The token type hint for the token introspection.\nIf omitted, it defaults to \"access_token\".",
                     "type": "string"
                   }
                 }
               },
               "overrides": {
-                "description": "Overrides the resolved identity object by setting the additional properties (claims) specified in this config, before appending the object to the authorization JSON. It requires the resolved identity object to always be a JSON object. Do not use this option with identity objects of other JSON types (array, string, etc).",
+                "description": "Overrides the resolved identity object by setting the additional properties (claims) specified in this config,\nbefore appending the object to the authorization JSON.\nIt requires the resolved identity object to always be a JSON object.\nDo not use this option with identity objects of other JSON types (array, string, etc).",
                 "type": "object",
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
                     "selector": {
-                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
                     },
                     "value": {
@@ -254,24 +256,24 @@
                 }
               },
               "plain": {
-                "description": "Identity object extracted from the context. Use this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.",
+                "description": "Identity object extracted from the context.\nUse this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.",
                 "type": "object",
                 "required": [
                   "selector"
                 ],
                 "properties": {
                   "selector": {
-                    "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                    "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                     "type": "string"
                   }
                 }
               },
               "priority": {
-                "description": "Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
+                "description": "Priority group of the config.\nAll configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
                 "type": "integer"
               },
               "when": {
-                "description": "Conditions for Authorino to enforce this config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
+                "description": "Conditions for Authorino to enforce this config.\nIf omitted, the config will be enforced for all requests.\nIf present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -291,7 +293,7 @@
                       }
                     },
                     "operator": {
-                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                       "type": "string",
                       "enum": [
                         "eq",
@@ -306,36 +308,36 @@
                       "type": "string"
                     },
                     "selector": {
-                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                       "type": "string"
                     },
                     "value": {
-                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                       "type": "string"
                     }
                   }
                 }
               },
               "x509": {
-                "description": "Authentication based on client X.509 certificates. The certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.",
+                "description": "Authentication based on client X.509 certificates.\nThe certificates presented by the clients must be signed by a trusted CA whose certificates are stored in Kubernetes secrets.",
                 "type": "object",
                 "required": [
                   "selector"
                 ],
                 "properties": {
                   "allNamespaces": {
-                    "description": "Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig. Enabling this option in namespaced Authorino instances has no effect.",
+                    "description": "Whether Authorino should look for TLS secrets in all namespaces or only in the same namespace as the AuthConfig.\nEnabling this option in namespaced Authorino instances has no effect.",
                     "type": "boolean"
                   },
                   "selector": {
-                    "description": "Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate clients trying to authenticate to this service",
+                    "description": "Label selector used by Authorino to match secrets from the cluster storing trusted CA certificates to validate\nclients trying to authenticate to this service",
                     "type": "object",
                     "properties": {
                       "matchExpressions": {
                         "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                         "type": "array",
                         "items": {
-                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
                           "type": "object",
                           "required": [
                             "key",
@@ -347,11 +349,11 @@
                               "type": "string"
                             },
                             "operator": {
-                              "description": "operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.",
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
                               "type": "string"
                             },
                             "values": {
-                              "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                               "type": "array",
                               "items": {
                                 "type": "string"
@@ -361,13 +363,14 @@
                         }
                       },
                       "matchLabels": {
-                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                         "type": "object",
                         "additionalProperties": {
                           "type": "string"
                         }
                       }
-                    }
+                    },
+                    "x-kubernetes-map-type": "atomic"
                   }
                 }
               }
@@ -375,24 +378,24 @@
           }
         },
         "authorization": {
-          "description": "Authorization policies. All policies MUST evaluate to \"allowed = true\" for the auth request be successful.",
+          "description": "Authorization policies.\nAll policies MUST evaluate to \"allowed = true\" for the auth request be successful.",
           "type": "object",
           "additionalProperties": {
             "type": "object",
             "properties": {
               "cache": {
-                "description": "Caching options for the resolved object returned when applying this config. Omit it to avoid caching objects for this config.",
+                "description": "Caching options for the resolved object returned when applying this config.\nOmit it to avoid caching objects for this config.",
                 "type": "object",
                 "required": [
                   "key"
                 ],
                 "properties": {
                   "key": {
-                    "description": "Key used to store the entry in the cache. The resolved key must be unique within the scope of this particular config.",
+                    "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -419,15 +422,15 @@
                     }
                   },
                   "resourceAttributes": {
-                    "description": "Use resourceAttributes to check permissions on Kubernetes resources. If omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.",
+                    "description": "Use resourceAttributes to check permissions on Kubernetes resources.\nIf omitted, it performs a non-resource SubjectAccessReview, with verb and path inferred from the request.",
                     "type": "object",
                     "properties": {
                       "group": {
-                        "description": "API group of the resource. Use '*' for all API groups.",
+                        "description": "API group of the resource.\nUse '*' for all API groups.",
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -437,11 +440,11 @@
                         }
                       },
                       "name": {
-                        "description": "Resource name Omit it to check for authorization on all resources of the specified kind.",
+                        "description": "Resource name\nOmit it to check for authorization on all resources of the specified kind.",
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -455,7 +458,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -465,11 +468,11 @@
                         }
                       },
                       "resource": {
-                        "description": "Resource kind Use '*' for all resource kinds.",
+                        "description": "Resource kind\nUse '*' for all resource kinds.",
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -483,7 +486,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -493,11 +496,11 @@
                         }
                       },
                       "verb": {
-                        "description": "Verb to check for authorization on the resource. Use '*' for all verbs.",
+                        "description": "Verb to check for authorization on the resource.\nUse '*' for all verbs.",
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -509,11 +512,11 @@
                     }
                   },
                   "user": {
-                    "description": "User to check for authorization in the Kubernetes RBAC. Omit it to check for group authorization only.",
+                    "description": "User to check for authorization in the Kubernetes RBAC.\nOmit it to check for group authorization only.",
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -533,22 +536,22 @@
                 "type": "object",
                 "properties": {
                   "allValues": {
-                    "description": "Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline. Otherwise, only the default `allow` rule will be exposed. Returning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.",
+                    "description": "Returns the value of all Rego rules in the virtual document. Values can be read in subsequent evaluators/phases of the Auth Pipeline.\nOtherwise, only the default `allow` rule will be exposed.\nReturning all Rego rules can affect performance of OPA policies during reconciliation (policy precompile) and at runtime.",
                     "type": "boolean"
                   },
                   "externalPolicy": {
-                    "description": "Settings for fetching the OPA policy from an external registry. Use it alternatively to 'rego'. For the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters', 'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.",
+                    "description": "Settings for fetching the OPA policy from an external registry.\nUse it alternatively to 'rego'.\nFor the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',\n'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.",
                     "type": "object",
                     "required": [
                       "url"
                     ],
                     "properties": {
                       "body": {
-                        "description": "Raw body of the HTTP request. Supersedes 'bodyParameters'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
+                        "description": "Raw body of the HTTP request.\nSupersedes 'bodyParameters'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -558,13 +561,13 @@
                         }
                       },
                       "bodyParameters": {
-                        "description": "Custom parameters to encode in the body of the HTTP request. Superseded by 'body'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
+                        "description": "Custom parameters to encode in the body of the HTTP request.\nSuperseded by 'body'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                         "type": "object",
                         "additionalProperties": {
                           "type": "object",
                           "properties": {
                             "selector": {
-                              "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                              "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                               "type": "string"
                             },
                             "value": {
@@ -575,7 +578,7 @@
                         }
                       },
                       "contentType": {
-                        "description": "Content-Type of the request body. Shapes how 'bodyParameters' are encoded. Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.",
+                        "description": "Content-Type of the request body. Shapes how 'bodyParameters' are encoded.\nUse it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.",
                         "type": "string",
                         "enum": [
                           "application/x-www-form-urlencoded",
@@ -583,7 +586,7 @@
                         ]
                       },
                       "credentials": {
-                        "description": "Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the \"Bearer\" prefix expected prepended to the secret value.",
+                        "description": "Defines where client credentials will be passed in the request to the service.\nIf omitted, it defaults to client credentials passed in the HTTP Authorization header and the \"Bearer\" prefix expected prepended to the secret value.",
                         "type": "object",
                         "properties": {
                           "authorizationHeader": {
@@ -636,7 +639,7 @@
                           "type": "object",
                           "properties": {
                             "selector": {
-                              "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                              "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                               "type": "string"
                             },
                             "value": {
@@ -647,7 +650,7 @@
                         }
                       },
                       "method": {
-                        "description": "HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.",
+                        "description": "HTTP verb used in the request to the service. Accepted values: GET (default), POST.\nWhen the request method is POST, the authorization JSON is passed in the body of the request.",
                         "type": "string",
                         "enum": [
                           "GET",
@@ -671,7 +674,7 @@
                         ],
                         "properties": {
                           "cache": {
-                            "description": "Caches and reuses the token until expired. Set it to false to force fetch the token at every authorization request regardless of expiration.",
+                            "description": "Caches and reuses the token until expired.\nSet it to false to force fetch the token at every authorization request regardless of expiration.",
                             "type": "boolean"
                           },
                           "clientId": {
@@ -717,7 +720,7 @@
                         }
                       },
                       "sharedSecretRef": {
-                        "description": "Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request. Ignored if used together with oauth2.",
+                        "description": "Reference to a Secret key whose value will be passed by Authorino in the request.\nThe HTTP service can use the shared secret to authenticate the origin of the request.\nIgnored if used together with oauth2.",
                         "type": "object",
                         "required": [
                           "key",
@@ -739,13 +742,13 @@
                         "type": "integer"
                       },
                       "url": {
-                        "description": "Endpoint URL of the HTTP service. The value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}",
+                        "description": "Endpoint URL of the HTTP service.\nThe value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported\nby https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.\nE.g. https://ext-auth-server.io/metadata?p={request.path}",
                         "type": "string"
                       }
                     }
                   },
                   "rego": {
-                    "description": "Authorization policy as a Rego language document. The Rego document must include the \"allow\" condition, set by Authorino to \"false\" by default (i.e. requests are unauthorized unless changed). The Rego document must NOT include the \"package\" declaration in line 1.",
+                    "description": "Authorization policy as a Rego language document.\nThe Rego document must include the \"allow\" condition, set by Authorino to \"false\" by default (i.e. requests are unauthorized unless changed).\nThe Rego document must NOT include the \"package\" declaration in line 1.",
                     "type": "string"
                   }
                 }
@@ -777,7 +780,7 @@
                           }
                         },
                         "operator": {
-                          "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                          "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                           "type": "string",
                           "enum": [
                             "eq",
@@ -792,11 +795,11 @@
                           "type": "string"
                         },
                         "selector": {
-                          "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                          "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                           "type": "string"
                         },
                         "value": {
-                          "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                          "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                           "type": "string"
                         }
                       }
@@ -805,7 +808,7 @@
                 }
               },
               "priority": {
-                "description": "Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
+                "description": "Priority group of the config.\nAll configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
                 "type": "integer"
               },
               "spicedb": {
@@ -828,7 +831,7 @@
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -845,7 +848,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -858,7 +861,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -895,7 +898,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -908,7 +911,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -922,7 +925,7 @@
                 }
               },
               "when": {
-                "description": "Conditions for Authorino to enforce this config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
+                "description": "Conditions for Authorino to enforce this config.\nIf omitted, the config will be enforced for all requests.\nIf present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -942,7 +945,7 @@
                       }
                     },
                     "operator": {
-                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                       "type": "string",
                       "enum": [
                         "eq",
@@ -957,11 +960,11 @@
                       "type": "string"
                     },
                     "selector": {
-                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                       "type": "string"
                     },
                     "value": {
-                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                       "type": "string"
                     }
                   }
@@ -971,7 +974,7 @@
           }
         },
         "callbacks": {
-          "description": "Callback functions. Authorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.",
+          "description": "Callback functions.\nAuthorino sends callbacks at the end of the auth pipeline to the endpoints specified in this config.",
           "type": "object",
           "additionalProperties": {
             "type": "object",
@@ -980,18 +983,18 @@
             ],
             "properties": {
               "cache": {
-                "description": "Caching options for the resolved object returned when applying this config. Omit it to avoid caching objects for this config.",
+                "description": "Caching options for the resolved object returned when applying this config.\nOmit it to avoid caching objects for this config.",
                 "type": "object",
                 "required": [
                   "key"
                 ],
                 "properties": {
                   "key": {
-                    "description": "Key used to store the entry in the cache. The resolved key must be unique within the scope of this particular config.",
+                    "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -1014,11 +1017,11 @@
                 ],
                 "properties": {
                   "body": {
-                    "description": "Raw body of the HTTP request. Supersedes 'bodyParameters'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
+                    "description": "Raw body of the HTTP request.\nSupersedes 'bodyParameters'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -1028,13 +1031,13 @@
                     }
                   },
                   "bodyParameters": {
-                    "description": "Custom parameters to encode in the body of the HTTP request. Superseded by 'body'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
+                    "description": "Custom parameters to encode in the body of the HTTP request.\nSuperseded by 'body'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                     "type": "object",
                     "additionalProperties": {
                       "type": "object",
                       "properties": {
                         "selector": {
-                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
                         },
                         "value": {
@@ -1045,7 +1048,7 @@
                     }
                   },
                   "contentType": {
-                    "description": "Content-Type of the request body. Shapes how 'bodyParameters' are encoded. Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.",
+                    "description": "Content-Type of the request body. Shapes how 'bodyParameters' are encoded.\nUse it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.",
                     "type": "string",
                     "enum": [
                       "application/x-www-form-urlencoded",
@@ -1053,7 +1056,7 @@
                     ]
                   },
                   "credentials": {
-                    "description": "Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the \"Bearer\" prefix expected prepended to the secret value.",
+                    "description": "Defines where client credentials will be passed in the request to the service.\nIf omitted, it defaults to client credentials passed in the HTTP Authorization header and the \"Bearer\" prefix expected prepended to the secret value.",
                     "type": "object",
                     "properties": {
                       "authorizationHeader": {
@@ -1106,7 +1109,7 @@
                       "type": "object",
                       "properties": {
                         "selector": {
-                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
                         },
                         "value": {
@@ -1117,7 +1120,7 @@
                     }
                   },
                   "method": {
-                    "description": "HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.",
+                    "description": "HTTP verb used in the request to the service. Accepted values: GET (default), POST.\nWhen the request method is POST, the authorization JSON is passed in the body of the request.",
                     "type": "string",
                     "enum": [
                       "GET",
@@ -1141,7 +1144,7 @@
                     ],
                     "properties": {
                       "cache": {
-                        "description": "Caches and reuses the token until expired. Set it to false to force fetch the token at every authorization request regardless of expiration.",
+                        "description": "Caches and reuses the token until expired.\nSet it to false to force fetch the token at every authorization request regardless of expiration.",
                         "type": "boolean"
                       },
                       "clientId": {
@@ -1187,7 +1190,7 @@
                     }
                   },
                   "sharedSecretRef": {
-                    "description": "Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request. Ignored if used together with oauth2.",
+                    "description": "Reference to a Secret key whose value will be passed by Authorino in the request.\nThe HTTP service can use the shared secret to authenticate the origin of the request.\nIgnored if used together with oauth2.",
                     "type": "object",
                     "required": [
                       "key",
@@ -1205,7 +1208,7 @@
                     }
                   },
                   "url": {
-                    "description": "Endpoint URL of the HTTP service. The value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}",
+                    "description": "Endpoint URL of the HTTP service.\nThe value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported\nby https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.\nE.g. https://ext-auth-server.io/metadata?p={request.path}",
                     "type": "string"
                   }
                 }
@@ -1215,11 +1218,11 @@
                 "type": "boolean"
               },
               "priority": {
-                "description": "Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
+                "description": "Priority group of the config.\nAll configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
                 "type": "integer"
               },
               "when": {
-                "description": "Conditions for Authorino to enforce this config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
+                "description": "Conditions for Authorino to enforce this config.\nIf omitted, the config will be enforced for all requests.\nIf present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -1239,7 +1242,7 @@
                       }
                     },
                     "operator": {
-                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                       "type": "string",
                       "enum": [
                         "eq",
@@ -1254,11 +1257,11 @@
                       "type": "string"
                     },
                     "selector": {
-                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                       "type": "string"
                     },
                     "value": {
-                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                       "type": "string"
                     }
                   }
@@ -1268,31 +1271,31 @@
           }
         },
         "hosts": {
-          "description": "The list of public host names of the services protected by this authentication/authorization scheme. Authorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.",
+          "description": "The list of public host names of the services protected by this authentication/authorization scheme.\nAuthorino uses the requested host to lookup for the corresponding authentication/authorization configs to enforce.",
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "metadata": {
-          "description": "Metadata sources. Authorino fetches auth metadata as JSON from sources specified in this config.",
+          "description": "Metadata sources.\nAuthorino fetches auth metadata as JSON from sources specified in this config.",
           "type": "object",
           "additionalProperties": {
             "type": "object",
             "properties": {
               "cache": {
-                "description": "Caching options for the resolved object returned when applying this config. Omit it to avoid caching objects for this config.",
+                "description": "Caching options for the resolved object returned when applying this config.\nOmit it to avoid caching objects for this config.",
                 "type": "object",
                 "required": [
                   "key"
                 ],
                 "properties": {
                   "key": {
-                    "description": "Key used to store the entry in the cache. The resolved key must be unique within the scope of this particular config.",
+                    "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -1315,11 +1318,11 @@
                 ],
                 "properties": {
                   "body": {
-                    "description": "Raw body of the HTTP request. Supersedes 'bodyParameters'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
+                    "description": "Raw body of the HTTP request.\nSupersedes 'bodyParameters'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -1329,13 +1332,13 @@
                     }
                   },
                   "bodyParameters": {
-                    "description": "Custom parameters to encode in the body of the HTTP request. Superseded by 'body'; use either one or the other. Use it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
+                    "description": "Custom parameters to encode in the body of the HTTP request.\nSuperseded by 'body'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                     "type": "object",
                     "additionalProperties": {
                       "type": "object",
                       "properties": {
                         "selector": {
-                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
                         },
                         "value": {
@@ -1346,7 +1349,7 @@
                     }
                   },
                   "contentType": {
-                    "description": "Content-Type of the request body. Shapes how 'bodyParameters' are encoded. Use it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.",
+                    "description": "Content-Type of the request body. Shapes how 'bodyParameters' are encoded.\nUse it with method=POST; for GET requests, Content-Type is automatically set to 'text/plain'.",
                     "type": "string",
                     "enum": [
                       "application/x-www-form-urlencoded",
@@ -1354,7 +1357,7 @@
                     ]
                   },
                   "credentials": {
-                    "description": "Defines where client credentials will be passed in the request to the service. If omitted, it defaults to client credentials passed in the HTTP Authorization header and the \"Bearer\" prefix expected prepended to the secret value.",
+                    "description": "Defines where client credentials will be passed in the request to the service.\nIf omitted, it defaults to client credentials passed in the HTTP Authorization header and the \"Bearer\" prefix expected prepended to the secret value.",
                     "type": "object",
                     "properties": {
                       "authorizationHeader": {
@@ -1407,7 +1410,7 @@
                       "type": "object",
                       "properties": {
                         "selector": {
-                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                          "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
                         },
                         "value": {
@@ -1418,7 +1421,7 @@
                     }
                   },
                   "method": {
-                    "description": "HTTP verb used in the request to the service. Accepted values: GET (default), POST. When the request method is POST, the authorization JSON is passed in the body of the request.",
+                    "description": "HTTP verb used in the request to the service. Accepted values: GET (default), POST.\nWhen the request method is POST, the authorization JSON is passed in the body of the request.",
                     "type": "string",
                     "enum": [
                       "GET",
@@ -1442,7 +1445,7 @@
                     ],
                     "properties": {
                       "cache": {
-                        "description": "Caches and reuses the token until expired. Set it to false to force fetch the token at every authorization request regardless of expiration.",
+                        "description": "Caches and reuses the token until expired.\nSet it to false to force fetch the token at every authorization request regardless of expiration.",
                         "type": "boolean"
                       },
                       "clientId": {
@@ -1488,7 +1491,7 @@
                     }
                   },
                   "sharedSecretRef": {
-                    "description": "Reference to a Secret key whose value will be passed by Authorino in the request. The HTTP service can use the shared secret to authenticate the origin of the request. Ignored if used together with oauth2.",
+                    "description": "Reference to a Secret key whose value will be passed by Authorino in the request.\nThe HTTP service can use the shared secret to authenticate the origin of the request.\nIgnored if used together with oauth2.",
                     "type": "object",
                     "required": [
                       "key",
@@ -1506,7 +1509,7 @@
                     }
                   },
                   "url": {
-                    "description": "Endpoint URL of the HTTP service. The value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON. E.g. https://ext-auth-server.io/metadata?p={request.path}",
+                    "description": "Endpoint URL of the HTTP service.\nThe value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported\nby https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.\nE.g. https://ext-auth-server.io/metadata?p={request.path}",
                     "type": "string"
                   }
                 }
@@ -1516,7 +1519,7 @@
                 "type": "boolean"
               },
               "priority": {
-                "description": "Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
+                "description": "Priority group of the config.\nAll configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
                 "type": "integer"
               },
               "uma": {
@@ -1532,13 +1535,14 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                         "type": "string"
                       }
-                    }
+                    },
+                    "x-kubernetes-map-type": "atomic"
                   },
                   "endpoint": {
-                    "description": "The endpoint of the UMA server. The value must coincide with the \"issuer\" claim of the UMA config discovered from the well-known uma configuration endpoint.",
+                    "description": "The endpoint of the UMA server.\nThe value must coincide with the \"issuer\" claim of the UMA config discovered from the well-known uma configuration endpoint.",
                     "type": "string"
                   }
                 }
@@ -1557,7 +1561,7 @@
                 }
               },
               "when": {
-                "description": "Conditions for Authorino to enforce this config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
+                "description": "Conditions for Authorino to enforce this config.\nIf omitted, the config will be enforced for all requests.\nIf present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
                 "type": "array",
                 "items": {
                   "type": "object",
@@ -1577,7 +1581,7 @@
                       }
                     },
                     "operator": {
-                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                      "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                       "type": "string",
                       "enum": [
                         "eq",
@@ -1592,11 +1596,11 @@
                       "type": "string"
                     },
                     "selector": {
-                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                      "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                       "type": "string"
                     },
                     "value": {
-                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                      "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                       "type": "string"
                     }
                   }
@@ -1614,7 +1618,7 @@
               "type": "object",
               "properties": {
                 "operator": {
-                  "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                  "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                   "type": "string",
                   "enum": [
                     "eq",
@@ -1625,11 +1629,11 @@
                   ]
                 },
                 "selector": {
-                  "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                  "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                   "type": "string"
                 },
                 "value": {
-                  "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                  "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                   "type": "string"
                 }
               }
@@ -1637,33 +1641,33 @@
           }
         },
         "response": {
-          "description": "Response items. Authorino builds custom responses to the client of the auth request.",
+          "description": "Response items.\nAuthorino builds custom responses to the client of the auth request.",
           "type": "object",
           "properties": {
             "success": {
-              "description": "Response items to be included in the auth response when the request is authenticated and authorized. For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.",
+              "description": "Response items to be included in the auth response when the request is authenticated and authorized.\nFor integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata and/or inject data in the request.",
               "type": "object",
               "properties": {
                 "dynamicMetadata": {
-                  "description": "Custom success response items wrapped as HTTP headers. For integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata. See https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata",
+                  "description": "Custom success response items wrapped as HTTP headers.\nFor integration of Authorino via proxy, the proxy must use these settings to propagate dynamic metadata.\nSee https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata",
                   "type": "object",
                   "additionalProperties": {
                     "description": "Settings of the success custom response item.",
                     "type": "object",
                     "properties": {
                       "cache": {
-                        "description": "Caching options for the resolved object returned when applying this config. Omit it to avoid caching objects for this config.",
+                        "description": "Caching options for the resolved object returned when applying this config.\nOmit it to avoid caching objects for this config.",
                         "type": "object",
                         "required": [
                           "key"
                         ],
                         "properties": {
                           "key": {
-                            "description": "Key used to store the entry in the cache. The resolved key must be unique within the scope of this particular config.",
+                            "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                             "type": "object",
                             "properties": {
                               "selector": {
-                                "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                                "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                 "type": "string"
                               },
                               "value": {
@@ -1679,7 +1683,7 @@
                         }
                       },
                       "json": {
-                        "description": "JSON object Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.",
+                        "description": "JSON object\nSpecify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.",
                         "type": "object",
                         "required": [
                           "properties"
@@ -1691,7 +1695,7 @@
                               "type": "object",
                               "properties": {
                                 "selector": {
-                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
                                 },
                                 "value": {
@@ -1704,7 +1708,7 @@
                         }
                       },
                       "key": {
-                        "description": "The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object). If omitted, it will be set to the name of the response config.",
+                        "description": "The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).\nIf omitted, it will be set to the name of the response config.",
                         "type": "string"
                       },
                       "metrics": {
@@ -1716,7 +1720,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -1726,11 +1730,11 @@
                         }
                       },
                       "priority": {
-                        "description": "Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
+                        "description": "Priority group of the config.\nAll configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
                         "type": "integer"
                       },
                       "when": {
-                        "description": "Conditions for Authorino to enforce this config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
+                        "description": "Conditions for Authorino to enforce this config.\nIf omitted, the config will be enforced for all requests.\nIf present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -1750,7 +1754,7 @@
                               }
                             },
                             "operator": {
-                              "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                              "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                               "type": "string",
                               "enum": [
                                 "eq",
@@ -1765,11 +1769,11 @@
                               "type": "string"
                             },
                             "selector": {
-                              "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                              "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                               "type": "string"
                             },
                             "value": {
-                              "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                              "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                               "type": "string"
                             }
                           }
@@ -1790,7 +1794,7 @@
                               "type": "object",
                               "properties": {
                                 "selector": {
-                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
                                 },
                                 "value": {
@@ -1805,7 +1809,7 @@
                             "type": "string"
                           },
                           "signingKeyRefs": {
-                            "description": "Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.",
+                            "description": "Reference by name to Kubernetes secrets and corresponding signing algorithms.\nThe secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.",
                             "type": "array",
                             "items": {
                               "type": "object",
@@ -1827,7 +1831,7 @@
                                   ]
                                 },
                                 "name": {
-                                  "description": "Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.",
+                                  "description": "Name of the signing key.\nThe value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.",
                                   "type": "string"
                                 }
                               }
@@ -1844,24 +1848,24 @@
                   }
                 },
                 "headers": {
-                  "description": "Custom success response items wrapped as HTTP headers. For integration of Authorino via proxy, the proxy must use these settings to inject data in the request.",
+                  "description": "Custom success response items wrapped as HTTP headers.\nFor integration of Authorino via proxy, the proxy must use these settings to inject data in the request.",
                   "type": "object",
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
                       "cache": {
-                        "description": "Caching options for the resolved object returned when applying this config. Omit it to avoid caching objects for this config.",
+                        "description": "Caching options for the resolved object returned when applying this config.\nOmit it to avoid caching objects for this config.",
                         "type": "object",
                         "required": [
                           "key"
                         ],
                         "properties": {
                           "key": {
-                            "description": "Key used to store the entry in the cache. The resolved key must be unique within the scope of this particular config.",
+                            "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                             "type": "object",
                             "properties": {
                               "selector": {
-                                "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                                "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                 "type": "string"
                               },
                               "value": {
@@ -1877,7 +1881,7 @@
                         }
                       },
                       "json": {
-                        "description": "JSON object Specify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.",
+                        "description": "JSON object\nSpecify it as the list of properties of the object, whose values can combine static values and values selected from the authorization JSON.",
                         "type": "object",
                         "required": [
                           "properties"
@@ -1889,7 +1893,7 @@
                               "type": "object",
                               "properties": {
                                 "selector": {
-                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
                                 },
                                 "value": {
@@ -1902,7 +1906,7 @@
                         }
                       },
                       "key": {
-                        "description": "The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object). If omitted, it will be set to the name of the response config.",
+                        "description": "The key used to add the custom response item (name of the HTTP header or root property of the Dynamic Metadata object).\nIf omitted, it will be set to the name of the response config.",
                         "type": "string"
                       },
                       "metrics": {
@@ -1914,7 +1918,7 @@
                         "type": "object",
                         "properties": {
                           "selector": {
-                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                            "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
                           },
                           "value": {
@@ -1924,11 +1928,11 @@
                         }
                       },
                       "priority": {
-                        "description": "Priority group of the config. All configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
+                        "description": "Priority group of the config.\nAll configs in the same priority group are evaluated concurrently; consecutive priority groups are evaluated sequentially.",
                         "type": "integer"
                       },
                       "when": {
-                        "description": "Conditions for Authorino to enforce this config. If omitted, the config will be enforced for all requests. If present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
+                        "description": "Conditions for Authorino to enforce this config.\nIf omitted, the config will be enforced for all requests.\nIf present, all conditions must match for the config to be enforced; otherwise, the config will be skipped.",
                         "type": "array",
                         "items": {
                           "type": "object",
@@ -1948,7 +1952,7 @@
                               }
                             },
                             "operator": {
-                              "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                              "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                               "type": "string",
                               "enum": [
                                 "eq",
@@ -1963,11 +1967,11 @@
                               "type": "string"
                             },
                             "selector": {
-                              "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                              "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                               "type": "string"
                             },
                             "value": {
-                              "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                              "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                               "type": "string"
                             }
                           }
@@ -1988,7 +1992,7 @@
                               "type": "object",
                               "properties": {
                                 "selector": {
-                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                                  "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
                                 },
                                 "value": {
@@ -2003,7 +2007,7 @@
                             "type": "string"
                           },
                           "signingKeyRefs": {
-                            "description": "Reference by name to Kubernetes secrets and corresponding signing algorithms. The secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.",
+                            "description": "Reference by name to Kubernetes secrets and corresponding signing algorithms.\nThe secrets must contain a `key.pem` entry whose value is the signing key formatted as PEM.",
                             "type": "array",
                             "items": {
                               "type": "object",
@@ -2025,7 +2029,7 @@
                                   ]
                                 },
                                 "name": {
-                                  "description": "Name of the signing key. The value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.",
+                                  "description": "Name of the signing key.\nThe value is used to reference the Kubernetes secret that stores the key and in the `kid` claim of the wristband token header.",
                                   "type": "string"
                                 }
                               }
@@ -2044,7 +2048,7 @@
               }
             },
             "unauthenticated": {
-              "description": "Customizations on the denial status attributes when the request is unauthenticated. For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config. Default: 401 Unauthorized",
+              "description": "Customizations on the denial status attributes when the request is unauthenticated.\nFor integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.\nDefault: 401 Unauthorized",
               "type": "object",
               "properties": {
                 "body": {
@@ -2052,7 +2056,7 @@
                   "type": "object",
                   "properties": {
                     "selector": {
-                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
                     },
                     "value": {
@@ -2075,7 +2079,7 @@
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -2090,7 +2094,7 @@
                   "type": "object",
                   "properties": {
                     "selector": {
-                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
                     },
                     "value": {
@@ -2102,7 +2106,7 @@
               }
             },
             "unauthorized": {
-              "description": "Customizations on the denial status attributes when the request is unauthorized. For integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config. Default: 403 Forbidden",
+              "description": "Customizations on the denial status attributes when the request is unauthorized.\nFor integration of Authorino via proxy, the proxy must honour the response status attributes specified in this config.\nDefault: 403 Forbidden",
               "type": "object",
               "properties": {
                 "body": {
@@ -2110,7 +2114,7 @@
                   "type": "object",
                   "properties": {
                     "selector": {
-                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
                     },
                     "value": {
@@ -2133,7 +2137,7 @@
                     "type": "object",
                     "properties": {
                       "selector": {
-                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
                       },
                       "value": {
@@ -2148,7 +2152,7 @@
                   "type": "object",
                   "properties": {
                     "selector": {
-                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\"). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. The following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                      "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
                     },
                     "value": {
@@ -2162,7 +2166,7 @@
           }
         },
         "when": {
-          "description": "Overall conditions for the AuthConfig to be enforced. If omitted, the AuthConfig will be enforced at all requests. If present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns to the auth request with status OK.",
+          "description": "Overall conditions for the AuthConfig to be enforced.\nIf omitted, the AuthConfig will be enforced at all requests.\nIf present, all conditions must match for the AuthConfig to be enforced; otherwise, Authorino skips the AuthConfig and returns to the auth request with status OK.",
           "type": "array",
           "items": {
             "type": "object",
@@ -2182,7 +2186,7 @@
                 }
               },
               "operator": {
-                "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\". Possible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
+                "description": "The binary operator to be applied to the content fetched from the authorization JSON, for comparison with \"value\".\nPossible values are: \"eq\" (equal to), \"neq\" (not equal to), \"incl\" (includes; for arrays), \"excl\" (excludes; for arrays), \"matches\" (regex)",
                 "type": "string",
                 "enum": [
                   "eq",
@@ -2197,11 +2201,11 @@
                 "type": "string"
               },
               "selector": {
-                "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method'). Any pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used. Authorino custom JSON path modifiers are also supported.",
+                "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                 "type": "string"
               },
               "value": {
-                "description": "The value of reference for the comparison with the content fetched from the authorization JSON. If used with the \"matches\" operator, the value must compile to a valid Golang regex.",
+                "description": "The value of reference for the comparison with the content fetched from the authorization JSON.\nIf used with the \"matches\" operator, the value must compile to a valid Golang regex.",
                 "type": "string"
               }
             }

--- a/class_generator/schema/authlist.json
+++ b/class_generator/schema/authlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/authorino.json
+++ b/class_generator/schema/authorino.json
@@ -59,7 +59,7 @@
               "type": "integer"
             },
             "port": {
-              "description": "Port number of the GRPC interface. DEPRECATED: use 'ports.grpc' instead.",
+              "description": "Port number of the GRPC interface.\nDEPRECATED: use 'ports.grpc' instead.",
               "type": "integer",
               "format": "int32"
             },
@@ -86,14 +86,15 @@
               "type": "object",
               "properties": {
                 "certSecretRef": {
-                  "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                  "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                   "type": "object",
                   "properties": {
                     "name": {
-                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                       "type": "string"
                     }
-                  }
+                  },
+                  "x-kubernetes-map-type": "atomic"
                 },
                 "enabled": {
                   "type": "boolean"
@@ -134,14 +135,15 @@
               "type": "object",
               "properties": {
                 "certSecretRef": {
-                  "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+                  "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
                   "type": "object",
                   "properties": {
                     "name": {
-                      "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?",
+                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
                       "type": "string"
                     }
-                  }
+                  },
+                  "x-kubernetes-map-type": "atomic"
                 },
                 "enabled": {
                   "type": "boolean"
@@ -219,12 +221,12 @@
                           "type": "string"
                         },
                         "mode": {
-                          "description": "mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+                          "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
                           "type": "integer",
                           "format": "int32"
                         },
                         "path": {
-                          "description": "path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.",
+                          "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
                           "type": "string"
                         }
                       }
@@ -257,7 +259,7 @@
       "type": "object",
       "properties": {
         "conditions": {
-          "description": "Conditions is an array of the current Authorino's CR conditions Supported condition types: ConditionReady",
+          "description": "Conditions is an array of the current Authorino's CR conditions\nSupported condition types: ConditionReady",
           "type": "array",
           "items": {
             "type": "object",

--- a/class_generator/schema/clusterqueue.json
+++ b/class_generator/schema/clusterqueue.json
@@ -59,7 +59,7 @@
           }
         },
         "cohort": {
-          "description": "cohort that this ClusterQueue belongs to. CQs that belong to the\nsame cohort can borrow unused resources from each other.\n\n\nA CQ can be a member of a single borrowing cohort. A workload submitted\nto a queue referencing this CQ can borrow quota from any CQ in the cohort.\nOnly quota for the [resource, flavor] pairs listed in the CQ can be\nborrowed.\nIf empty, this ClusterQueue cannot borrow from any other ClusterQueue and\nvice versa.\n\n\nA cohort is a name that links CQs together, but it doesn't reference any\nobject.\n\n\nValidation of a cohort name is equivalent to that of object names:\nsubdomain in DNS (RFC 1123).",
+          "description": "cohort that this ClusterQueue belongs to. CQs that belong to the\nsame cohort can borrow unused resources from each other.\n\nA CQ can be a member of a single borrowing cohort. A workload submitted\nto a queue referencing this CQ can borrow quota from any CQ in the cohort.\nOnly quota for the [resource, flavor] pairs listed in the CQ can be\nborrowed.\nIf empty, this ClusterQueue cannot borrow from any other ClusterQueue and\nvice versa.\n\nA cohort is a name that links CQs together, but it doesn't reference any\nobject.\n\nValidation of a cohort name is equivalent to that of object names:\nsubdomain in DNS (RFC 1123).",
           "type": "string",
           "maxLength": 253,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
@@ -80,7 +80,7 @@
           "type": "object",
           "properties": {
             "whenCanBorrow": {
-              "description": "whenCanBorrow determines whether a workload should try the next flavor\nbefore borrowing in current flavor. The possible values are:\n\n\n- `Borrow` (default): allocate in current flavor if borrowing\n  is possible.\n- `TryNextFlavor`: try next flavor even if the current\n  flavor has enough resources to borrow.",
+              "description": "whenCanBorrow determines whether a workload should try the next flavor\nbefore borrowing in current flavor. The possible values are:\n\n- `Borrow` (default): allocate in current flavor if borrowing\n  is possible.\n- `TryNextFlavor`: try next flavor even if the current\n  flavor has enough resources to borrow.",
               "type": "string",
               "enum": [
                 "Borrow",
@@ -88,7 +88,7 @@
               ]
             },
             "whenCanPreempt": {
-              "description": "whenCanPreempt determines whether a workload should try the next flavor\nbefore borrowing in current flavor. The possible values are:\n\n\n- `Preempt`: allocate in current flavor if it's possible to preempt some workloads.\n- `TryNextFlavor` (default): try next flavor even if there are enough\n  candidates for preemption in the current flavor.",
+              "description": "whenCanPreempt determines whether a workload should try the next flavor\nbefore borrowing in current flavor. The possible values are:\n\n- `Preempt`: allocate in current flavor if it's possible to preempt some workloads.\n- `TryNextFlavor` (default): try next flavor even if there are enough\n  candidates for preemption in the current flavor.",
               "type": "string",
               "enum": [
                 "Preempt",
@@ -143,7 +143,7 @@
           "x-kubernetes-map-type": "atomic"
         },
         "preemption": {
-          "description": "preemption describes policies to preempt Workloads from this ClusterQueue\nor the ClusterQueue's cohort.\n\n\nPreemption can happen in two scenarios:\n\n\n- When a Workload fits within the nominal quota of the ClusterQueue, but\n  the quota is currently borrowed by other ClusterQueues in the cohort.\n  Preempting Workloads in other ClusterQueues allows this ClusterQueue to\n  reclaim its nominal quota.\n- When a Workload doesn't fit within the nominal quota of the ClusterQueue\n  and there are admitted Workloads in the ClusterQueue with lower priority.\n\n\nThe preemption algorithm tries to find a minimal set of Workloads to\npreempt to accomomdate the pending Workload, preempting Workloads with\nlower priority first.",
+          "description": "preemption describes policies to preempt Workloads from this ClusterQueue\nor the ClusterQueue's cohort.\n\nPreemption can happen in two scenarios:\n\n- When a Workload fits within the nominal quota of the ClusterQueue, but\n  the quota is currently borrowed by other ClusterQueues in the cohort.\n  Preempting Workloads in other ClusterQueues allows this ClusterQueue to\n  reclaim its nominal quota.\n- When a Workload doesn't fit within the nominal quota of the ClusterQueue\n  and there are admitted Workloads in the ClusterQueue with lower priority.\n\nThe preemption algorithm tries to find a minimal set of Workloads to\npreempt to accomomdate the pending Workload, preempting Workloads with\nlower priority first.",
           "type": "object",
           "properties": {
             "borrowWithinCohort": {
@@ -166,7 +166,7 @@
               }
             },
             "reclaimWithinCohort": {
-              "description": "reclaimWithinCohort determines whether a pending Workload can preempt\nWorkloads from other ClusterQueues in the cohort that are using more than\ntheir nominal quota. The possible values are:\n\n\n- `Never` (default): do not preempt Workloads in the cohort.\n- `LowerPriority`: if the pending Workload fits within the nominal\n  quota of its ClusterQueue, only preempt Workloads in the cohort that have\n  lower priority than the pending Workload.\n- `Any`: if the pending Workload fits within the nominal quota of its\n  ClusterQueue, preempt any Workload in the cohort, irrespective of\n  priority.",
+              "description": "reclaimWithinCohort determines whether a pending Workload can preempt\nWorkloads from other ClusterQueues in the cohort that are using more than\ntheir nominal quota. The possible values are:\n\n- `Never` (default): do not preempt Workloads in the cohort.\n- `LowerPriority`: **Classic Preemption** if the pending Workload\n  fits within the nominal quota of its ClusterQueue, only preempt\n  Workloads in the cohort that have lower priority than the pending\n  Workload. **Fair Sharing** only preempt Workloads in the cohort that\n  have lower priority than the pending Workload and that satisfy the\n  fair sharing preemptionStategies.\n- `Any`: **Classic Preemption** if the pending Workload fits within\n   the nominal quota of its ClusterQueue, preempt any Workload in the\n   cohort, irrespective of priority. **Fair Sharing** preempt Workloads\n   in the cohort that satisfy the fair sharing preemptionStrategies.",
               "type": "string",
               "enum": [
                 "Never",
@@ -175,7 +175,7 @@
               ]
             },
             "withinClusterQueue": {
-              "description": "withinClusterQueue determines whether a pending Workload that doesn't fit\nwithin the nominal quota for its ClusterQueue, can preempt active Workloads in\nthe ClusterQueue. The possible values are:\n\n\n- `Never` (default): do not preempt Workloads in the ClusterQueue.\n- `LowerPriority`: only preempt Workloads in the ClusterQueue that have\n  lower priority than the pending Workload.\n- `LowerOrNewerEqualPriority`: only preempt Workloads in the ClusterQueue that\n  either have a lower priority than the pending workload or equal priority\n  and are newer than the pending workload.",
+              "description": "withinClusterQueue determines whether a pending Workload that doesn't fit\nwithin the nominal quota for its ClusterQueue, can preempt active Workloads in\nthe ClusterQueue. The possible values are:\n\n- `Never` (default): do not preempt Workloads in the ClusterQueue.\n- `LowerPriority`: only preempt Workloads in the ClusterQueue that have\n  lower priority than the pending Workload.\n- `LowerOrNewerEqualPriority`: only preempt Workloads in the ClusterQueue that\n  either have a lower priority than the pending workload or equal priority\n  and are newer than the pending workload.",
               "type": "string",
               "enum": [
                 "Never",
@@ -192,7 +192,7 @@
           ]
         },
         "queueingStrategy": {
-          "description": "QueueingStrategy indicates the queueing strategy of the workloads\nacross the queues in this ClusterQueue.\nCurrent Supported Strategies:\n\n\n- StrictFIFO: workloads are ordered strictly by creation time.\nOlder workloads that can't be admitted will block admitting newer\nworkloads even if they fit available quota.\n- BestEffortFIFO: workloads are ordered by creation time,\nhowever older workloads that can't be admitted will not block\nadmitting newer workloads that fit existing quota.",
+          "description": "QueueingStrategy indicates the queueing strategy of the workloads\nacross the queues in this ClusterQueue.\nCurrent Supported Strategies:\n\n- StrictFIFO: workloads are ordered strictly by creation time.\nOlder workloads that can't be admitted will block admitting newer\nworkloads even if they fit available quota.\n- BestEffortFIFO: workloads are ordered by creation time,\nhowever older workloads that can't be admitted will not block\nadmitting newer workloads that fit existing quota.",
           "type": "string",
           "enum": [
             "StrictFIFO",
@@ -256,7 +256,7 @@
                             "x-kubernetes-int-or-string": true
                           },
                           "lendingLimit": {
-                            "description": "lendingLimit is the maximum amount of unused quota for the [flavor, resource]\ncombination that this ClusterQueue can lend to other ClusterQueues in the same cohort.\nIn total, at a given time, ClusterQueue reserves for its exclusive use\na quantity of quota equals to nominalQuota - lendingLimit.\nIf null, it means that there is no lending limit, meaning that\nall the nominalQuota can be borrowed by other clusterQueues in the cohort.\nIf not null, it must be non-negative.\nlendingLimit must be null if spec.cohort is empty.\nThis field is in alpha stage. To be able to use this field,\nenable the feature gate LendingLimit, which is disabled by default.",
+                            "description": "lendingLimit is the maximum amount of unused quota for the [flavor, resource]\ncombination that this ClusterQueue can lend to other ClusterQueues in the same cohort.\nIn total, at a given time, ClusterQueue reserves for its exclusive use\na quantity of quota equals to nominalQuota - lendingLimit.\nIf null, it means that there is no lending limit, meaning that\nall the nominalQuota can be borrowed by other clusterQueues in the cohort.\nIf not null, it must be non-negative.\nlendingLimit must be null if spec.cohort is empty.\nThis field is in beta stage and is enabled by default.",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           },
@@ -265,7 +265,7 @@
                             "type": "string"
                           },
                           "nominalQuota": {
-                            "description": "nominalQuota is the quantity of this resource that is available for\nWorkloads admitted by this ClusterQueue at a point in time.\nThe nominalQuota must be non-negative.\nnominalQuota should represent the resources in the cluster available for\nrunning jobs (after discounting resources consumed by system components\nand pods not managed by kueue). In an autoscaled cluster, nominalQuota\nshould account for resources that can be provided by a component such as\nKubernetes cluster-autoscaler.\n\n\nIf the ClusterQueue belongs to a cohort, the sum of the quotas for each\n(flavor, resource) combination defines the maximum quantity that can be\nallocated by a ClusterQueue in the cohort.",
+                            "description": "nominalQuota is the quantity of this resource that is available for\nWorkloads admitted by this ClusterQueue at a point in time.\nThe nominalQuota must be non-negative.\nnominalQuota should represent the resources in the cluster available for\nrunning jobs (after discounting resources consumed by system components\nand pods not managed by kueue). In an autoscaled cluster, nominalQuota\nshould account for resources that can be provided by a component such as\nKubernetes cluster-autoscaler.\n\nIf the ClusterQueue belongs to a cohort, the sum of the quotas for each\n(flavor, resource) combination defines the maximum quantity that can be\nallocated by a ClusterQueue in the cohort.",
                             "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                             "x-kubernetes-int-or-string": true
                           }
@@ -294,7 +294,7 @@
           "x-kubernetes-list-type": "atomic"
         },
         "stopPolicy": {
-          "description": "stopPolicy - if set to a value different from None, the ClusterQueue is considered Inactive, no new reservation being\nmade.\n\n\nDepending on its value, its associated workloads will:\n\n\n- None - Workloads are admitted\n- HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.\n- Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.",
+          "description": "stopPolicy - if set to a value different from None, the ClusterQueue is considered Inactive, no new reservation being\nmade.\n\nDepending on its value, its associated workloads will:\n\n- None - Workloads are admitted\n- HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.\n- Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.",
           "type": "string",
           "enum": [
             "None",
@@ -323,7 +323,7 @@
           "description": "conditions hold the latest available observations of the ClusterQueue\ncurrent state.",
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -366,7 +366,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
@@ -508,7 +508,7 @@
           "format": "int32"
         },
         "pendingWorkloadsStatus": {
-          "description": "PendingWorkloadsStatus contains the information exposed about the current\nstatus of the pending workloads in the cluster queue.",
+          "description": "PendingWorkloadsStatus contains the information exposed about the current\nstatus of the pending workloads in the cluster queue.\nDeprecated: This field will be removed on v1beta2, use VisibilityOnDemand\n(https://kueue.sigs.k8s.io/docs/tasks/manage/monitor_pending_workloads/pending_workloads_on_demand/)\ninstead.",
           "type": "object",
           "required": [
             "lastChangeTime"

--- a/class_generator/schema/codeflare.json
+++ b/class_generator/schema/codeflare.json
@@ -53,38 +53,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -103,17 +104,40 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -125,6 +149,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "CodeFlare name must be default-codeflare",

--- a/class_generator/schema/codeflarelist.json
+++ b/class_generator/schema/codeflarelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/cohort.json
+++ b/class_generator/schema/cohort.json
@@ -128,5 +128,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/cohortlist.json
+++ b/class_generator/schema/cohortlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/dashboard.json
+++ b/class_generator/schema/dashboard.json
@@ -54,38 +54,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,12 +105,10 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
@@ -129,6 +128,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "Dashboard name must be default-dashboard",

--- a/class_generator/schema/dashboardlist.json
+++ b/class_generator/schema/dashboardlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/datasciencecluster.json
+++ b/class_generator/schema/datasciencecluster.json
@@ -23,7 +23,7 @@
           "type": "object",
           "properties": {
             "codeflare": {
-              "description": "CodeFlare component configuration.\nIf CodeFlare Operator has been installed in the cluster, it should be uninstalled first before enabled component.",
+              "description": "CodeFlare component configuration.\nIf CodeFlare Operator has been installed in the cluster, it should be uninstalled first before enabling component.",
               "type": "object",
               "properties": {
                 "devFlags": {
@@ -107,7 +107,49 @@
               }
             },
             "datasciencepipelines": {
-              "description": "DataServicePipeline component configuration.\nRequire OpenShift Pipelines Operator to be installed before enable component",
+              "description": "DataSciencePipeline component configuration.\nRequires OpenShift Pipelines Operator to be installed before enable component",
+              "type": "object",
+              "properties": {
+                "devFlags": {
+                  "description": "Add developer fields",
+                  "type": "object",
+                  "properties": {
+                    "manifests": {
+                      "description": "List of custom manifests for the given component",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "contextDir": {
+                            "description": "contextDir is the relative path to the folder containing manifests in a repository, default value \"manifests\"",
+                            "type": "string"
+                          },
+                          "sourcePath": {
+                            "description": "sourcePath is the subpath within contextDir where kustomize builds start. Examples include any sub-folder or path: `base`, `overlays/dev`, `default`, `odh` etc.",
+                            "type": "string"
+                          },
+                          "uri": {
+                            "description": "uri is the URI point to a git repo with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                }
+              }
+            },
+            "feastoperator": {
+              "description": "Feast Operator component configuration.",
               "type": "object",
               "properties": {
                 "devFlags": {
@@ -149,7 +191,7 @@
               }
             },
             "kserve": {
-              "description": "Kserve component configuration.\nRequire OpenShift Serverless and OpenShift Service Mesh Operators to be installed before enable component\nDoes not support enabled ModelMeshServing at the same time",
+              "description": "Kserve component configuration.\nRequires OpenShift Serverless and OpenShift Service Mesh Operators to be installed before enable component\nDoes not support enabled ModelMeshServing at the same time",
               "type": "object",
               "properties": {
                 "defaultDeploymentMode": {
@@ -195,6 +237,29 @@
                   "enum": [
                     "Managed",
                     "Removed"
+                  ]
+                },
+                "nim": {
+                  "description": "Configures and enables NVIDIA NIM integration",
+                  "type": "object",
+                  "properties": {
+                    "managementState": {
+                      "type": "string",
+                      "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                      "enum": [
+                        "Managed",
+                        "Removed"
+                      ]
+                    }
+                  }
+                },
+                "rawDeploymentServiceConfig": {
+                  "description": "Configures the type of service that is created for InferenceServices using RawDeployment.\nThe values for RawDeploymentServiceConfig can be \"Headless\" or \"Headed\".\nHeadless : sets \"ServiceClusterIPNone = true\" in the 'inferenceservice-config' configmap for Kserve.\nHeaded : sets \"ServiceClusterIPNone = false\" in the 'inferenceservice-config' configmap for Kserve.",
+                  "type": "string",
+                  "pattern": "^(Headless|Headed)$",
+                  "enum": [
+                    "Headless",
+                    "Headed"
                   ]
                 },
                 "serving": {
@@ -550,6 +615,12 @@
                     "Managed",
                     "Removed"
                   ]
+                },
+                "workbenchNamespace": {
+                  "description": "Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to \"rhods-notebooks\"",
+                  "type": "string",
+                  "maxLength": 63,
+                  "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
                 }
               }
             }
@@ -565,11 +636,474 @@
           "description": "Expose component's specific status",
           "type": "object",
           "properties": {
-            "modelregistry": {
-              "description": "ModelRegistry component status",
+            "codeflare": {
+              "description": "CodeFlare component status.",
               "type": "object",
               "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "dashboard": {
+              "description": "Dashboard component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            },
+            "datasciencepipelines": {
+              "description": "DataSciencePipeline component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "feastoperator": {
+              "description": "Feast Operator component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "kserve": {
+              "description": "Kserve component status.",
+              "type": "object",
+              "properties": {
+                "defaultDeploymentMode": {
+                  "description": "DefaultDeploymentMode is the value of the defaultDeploymentMode field\nas read from the \"deploy\" JSON in the inferenceservice-config ConfigMap",
+                  "type": "string"
+                },
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "serverlessMode": {
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$"
+                }
+              }
+            },
+            "kueue": {
+              "description": "Kueue component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "modelmeshserving": {
+              "description": "ModelMeshServing component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "modelregistry": {
+              "description": "ModelRegistry component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
                 "registriesNamespace": {
+                  "type": "string"
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "ray": {
+              "description": "Ray component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "trainingoperator": {
+              "description": "Training Operator component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "trustyai": {
+              "description": "TrustyAI component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                }
+              }
+            },
+            "workbenches": {
+              "description": "Workbenches component status.",
+              "type": "object",
+              "properties": {
+                "managementState": {
+                  "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
+                  "type": "string",
+                  "pattern": "^(Managed|Unmanaged|Force|Removed)$",
+                  "enum": [
+                    "Managed",
+                    "Removed"
+                  ]
+                },
+                "releases": {
+                  "type": "array",
+                  "items": {
+                    "description": "ComponentRelease represents the detailed status of a component release.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "repoUrl": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "workbenchNamespace": {
                   "type": "string"
                 }
               }
@@ -577,10 +1111,8 @@
           }
         },
         "conditions": {
-          "description": "Conditions describes the state of the DataScienceCluster resource.",
           "type": "array",
           "items": {
-            "description": "Condition represents the state of the operator's\nreconciliation functionality.",
             "type": "object",
             "required": [
               "status",
@@ -588,28 +1120,51 @@
             ],
             "properties": {
               "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
                 "type": "string",
                 "format": "date-time"
               },
               "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
+                "description": "message is a human-readable message indicating details about the transition.",
                 "type": "string"
               },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
               "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
                 "type": "string"
               },
               "status": {
-                "type": "string"
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
               },
               "type": {
-                "description": "ConditionType is the state of the operator's reconciliation functionality.",
-                "type": "string"
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
               }
             }
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
         "errorMessage": {
           "type": "string"
@@ -621,8 +1176,12 @@
             "type": "boolean"
           }
         },
+        "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
+          "type": "integer",
+          "format": "int64"
+        },
         "phase": {
-          "description": "Phase describes the Phase of DataScienceCluster reconciliation state\nThis is used by OLM UI to provide status information to the user",
           "type": "string"
         },
         "relatedObjects": {

--- a/class_generator/schema/datasciencepipelines.json
+++ b/class_generator/schema/datasciencepipelines.json
@@ -54,38 +54,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,17 +105,40 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -126,6 +150,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "DataSciencePipelines name must be default-datasciencepipelines",

--- a/class_generator/schema/datasciencepipelinesapplication.json
+++ b/class_generator/schema/datasciencepipelinesapplication.json
@@ -24,17 +24,19 @@
           "type": "object",
           "properties": {
             "applyTektonCustomResource": {
-              "description": "Default: true Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: true\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "boolean"
             },
             "archiveLogs": {
-              "description": "Default: false Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: false\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "boolean"
             },
             "argoDriverImage": {
+              "description": "Driver image used during pipeline execution.",
               "type": "string"
             },
             "argoLauncherImage": {
+              "description": "Launcher/Executor image used during pipeline execution.",
               "type": "string"
             },
             "artifactImage": {
@@ -54,15 +56,15 @@
               }
             },
             "artifactSignedURLExpirySeconds": {
-              "description": "The expiry time (seconds) for artifact download links when querying the dsp server via /apis/v2beta1/artifacts/{id}?share_url=true Default: 60",
+              "description": "The expiry time (seconds) for artifact download links when\nquerying the dsp server via /apis/v2beta1/artifacts/{id}?share_url=true\nDefault: 60",
               "type": "integer"
             },
             "autoUpdatePipelineDefaultVersion": {
-              "description": "Default: true Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: true\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "boolean"
             },
             "cABundle": {
-              "description": "If the Object store/DB is behind a TLS secured connection that is unrecognized by the host OpenShift/K8s cluster, then you can provide a PEM formatted CA bundle to be injected into the DSP server pod to trust this connection. CA Bundle should be provided as values within configmaps, mapped to keys.",
+              "description": "If the Object store/DB is behind a TLS secured connection that is\nunrecognized by the host OpenShift/K8s cluster, then you can\nprovide a PEM formatted CA bundle to be injected into the DSP\nserver pod to trust this connection. CA Bundle should be provided\nas values within configmaps, mapped to keys.",
               "type": "object",
               "required": [
                 "configMapKey",
@@ -70,7 +72,7 @@
               ],
               "properties": {
                 "configMapKey": {
-                  "description": "Key should map to a CA bundle. The key is also used to name the CA bundle file (e.g. ca-bundle.crt)",
+                  "description": "Key should map to a CA bundle. The key is also used to name\nthe CA bundle file (e.g. ca-bundle.crt)",
                   "type": "string"
                 },
                 "configMapName": {
@@ -79,11 +81,11 @@
               }
             },
             "caBundleFileMountPath": {
-              "description": "This is the path where the ca bundle will be mounted in the pipeline server and user executor pods",
+              "description": "This is the path where the ca bundle will be mounted in the\npipeline server and user executor pods",
               "type": "string"
             },
             "caBundleFileName": {
-              "description": "This is the filename of the ca bundle that will be created in the pipeline server and user executor pods",
+              "description": "This is the filename of the ca bundle that will be created in the\npipeline server and user executor pods",
               "type": "string"
             },
             "cacheImage": {
@@ -91,15 +93,15 @@
               "type": "string"
             },
             "collectMetrics": {
-              "description": "Default: true Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: true\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "boolean"
             },
             "customKfpLauncherConfigMap": {
-              "description": "When specified, the `data` contents of the `kfp-launcher` ConfigMap that DSPO writes will be fully replaced with the `data` contents of the ConfigMap specified here. This allows the user to fully replace the `data` contents of the kfp-launcher ConfigMap. The `kfp-launcher` component requires a ConfigMap to exist in the namespace where it runs (i.e. the namespace where pipelines run). This ConfigMap contains object storage configuration, as well as pipeline root (object store root path where artifacts will be uploaded) configuration. Currently this ConfigMap *must* be named \"kfp-launcher\". We currently deploy a default copy of the kfp-launcher ConfigMap via DSPO, but a user may want to provide their own ConfigMap configuration, so that they can specify multiple object storage sources and paths.",
+              "description": "When specified, the `data` contents of the `kfp-launcher` ConfigMap that DSPO writes\nwill be fully replaced with the `data` contents of the ConfigMap specified here.\nThis allows the user to fully replace the `data` contents of the kfp-launcher ConfigMap.\nThe `kfp-launcher` component requires a ConfigMap to exist in the namespace\nwhere it runs (i.e. the namespace where pipelines run). This ConfigMap contains\nobject storage configuration, as well as pipeline root (object store root path\nwhere artifacts will be uploaded) configuration. Currently this ConfigMap *must*\nbe named \"kfp-launcher\". We currently deploy a default copy of the kfp-launcher\nConfigMap via DSPO, but a user may want to provide their own ConfigMap configuration,\nso that they can specify multiple object storage sources and paths.",
               "type": "string"
             },
             "customServerConfigMap": {
-              "description": "CustomServerConfig is a custom config file that you can provide for the api server to use instead.",
+              "description": "CustomServerConfig is a custom config file that you can provide\nfor the api server to use instead.",
               "type": "object",
               "properties": {
                 "key": {
@@ -111,7 +113,7 @@
               }
             },
             "dbConfigConMaxLifetimeSec": {
-              "description": "Default: 120 Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: 120\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "integer"
             },
             "deploy": {
@@ -123,19 +125,72 @@
               "type": "boolean"
             },
             "enableSamplePipeline": {
-              "description": "Include sample pipelines with the deployment of this DSP API Server. Default: true",
+              "description": "Include the Iris sample pipeline with the deployment of this DSP API Server. Default: true",
               "type": "boolean"
             },
             "image": {
               "description": "Specify a custom image for DSP API Server.",
               "type": "string"
             },
+            "initResources": {
+              "description": "Specify init container resource requirements. The init container\nis used to build managed-pipelines and store them in a shared volume.",
+              "type": "object",
+              "properties": {
+                "limits": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "memory": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  }
+                },
+                "requests": {
+                  "type": "object",
+                  "properties": {
+                    "cpu": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "memory": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  }
+                }
+              }
+            },
             "injectDefaultScript": {
-              "description": "Inject the archive step script. Default: true Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Inject the archive step script. Default: true\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "boolean"
             },
+            "managedPipelines": {
+              "description": "Enable various managed pipelines on this DSP API server.",
+              "type": "object",
+              "properties": {
+                "instructLab": {
+                  "description": "Configures whether to automatically import the InstructLab pipeline.\nYou must enable the trainingoperator component to run the InstructLab pipeline.",
+                  "type": "object",
+                  "properties": {
+                    "state": {
+                      "description": "Set to one of the following values:\n\n- \"Managed\" : This pipeline is automatically imported.\n- \"Removed\" : This pipeline is not automatically imported. If previously set to \"Managed\", setting to \"Removed\" does not remove existing managed pipelines but does prevent future updates from being imported.\t//",
+                      "type": "string",
+                      "pattern": "^(Managed|Removed)$",
+                      "enum": [
+                        "Managed",
+                        "Removed"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
             "moveResultsImage": {
-              "description": "Image used for internal artifact passing handling within Tekton taskruns. This field specifies the image used in the 'move-all-results-to-tekton-home' step. Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Image used for internal artifact passing handling within Tekton taskruns. This field specifies the image used in the 'move-all-results-to-tekton-home' step.\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "string"
             },
             "resources": {
@@ -170,12 +225,20 @@
                 }
               }
             },
+            "rhelAIImage": {
+              "description": "RhelAI image used for ilab tasks in managed pipelines.",
+              "type": "string"
+            },
+            "runtimeGenericImage": {
+              "description": "Generic runtime image used for building managed pipelines during\napi server init, and for basic runtime operations.",
+              "type": "string"
+            },
             "stripEOF": {
-              "description": "Default: true Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: true\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "boolean"
             },
             "terminateStatus": {
-              "description": "Default: \"Cancelled\" - Allowed Values: \"Cancelled\", \"StoppedRunFinally\", \"CancelledRunFinally\" Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: \"Cancelled\" - Allowed Values: \"Cancelled\", \"StoppedRunFinally\", \"CancelledRunFinally\"\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "string",
               "enum": [
                 "Cancelled",
@@ -183,8 +246,12 @@
                 "CancelledRunFinally"
               ]
             },
+            "toolboxImage": {
+              "description": "Toolbox image used for basic container spec runtime operations\nin managed pipelines.",
+              "type": "string"
+            },
             "trackArtifacts": {
-              "description": "Default: true Deprecated: DSP V1 only, will be removed in the future.",
+              "description": "Default: true\nDeprecated: DSP V1 only, will be removed in the future.",
               "type": "boolean"
             }
           }
@@ -194,7 +261,7 @@
           "type": "object",
           "properties": {
             "customExtraParams": {
-              "description": "CustomExtraParams allow users to further customize the sql dsn parameters used by the Pipeline Server when opening a connection with the Database. ref: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#dsn-data-source-name \n Value must be a JSON string. For example, to disable tls for Pipeline Server DB connection the user can provide a string: {\"tls\":\"true\"} \n If updating post DSPA deployment, then a manual restart of the pipeline server pod will be required so the new configmap may be consumed.",
+              "description": "CustomExtraParams allow users to further customize the sql dsn parameters used by the Pipeline Server\nwhen opening a connection with the Database.\nref: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#dsn-data-source-name\n\nValue must be a JSON string. For example, to disable tls for Pipeline Server DB connection\nthe user can provide a string: {\"tls\":\"true\"}\n\nIf updating post DSPA deployment, then a manual restart of the pipeline server pod will be required\nso the new configmap may be consumed.",
               "type": "string"
             },
             "disableHealthCheck": {
@@ -341,7 +408,7 @@
                   "type": "string"
                 },
                 "resources": {
-                  "description": "ResourceRequirements structures compute resource requirements. Replaces ResourceRequirements from corev1 which also includes optional storage field. We handle storage field separately, and should not include it as a subfield for Resources.",
+                  "description": "ResourceRequirements structures compute resource requirements.\nReplaces ResourceRequirements from corev1 which also includes optional storage field.\nWe handle storage field separately, and should not include it as a subfield for Resources.",
                   "type": "object",
                   "properties": {
                     "limits": {
@@ -384,7 +451,7 @@
                   "type": "string"
                 },
                 "resources": {
-                  "description": "ResourceRequirements structures compute resource requirements. Replaces ResourceRequirements from corev1 which also includes optional storage field. We handle storage field separately, and should not include it as a subfield for Resources.",
+                  "description": "ResourceRequirements structures compute resource requirements.\nReplaces ResourceRequirements from corev1 which also includes optional storage field.\nWe handle storage field separately, and should not include it as a subfield for Resources.",
                   "type": "object",
                   "properties": {
                     "limits": {
@@ -428,7 +495,7 @@
                   "type": "string"
                 },
                 "resources": {
-                  "description": "ResourceRequirements structures compute resource requirements. Replaces ResourceRequirements from corev1 which also includes optional storage field. We handle storage field separately, and should not include it as a subfield for Resources.",
+                  "description": "ResourceRequirements structures compute resource requirements.\nReplaces ResourceRequirements from corev1 which also includes optional storage field.\nWe handle storage field separately, and should not include it as a subfield for Resources.",
                   "type": "object",
                   "properties": {
                     "limits": {
@@ -856,7 +923,7 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -867,23 +934,23 @@
             ],
             "properties": {
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
                 "type": "string",
                 "maxLength": 32768
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
                 "type": "string",
                 "maxLength": 1024,
                 "minLength": 1,
@@ -899,7 +966,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"

--- a/class_generator/schema/datasciencepipelineslist.json
+++ b/class_generator/schema/datasciencepipelineslist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/dscinitialization.json
+++ b/class_generator/schema/dscinitialization.json
@@ -17,9 +17,6 @@
     "spec": {
       "description": "DSCInitializationSpec defines the desired state of DSCInitialization.",
       "type": "object",
-      "required": [
-        "applicationsNamespace"
-      ],
       "properties": {
         "applicationsNamespace": {
           "description": "Namespace for applications to be installed, non-configurable, default to \"redhat-ods-applications\"",
@@ -37,7 +34,12 @@
           "description": "Internal development useful field to test customizations.\nThis is not recommended to be used in production environment.",
           "type": "object",
           "properties": {
+            "logLevel": {
+              "description": "Override Zap log level. Can be \"debug\", \"info\", \"error\" or a number (more verbose).",
+              "type": "string"
+            },
             "logmode": {
+              "description": "## DEPRECATED ##: Ignored, use LogLevel instead",
               "type": "string",
               "enum": [
                 "devel",
@@ -48,7 +50,7 @@
               ]
             },
             "manifestsUri": {
-              "description": "Custom manifests uri for odh-manifests",
+              "description": "## DEPRECATED ## : ManifestsUri set on DSCI is not maintained.\nCustom manifests uri for odh-manifests",
               "type": "string"
             }
           }
@@ -58,7 +60,7 @@
           "type": "object",
           "properties": {
             "managementState": {
-              "description": "Set to one of the following values:\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so.\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it.",
+              "description": "Set to one of the following values:\n\n- \"Managed\" : the operator is actively managing the component and trying to keep it active.\n              It will only upgrade the component if it is safe to do so\n\n- \"Removed\" : the operator is actively managing the component and will not install it,\n              or if it is installed, the operator will try to remove it",
               "type": "string",
               "pattern": "^(Managed|Unmanaged|Force|Removed)$",
               "enum": [
@@ -67,10 +69,16 @@
               ]
             },
             "namespace": {
-              "description": "Namespace for monitoring if it is enabled",
+              "description": "monitoring spec exposed to DSCI api\nNamespace for monitoring if it is enabled",
               "type": "string",
               "maxLength": 63,
-              "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
+              "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$",
+              "x-kubernetes-validations": [
+                {
+                  "message": "MonitoringNamespace is immutable",
+                  "rule": "self == oldSelf"
+                }
+              ]
             }
           }
         },

--- a/class_generator/schema/feastoperator.json
+++ b/class_generator/schema/feastoperator.json
@@ -150,6 +150,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "FeastOperator name must be 'default-feastoperator'",

--- a/class_generator/schema/feastoperatorlist.json
+++ b/class_generator/schema/feastoperatorlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/featurestore.json
+++ b/class_generator/schema/featurestore.json
@@ -1,0 +1,7768 @@
+{
+  "description": "FeatureStore is the Schema for the featurestores API",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
+    "spec": {
+      "description": "FeatureStoreSpec defines the desired state of FeatureStore",
+      "type": "object",
+      "required": [
+        "feastProject"
+      ],
+      "properties": {
+        "authz": {
+          "description": "AuthzConfig defines the authorization settings for the deployed Feast services.",
+          "type": "object",
+          "properties": {
+            "kubernetes": {
+              "description": "KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.\nhttps://kubernetes.",
+              "type": "object",
+              "properties": {
+                "roles": {
+                  "description": "The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "oidc": {
+              "description": "OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.\nhttps://auth0.",
+              "type": "object",
+              "required": [
+                "secretRef"
+              ],
+              "properties": {
+                "secretRef": {
+                  "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                }
+              }
+            }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "One selection required between kubernetes or oidc.",
+              "rule": "[has(self.kubernetes), has(self.oidc)].exists_one(c, c)"
+            }
+          ]
+        },
+        "cronJob": {
+          "description": "FeastCronJob defines a CronJob to execute against a Feature Store deployment.",
+          "type": "object",
+          "properties": {
+            "concurrencyPolicy": {
+              "description": "Specifies how to treat concurrent executions of a Job.",
+              "type": "string"
+            },
+            "containerConfigs": {
+              "description": "CronJobContainerConfigs k8s container settings for the CronJob",
+              "type": "object",
+              "properties": {
+                "commands": {
+                  "description": "Array of commands to be executed (in order) against a Feature Store deployment.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "env": {
+                  "type": "array",
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "type": "object",
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                            "type": "object",
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                            "type": "object",
+                            "required": [
+                              "resource"
+                            ],
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "envFrom": {
+                  "type": "array",
+                  "items": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                    "type": "object",
+                    "properties": {
+                      "configMapRef": {
+                        "description": "The ConfigMap to select from",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "prefix": {
+                        "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "The Secret to select from",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    }
+                  }
+                },
+                "image": {
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "PullPolicy describes a policy for if/when to pull a container image",
+                  "type": "string"
+                },
+                "resources": {
+                  "description": "ResourceRequirements describes the compute resource requirements.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "failedJobsHistoryLimit": {
+              "description": "The number of failed finished jobs to retain. Value must be non-negative integer.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "jobSpec": {
+              "description": "Specification of the desired behavior of a job.",
+              "type": "object",
+              "properties": {
+                "activeDeadlineSeconds": {
+                  "description": "Specifies the duration in seconds relative to the startTime that the job\nmay be continuously active before the system tr",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "backoffLimit": {
+                  "description": "Specifies the number of retries before marking this job failed.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "backoffLimitPerIndex": {
+                  "description": "Specifies the limit for the number of retries within an\nindex before marking this index as failed.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "completionMode": {
+                  "description": "completionMode specifies how Pod completions are tracked. It can be\n`NonIndexed` (default) or `Indexed`.",
+                  "type": "string"
+                },
+                "completions": {
+                  "description": "Specifies the desired number of successfully finished pods the\njob should be run with.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "maxFailedIndexes": {
+                  "description": "Specifies the maximal number of failed indexes before marking the Job as\nfailed, when backoffLimitPerIndex is set.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "parallelism": {
+                  "description": "Specifies the maximum desired number of pods the job should\nrun at any given time.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "podFailurePolicy": {
+                  "description": "Specifies the policy of handling failed pods.",
+                  "type": "object",
+                  "required": [
+                    "rules"
+                  ],
+                  "properties": {
+                    "rules": {
+                      "description": "A list of pod failure policy rules. The rules are evaluated in order.",
+                      "type": "array",
+                      "items": {
+                        "description": "PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.",
+                        "type": "object",
+                        "required": [
+                          "action"
+                        ],
+                        "properties": {
+                          "action": {
+                            "description": "Specifies the action taken on a pod failure when the requirements are satisfied.",
+                            "type": "string"
+                          },
+                          "onExitCodes": {
+                            "description": "Represents the requirement on the container exit codes.",
+                            "type": "object",
+                            "required": [
+                              "operator",
+                              "values"
+                            ],
+                            "properties": {
+                              "containerName": {
+                                "description": "Restricts the check for exit codes to the container with the\nspecified name.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "Represents the relationship between the container exit code(s) and the\nspecified values.",
+                                "type": "string"
+                              },
+                              "values": {
+                                "description": "Specifies the set of values.",
+                                "type": "array",
+                                "items": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "x-kubernetes-list-type": "set"
+                              }
+                            }
+                          },
+                          "onPodConditions": {
+                            "description": "Represents the requirement on the pod conditions. The requirement is represented\nas a list of pod condition patterns.",
+                            "type": "array",
+                            "items": {
+                              "description": "PodFailurePolicyOnPodConditionsPattern describes a pattern for matching\nan actual pod condition type.",
+                              "type": "object",
+                              "required": [
+                                "status",
+                                "type"
+                              ],
+                              "properties": {
+                                "status": {
+                                  "description": "Specifies the required Pod condition status.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "description": "Specifies the required Pod condition type.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                },
+                "podReplacementPolicy": {
+                  "description": "podReplacementPolicy specifies when to create replacement Pods.",
+                  "type": "string"
+                },
+                "suspend": {
+                  "description": "suspend specifies whether the Job controller should create Pods or not.",
+                  "type": "boolean"
+                },
+                "ttlSecondsAfterFinished": {
+                  "description": "ttlSecondsAfterFinished limits the lifetime of a Job that has finished\nexecution (either Complete or Failed).",
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "schedule": {
+              "description": "The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
+              "type": "string"
+            },
+            "startingDeadlineSeconds": {
+              "description": "Optional deadline in seconds for starting the job if it misses scheduled\ntime for any reason.",
+              "type": "integer",
+              "format": "int64"
+            },
+            "successfulJobsHistoryLimit": {
+              "description": "The number of successful finished jobs to retain. Value must be non-negative integer.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "suspend": {
+              "description": "This flag tells the controller to suspend subsequent executions, it does\nnot apply to already started executions.",
+              "type": "boolean"
+            },
+            "timeZone": {
+              "description": "The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.",
+              "type": "string"
+            }
+          }
+        },
+        "feastProject": {
+          "description": "FeastProject is the Feast project id.",
+          "type": "string",
+          "pattern": "^[A-Za-z0-9][A-Za-z0-9_]*$"
+        },
+        "feastProjectDir": {
+          "description": "FeastProjectDir defines how to create the feast project directory.",
+          "type": "object",
+          "properties": {
+            "git": {
+              "description": "GitCloneOptions describes how a clone should be performed.",
+              "type": "object",
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "configs": {
+                  "description": "Configs passed to git via `-c`\ne.g. http.sslVerify: 'false'\nOR 'url.\"https://api:\\${TOKEN}@github.com/\".",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "env": {
+                  "type": "array",
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "type": "object",
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                            "type": "object",
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                            "type": "object",
+                            "required": [
+                              "resource"
+                            ],
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "envFrom": {
+                  "type": "array",
+                  "items": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                    "type": "object",
+                    "properties": {
+                      "configMapRef": {
+                        "description": "The ConfigMap to select from",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "prefix": {
+                        "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "The Secret to select from",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    }
+                  }
+                },
+                "featureRepoPath": {
+                  "description": "FeatureRepoPath is the relative path to the feature repo subdirectory. Default is 'feature_repo'.",
+                  "type": "string"
+                },
+                "ref": {
+                  "description": "Reference to a branch / tag / commit",
+                  "type": "string"
+                },
+                "url": {
+                  "description": "The repository URL to clone from.",
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "RepoPath must be a file name only, with no slashes.",
+                  "rule": "has(self.featureRepoPath) ? !self.featureRepoPath.startsWith('/') : true"
+                }
+              ]
+            },
+            "init": {
+              "description": "FeastInitOptions defines how to run a `feast init`.",
+              "type": "object",
+              "properties": {
+                "minimal": {
+                  "type": "boolean"
+                },
+                "template": {
+                  "description": "Template for the created project",
+                  "type": "string",
+                  "enum": [
+                    "local",
+                    "gcp",
+                    "aws",
+                    "snowflake",
+                    "spark",
+                    "postgres",
+                    "hbase",
+                    "cassandra",
+                    "hazelcast",
+                    "ikv",
+                    "couchbase"
+                  ]
+                }
+              }
+            }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "One selection required between init or git.",
+              "rule": "[has(self.git), has(self.init)].exists_one(c, c)"
+            }
+          ]
+        },
+        "services": {
+          "description": "FeatureStoreServices defines the desired feast services. An ephemeral onlineStore feature server is deployed by default.",
+          "type": "object",
+          "properties": {
+            "deploymentStrategy": {
+              "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+              "type": "object",
+              "properties": {
+                "rollingUpdate": {
+                  "description": "Rolling update config params. Present only if DeploymentStrategyType =\nRollingUpdate.",
+                  "type": "object",
+                  "properties": {
+                    "maxSurge": {
+                      "description": "The maximum number of pods that can be scheduled above the desired number of\npods.",
+                      "x-kubernetes-int-or-string": true
+                    },
+                    "maxUnavailable": {
+                      "description": "The maximum number of pods that can be unavailable during the update.",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  }
+                },
+                "type": {
+                  "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+                  "type": "string"
+                }
+              }
+            },
+            "disableInitContainers": {
+              "description": "Disable the 'feast repo initialization' initContainer",
+              "type": "boolean"
+            },
+            "offlineStore": {
+              "description": "OfflineStore configures the offline store service",
+              "type": "object",
+              "properties": {
+                "persistence": {
+                  "description": "OfflineStorePersistence configures the persistence settings for the offline store service",
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "description": "OfflineStoreFilePersistence configures the file-based persistence for the offline store service",
+                      "type": "object",
+                      "properties": {
+                        "pvc": {
+                          "description": "PvcConfig defines the settings for a persistent file store based on PVCs.",
+                          "type": "object",
+                          "required": [
+                            "mountPath"
+                          ],
+                          "properties": {
+                            "create": {
+                              "description": "Settings for creating a new PVC",
+                              "type": "object",
+                              "properties": {
+                                "accessModes": {
+                                  "description": "AccessModes k8s persistent volume access modes. Defaults to [\"ReadWriteOnce\"].",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "resources": {
+                                  "description": "Resources describes the storage resource requirements for a volume.",
+                                  "type": "object",
+                                  "properties": {
+                                    "limits": {
+                                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "requests": {
+                                      "description": "Requests describes the minimum amount of compute resources required.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                },
+                                "storageClassName": {
+                                  "description": "StorageClassName is the name of an existing StorageClass to which this persistent volume belongs.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "PvcCreate is immutable",
+                                  "rule": "self == oldSelf"
+                                }
+                              ]
+                            },
+                            "mountPath": {
+                              "description": "MountPath within the container at which the volume should be mounted.\nMust start by \"/\" and cannot contain ':'.",
+                              "type": "string"
+                            },
+                            "ref": {
+                              "description": "Reference to an existing field",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "One selection is required between ref and create.",
+                              "rule": "[has(self.ref), has(self.create)].exists_one(c, c)"
+                            },
+                            {
+                              "message": "Mount path must start with '/' and must not contain ':'",
+                              "rule": "self.mountPath.matches('^/[^:]*$')"
+                            }
+                          ]
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "file",
+                            "dask",
+                            "duckdb"
+                          ]
+                        }
+                      }
+                    },
+                    "store": {
+                      "description": "OfflineStoreDBStorePersistence configures the DB store persistence for the offline store service",
+                      "type": "object",
+                      "required": [
+                        "secretRef",
+                        "type"
+                      ],
+                      "properties": {
+                        "secretKeyName": {
+                          "description": "By default, the selected store \"type\" is used as the SecretKeyName",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Data store parameters should be placed as-is from the \"feature_store.yaml\" under the secret key.",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "type": {
+                          "description": "Type of the persistence type you want to use.",
+                          "type": "string",
+                          "enum": [
+                            "snowflake.offline",
+                            "bigquery",
+                            "redshift",
+                            "spark",
+                            "postgres",
+                            "trino",
+                            "athena",
+                            "mssql",
+                            "couchbase.offline"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "One selection required between file or store.",
+                      "rule": "[has(self.file), has(self.store)].exists_one(c, c)"
+                    }
+                  ]
+                },
+                "server": {
+                  "description": "Creates a remote offline server container",
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                            "type": "string"
+                          },
+                          "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                            "type": "object",
+                            "properties": {
+                              "configMapKeyRef": {
+                                "description": "Selects a key of a ConfigMap.",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key to select.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "fieldRef": {
+                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                "type": "object",
+                                "required": [
+                                  "fieldPath"
+                                ],
+                                "properties": {
+                                  "apiVersion": {
+                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "description": "Path of the field to select in the specified API version.",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                "type": "object",
+                                "required": [
+                                  "resource"
+                                ],
+                                "properties": {
+                                  "containerName": {
+                                    "description": "Container name: required for volumes, optional for env vars",
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "resource": {
+                                    "description": "Required: resource to select",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envFrom": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                        "type": "object",
+                        "properties": {
+                          "configMapRef": {
+                            "description": "The ConfigMap to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "prefix": {
+                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "The Secret to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "imagePullPolicy": {
+                      "description": "PullPolicy describes a policy for if/when to pull a container image",
+                      "type": "string"
+                    },
+                    "logLevel": {
+                      "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                      "type": "string",
+                      "enum": [
+                        "debug",
+                        "info",
+                        "warning",
+                        "error",
+                        "critical"
+                      ]
+                    },
+                    "resources": {
+                      "description": "ResourceRequirements describes the compute resource requirements.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "tls": {
+                      "description": "TlsConfigs configures server TLS for a feast service.",
+                      "type": "object",
+                      "properties": {
+                        "disable": {
+                          "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                          "type": "boolean"
+                        },
+                        "secretKeyNames": {
+                          "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                          "type": "object",
+                          "properties": {
+                            "tlsCrt": {
+                              "description": "defaults to \"tls.crt\"",
+                              "type": "string"
+                            },
+                            "tlsKey": {
+                              "description": "defaults to \"tls.key\"",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "secretRef": {
+                          "description": "references the local k8s secret where the TLS key and cert reside",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "`secretRef` required if `disable` is false.",
+                          "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                        }
+                      ]
+                    },
+                    "volumeMounts": {
+                      "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                      "type": "array",
+                      "items": {
+                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                        "type": "object",
+                        "required": [
+                          "mountPath",
+                          "name"
+                        ],
+                        "properties": {
+                          "mountPath": {
+                            "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                            "type": "string"
+                          },
+                          "mountPropagation": {
+                            "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "This must match the Name of a Volume.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "recursiveReadOnly": {
+                            "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                            "type": "string"
+                          },
+                          "subPath": {
+                            "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                            "type": "string"
+                          },
+                          "subPathExpr": {
+                            "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "onlineStore": {
+              "description": "OnlineStore configures the online store service",
+              "type": "object",
+              "properties": {
+                "persistence": {
+                  "description": "OnlineStorePersistence configures the persistence settings for the online store service",
+                  "type": "object",
+                  "properties": {
+                    "file": {
+                      "description": "OnlineStoreFilePersistence configures the file-based persistence for the online store service",
+                      "type": "object",
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        },
+                        "pvc": {
+                          "description": "PvcConfig defines the settings for a persistent file store based on PVCs.",
+                          "type": "object",
+                          "required": [
+                            "mountPath"
+                          ],
+                          "properties": {
+                            "create": {
+                              "description": "Settings for creating a new PVC",
+                              "type": "object",
+                              "properties": {
+                                "accessModes": {
+                                  "description": "AccessModes k8s persistent volume access modes. Defaults to [\"ReadWriteOnce\"].",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                },
+                                "resources": {
+                                  "description": "Resources describes the storage resource requirements for a volume.",
+                                  "type": "object",
+                                  "properties": {
+                                    "limits": {
+                                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    },
+                                    "requests": {
+                                      "description": "Requests describes the minimum amount of compute resources required.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      }
+                                    }
+                                  }
+                                },
+                                "storageClassName": {
+                                  "description": "StorageClassName is the name of an existing StorageClass to which this persistent volume belongs.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "PvcCreate is immutable",
+                                  "rule": "self == oldSelf"
+                                }
+                              ]
+                            },
+                            "mountPath": {
+                              "description": "MountPath within the container at which the volume should be mounted.\nMust start by \"/\" and cannot contain ':'.",
+                              "type": "string"
+                            },
+                            "ref": {
+                              "description": "Reference to an existing field",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "One selection is required between ref and create.",
+                              "rule": "[has(self.ref), has(self.create)].exists_one(c, c)"
+                            },
+                            {
+                              "message": "Mount path must start with '/' and must not contain ':'",
+                              "rule": "self.mountPath.matches('^/[^:]*$')"
+                            }
+                          ]
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "Ephemeral stores must have absolute paths.",
+                          "rule": "(!has(self.pvc) && has(self.path)) ? self.path.startsWith('/') : true"
+                        },
+                        {
+                          "message": "PVC path must be a file name only, with no slashes.",
+                          "rule": "(has(self.pvc) && has(self.path)) ? !self.path.startsWith('/') : true"
+                        },
+                        {
+                          "message": "Online store does not support S3 or GS buckets.",
+                          "rule": "has(self.path) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true"
+                        }
+                      ]
+                    },
+                    "store": {
+                      "description": "OnlineStoreDBStorePersistence configures the DB store persistence for the online store service",
+                      "type": "object",
+                      "required": [
+                        "secretRef",
+                        "type"
+                      ],
+                      "properties": {
+                        "secretKeyName": {
+                          "description": "By default, the selected store \"type\" is used as the SecretKeyName",
+                          "type": "string"
+                        },
+                        "secretRef": {
+                          "description": "Data store parameters should be placed as-is from the \"feature_store.yaml\" under the secret key.",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "type": {
+                          "description": "Type of the persistence type you want to use.",
+                          "type": "string",
+                          "enum": [
+                            "snowflake.online",
+                            "redis",
+                            "ikv",
+                            "datastore",
+                            "dynamodb",
+                            "bigtable",
+                            "postgres",
+                            "cassandra",
+                            "mysql",
+                            "hazelcast",
+                            "singlestore",
+                            "hbase",
+                            "elasticsearch",
+                            "qdrant",
+                            "couchbase.online",
+                            "milvus"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "One selection required between file or store.",
+                      "rule": "[has(self.file), has(self.store)].exists_one(c, c)"
+                    }
+                  ]
+                },
+                "server": {
+                  "description": "Creates a feature server container",
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                            "type": "string"
+                          },
+                          "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                            "type": "object",
+                            "properties": {
+                              "configMapKeyRef": {
+                                "description": "Selects a key of a ConfigMap.",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key to select.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "fieldRef": {
+                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                "type": "object",
+                                "required": [
+                                  "fieldPath"
+                                ],
+                                "properties": {
+                                  "apiVersion": {
+                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "description": "Path of the field to select in the specified API version.",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                "type": "object",
+                                "required": [
+                                  "resource"
+                                ],
+                                "properties": {
+                                  "containerName": {
+                                    "description": "Container name: required for volumes, optional for env vars",
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "resource": {
+                                    "description": "Required: resource to select",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envFrom": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                        "type": "object",
+                        "properties": {
+                          "configMapRef": {
+                            "description": "The ConfigMap to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "prefix": {
+                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "The Secret to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "imagePullPolicy": {
+                      "description": "PullPolicy describes a policy for if/when to pull a container image",
+                      "type": "string"
+                    },
+                    "logLevel": {
+                      "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                      "type": "string",
+                      "enum": [
+                        "debug",
+                        "info",
+                        "warning",
+                        "error",
+                        "critical"
+                      ]
+                    },
+                    "resources": {
+                      "description": "ResourceRequirements describes the compute resource requirements.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "tls": {
+                      "description": "TlsConfigs configures server TLS for a feast service.",
+                      "type": "object",
+                      "properties": {
+                        "disable": {
+                          "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                          "type": "boolean"
+                        },
+                        "secretKeyNames": {
+                          "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                          "type": "object",
+                          "properties": {
+                            "tlsCrt": {
+                              "description": "defaults to \"tls.crt\"",
+                              "type": "string"
+                            },
+                            "tlsKey": {
+                              "description": "defaults to \"tls.key\"",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "secretRef": {
+                          "description": "references the local k8s secret where the TLS key and cert reside",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "`secretRef` required if `disable` is false.",
+                          "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                        }
+                      ]
+                    },
+                    "volumeMounts": {
+                      "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                      "type": "array",
+                      "items": {
+                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                        "type": "object",
+                        "required": [
+                          "mountPath",
+                          "name"
+                        ],
+                        "properties": {
+                          "mountPath": {
+                            "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                            "type": "string"
+                          },
+                          "mountPropagation": {
+                            "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "This must match the Name of a Volume.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "recursiveReadOnly": {
+                            "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                            "type": "string"
+                          },
+                          "subPath": {
+                            "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                            "type": "string"
+                          },
+                          "subPathExpr": {
+                            "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "registry": {
+              "description": "Registry configures the registry service. One selection is required. Local is the default setting.",
+              "type": "object",
+              "properties": {
+                "local": {
+                  "description": "LocalRegistryConfig configures the registry service",
+                  "type": "object",
+                  "properties": {
+                    "persistence": {
+                      "description": "RegistryPersistence configures the persistence settings for the registry service",
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "description": "RegistryFilePersistence configures the file-based persistence for the registry service",
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "type": "string"
+                            },
+                            "pvc": {
+                              "description": "PvcConfig defines the settings for a persistent file store based on PVCs.",
+                              "type": "object",
+                              "required": [
+                                "mountPath"
+                              ],
+                              "properties": {
+                                "create": {
+                                  "description": "Settings for creating a new PVC",
+                                  "type": "object",
+                                  "properties": {
+                                    "accessModes": {
+                                      "description": "AccessModes k8s persistent volume access modes. Defaults to [\"ReadWriteOnce\"].",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "resources": {
+                                      "description": "Resources describes the storage resource requirements for a volume.",
+                                      "type": "object",
+                                      "properties": {
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "storageClassName": {
+                                      "description": "StorageClassName is the name of an existing StorageClass to which this persistent volume belongs.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "PvcCreate is immutable",
+                                      "rule": "self == oldSelf"
+                                    }
+                                  ]
+                                },
+                                "mountPath": {
+                                  "description": "MountPath within the container at which the volume should be mounted.\nMust start by \"/\" and cannot contain ':'.",
+                                  "type": "string"
+                                },
+                                "ref": {
+                                  "description": "Reference to an existing field",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "One selection is required between ref and create.",
+                                  "rule": "[has(self.ref), has(self.create)].exists_one(c, c)"
+                                },
+                                {
+                                  "message": "Mount path must start with '/' and must not contain ':'",
+                                  "rule": "self.mountPath.matches('^/[^:]*$')"
+                                }
+                              ]
+                            },
+                            "s3_additional_kwargs": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Registry files must use absolute paths or be S3 ('s3://') or GS ('gs://') object store URIs.",
+                              "rule": "(!has(self.pvc) && has(self.path)) ? (self.path.startsWith('/') || self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true"
+                            },
+                            {
+                              "message": "PVC path must be a file name only, with no slashes.",
+                              "rule": "(has(self.pvc) && has(self.path)) ? !self.path.startsWith('/') : true"
+                            },
+                            {
+                              "message": "PVC persistence does not support S3 or GS object store URIs.",
+                              "rule": "(has(self.pvc) && has(self.path)) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true"
+                            },
+                            {
+                              "message": "Additional S3 settings are available only for S3 object store URIs.",
+                              "rule": "(has(self.s3_additional_kwargs) && has(self.path)) ? self.path.startsWith('s3://') : true"
+                            }
+                          ]
+                        },
+                        "store": {
+                          "description": "RegistryDBStorePersistence configures the DB store persistence for the registry service",
+                          "type": "object",
+                          "required": [
+                            "secretRef",
+                            "type"
+                          ],
+                          "properties": {
+                            "secretKeyName": {
+                              "description": "By default, the selected store \"type\" is used as the SecretKeyName",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "Data store parameters should be placed as-is from the \"feature_store.yaml\" under the secret key.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "type": {
+                              "description": "Type of the persistence type you want to use.",
+                              "type": "string",
+                              "enum": [
+                                "sql",
+                                "snowflake.registry"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "One selection required between file or store.",
+                          "rule": "[has(self.file), has(self.store)].exists_one(c, c)"
+                        }
+                      ]
+                    },
+                    "server": {
+                      "description": "Creates a registry server container",
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "array",
+                          "items": {
+                            "description": "EnvVar represents an environment variable present in a Container.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                "type": "object",
+                                "properties": {
+                                  "configMapKeyRef": {
+                                    "description": "Selects a key of a ConfigMap.",
+                                    "type": "object",
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to select.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "fieldRef": {
+                                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                    "type": "object",
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                    "type": "object",
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "type": "object",
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "envFrom": {
+                          "type": "array",
+                          "items": {
+                            "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                            "type": "object",
+                            "properties": {
+                              "configMapRef": {
+                                "description": "The ConfigMap to select from",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "prefix": {
+                                "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "description": "The Secret to select from",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imagePullPolicy": {
+                          "description": "PullPolicy describes a policy for if/when to pull a container image",
+                          "type": "string"
+                        },
+                        "logLevel": {
+                          "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                          "type": "string",
+                          "enum": [
+                            "debug",
+                            "info",
+                            "warning",
+                            "error",
+                            "critical"
+                          ]
+                        },
+                        "resources": {
+                          "description": "ResourceRequirements describes the compute resource requirements.",
+                          "type": "object",
+                          "properties": {
+                            "claims": {
+                              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                              "type": "array",
+                              "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "limits": {
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "requests": {
+                              "description": "Requests describes the minimum amount of compute resources required.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          }
+                        },
+                        "tls": {
+                          "description": "TlsConfigs configures server TLS for a feast service.",
+                          "type": "object",
+                          "properties": {
+                            "disable": {
+                              "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                              "type": "boolean"
+                            },
+                            "secretKeyNames": {
+                              "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                              "type": "object",
+                              "properties": {
+                                "tlsCrt": {
+                                  "description": "defaults to \"tls.crt\"",
+                                  "type": "string"
+                                },
+                                "tlsKey": {
+                                  "description": "defaults to \"tls.key\"",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "secretRef": {
+                              "description": "references the local k8s secret where the TLS key and cert reside",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "`secretRef` required if `disable` is false.",
+                              "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                            }
+                          ]
+                        },
+                        "volumeMounts": {
+                          "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                          "type": "array",
+                          "items": {
+                            "description": "VolumeMount describes a mounting of a Volume within a container.",
+                            "type": "object",
+                            "required": [
+                              "mountPath",
+                              "name"
+                            ],
+                            "properties": {
+                              "mountPath": {
+                                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                "type": "string"
+                              },
+                              "mountPropagation": {
+                                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "This must match the Name of a Volume.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                                "type": "string"
+                              },
+                              "subPath": {
+                                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                "type": "string"
+                              },
+                              "subPathExpr": {
+                                "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "remote": {
+                  "description": "RemoteRegistryConfig points to a remote feast registry server.",
+                  "type": "object",
+                  "properties": {
+                    "feastRef": {
+                      "description": "Reference to an existing `FeatureStore` CR in the same k8s cluster.",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "name": {
+                          "description": "Name of the FeatureStore",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace of the FeatureStore",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "hostname": {
+                      "description": "Host address of the remote registry service - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`",
+                      "type": "string"
+                    },
+                    "tls": {
+                      "description": "TlsRemoteRegistryConfigs configures client TLS for a remote feast registry.",
+                      "type": "object",
+                      "required": [
+                        "certName",
+                        "configMapRef"
+                      ],
+                      "properties": {
+                        "certName": {
+                          "description": "defines the configmap key name for the client TLS cert.",
+                          "type": "string"
+                        },
+                        "configMapRef": {
+                          "description": "references the local k8s configmap where the TLS cert resides",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      }
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "One selection required.",
+                      "rule": "[has(self.hostname), has(self.feastRef)].exists_one(c, c)"
+                    }
+                  ]
+                }
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "One selection required.",
+                  "rule": "[has(self.local), has(self.remote)].exists_one(c, c)"
+                }
+              ]
+            },
+            "ui": {
+              "description": "Creates a UI server container",
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "array",
+                  "items": {
+                    "description": "EnvVar represents an environment variable present in a Container.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                        "type": "string"
+                      },
+                      "valueFrom": {
+                        "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                        "type": "object",
+                        "properties": {
+                          "configMapKeyRef": {
+                            "description": "Selects a key of a ConfigMap.",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key to select.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "fieldRef": {
+                            "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                            "type": "object",
+                            "required": [
+                              "fieldPath"
+                            ],
+                            "properties": {
+                              "apiVersion": {
+                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                "type": "string"
+                              },
+                              "fieldPath": {
+                                "description": "Path of the field to select in the specified API version.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "resourceFieldRef": {
+                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                            "type": "object",
+                            "required": [
+                              "resource"
+                            ],
+                            "properties": {
+                              "containerName": {
+                                "description": "Container name: required for volumes, optional for env vars",
+                                "type": "string"
+                              },
+                              "divisor": {
+                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              },
+                              "resource": {
+                                "description": "Required: resource to select",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "secretKeyRef": {
+                            "description": "Selects a key of a secret in the pod's namespace",
+                            "type": "object",
+                            "required": [
+                              "key"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret or its key must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "envFrom": {
+                  "type": "array",
+                  "items": {
+                    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                    "type": "object",
+                    "properties": {
+                      "configMapRef": {
+                        "description": "The ConfigMap to select from",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "prefix": {
+                        "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "The Secret to select from",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    }
+                  }
+                },
+                "image": {
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "PullPolicy describes a policy for if/when to pull a container image",
+                  "type": "string"
+                },
+                "logLevel": {
+                  "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                  "type": "string",
+                  "enum": [
+                    "debug",
+                    "info",
+                    "warning",
+                    "error",
+                    "critical"
+                  ]
+                },
+                "resources": {
+                  "description": "ResourceRequirements describes the compute resource requirements.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "tls": {
+                  "description": "TlsConfigs configures server TLS for a feast service.",
+                  "type": "object",
+                  "properties": {
+                    "disable": {
+                      "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                      "type": "boolean"
+                    },
+                    "secretKeyNames": {
+                      "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                      "type": "object",
+                      "properties": {
+                        "tlsCrt": {
+                          "description": "defaults to \"tls.crt\"",
+                          "type": "string"
+                        },
+                        "tlsKey": {
+                          "description": "defaults to \"tls.key\"",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "secretRef": {
+                      "description": "references the local k8s secret where the TLS key and cert reside",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                          "type": "string"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "`secretRef` required if `disable` is false.",
+                      "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                    }
+                  ]
+                },
+                "volumeMounts": {
+                  "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                  "type": "array",
+                  "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                    "type": "object",
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "properties": {
+                      "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "This must match the Name of a Volume.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "recursiveReadOnly": {
+                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                        "type": "string"
+                      },
+                      "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "volumes": {
+              "description": "Volumes specifies the volumes to mount in the FeatureStore deployment.",
+              "type": "array",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to th",
+                    "type": "object",
+                    "required": [
+                      "volumeID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "readOnly": {
+                        "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "azureDisk": {
+                    "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                    "type": "object",
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "properties": {
+                      "cachingMode": {
+                        "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "diskName is the Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "diskURI is the URI of data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage accoun",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "azureFile": {
+                    "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                    "type": "object",
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "properties": {
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "shareName is the azure share Name",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "cephfs": {
+                    "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                    "type": "object",
+                    "required": [
+                      "monitors"
+                    ],
+                    "properties": {
+                      "monitors": {
+                        "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "user": {
+                        "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "cinder": {
+                    "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.",
+                    "type": "object",
+                    "required": [
+                      "volumeID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "volumeID": {
+                        "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "configMap": {
+                    "description": "configMap represents a configMap that should populate this volume",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "defaultMode is optional: mode bits used to set permissions on created files by default.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "items": {
+                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volum",
+                        "type": "array",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "path": {
+                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "name": {
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "optional specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "csi": {
+                    "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta fea",
+                    "type": "object",
+                    "required": [
+                      "driver"
+                    ],
+                    "properties": {
+                      "driver": {
+                        "description": "driver is the name of the CSI driver that handles this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to c",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "readOnly": {
+                        "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "downwardAPI": {
+                    "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "type": "array",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "type": "object",
+                          "required": [
+                            "path"
+                          ],
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                              "type": "object",
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal valu",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path.",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.",
+                              "type": "object",
+                              "required": [
+                                "resource"
+                              ],
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    }
+                  },
+                  "emptyDir": {
+                    "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.",
+                    "type": "object",
+                    "properties": {
+                      "medium": {
+                        "description": "medium represents what type of storage medium should back this directory.",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  },
+                  "ephemeral": {
+                    "description": "ephemeral represents a volume that is handled by a cluster storage driver.",
+                    "type": "object",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume.",
+                        "type": "object",
+                        "required": [
+                          "spec"
+                        ],
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim.",
+                            "type": "object",
+                            "properties": {
+                              "accessModes": {
+                                "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "dataSource": {
+                                "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.",
+                                "type": "object",
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "dataSourceRef": {
+                                "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired.",
+                                "type": "object",
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "resources": {
+                                "description": "resources represents the minimum resources the volume should have.",
+                                "type": "object",
+                                "properties": {
+                                  "limits": {
+                                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "requests": {
+                                    "description": "Requests describes the minimum amount of compute resources required.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                }
+                              },
+                              "selector": {
+                                "description": "selector is a label query over volumes to consider for binding.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "storageClassName": {
+                                "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.",
+                                "type": "string"
+                              },
+                              "volumeAttributesClassName": {
+                                "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "fc": {
+                    "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "type": "object",
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "lun is Optional: FC target lun number",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "readOnly": {
+                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "wwids": {
+                        "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, ",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    }
+                  },
+                  "flexVolume": {
+                    "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.",
+                    "type": "object",
+                    "required": [
+                      "driver"
+                    ],
+                    "properties": {
+                      "driver": {
+                        "description": "driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "description": "options is Optional: this field holds extra command options if any.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "readOnly": {
+                        "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugi",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    }
+                  },
+                  "flocker": {
+                    "description": "flocker represents a Flocker volume attached to a kubelet's host machine.",
+                    "type": "object",
+                    "properties": {
+                      "datasetName": {
+                        "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as depreca",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "gcePersistentDisk": {
+                    "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the po",
+                    "type": "object",
+                    "required": [
+                      "pdName"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is filesystem type of the volume that you want to mount.",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "pdName": {
+                        "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "gitRepo": {
+                    "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated.",
+                    "type": "object",
+                    "required": [
+                      "repository"
+                    ],
+                    "properties": {
+                      "directory": {
+                        "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "repository is the URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "revision is the commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "glusterfs": {
+                    "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.",
+                    "type": "object",
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "properties": {
+                      "endpoints": {
+                        "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "hostPath": {
+                    "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container.",
+                    "type": "object",
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "iscsi": {
+                    "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.",
+                    "type": "object",
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "initiatorName is the custom iSCSI Initiator Name.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "iqn is the target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "lun represents iSCSI Target Lun number.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "portals": {
+                        "description": "portals is the iSCSI Target Portal List.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "targetPortal": {
+                        "description": "targetPortal is iSCSI Target Portal.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "name": {
+                    "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.",
+                    "type": "object",
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "properties": {
+                      "path": {
+                        "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.",
+                    "type": "object",
+                    "required": [
+                      "claimName"
+                    ],
+                    "properties": {
+                      "claimName": {
+                        "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "photonPersistentDisk": {
+                    "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                    "type": "object",
+                    "required": [
+                      "pdID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "portworxVolume": {
+                    "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                    "type": "object",
+                    "required": [
+                      "volumeID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "volumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "projected": {
+                    "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "defaultMode are the mode bits used to set permissions on created files by default.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "sources": {
+                        "description": "sources is the list of volume projections",
+                        "type": "array",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types",
+                          "type": "object",
+                          "properties": {
+                            "clusterTrustBundle": {
+                              "description": "ClusterTrustBundle allows a pod to access the `.spec.",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "labelSelector": {
+                                  "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.",
+                                  "type": "object",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty.",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "description": "matchLabels is a map of {key,value} pairs.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "name": {
+                                  "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.",
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "description": "Relative path from the volume root to write the bundle.",
+                                  "type": "string"
+                                },
+                                "signerName": {
+                                  "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "configMap": {
+                              "description": "configMap information about the configMap data to project",
+                              "type": "object",
+                              "properties": {
+                                "items": {
+                                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volum",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "type": "object",
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "downwardAPI": {
+                              "description": "downwardAPI information about the downwardAPI data to project",
+                              "type": "object",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "type": "object",
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                        "type": "object",
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal valu",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path.",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.",
+                                        "type": "object",
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "secret": {
+                              "description": "secret information about the secret data to project",
+                              "type": "object",
+                              "properties": {
+                                "items": {
+                                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume a",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "type": "object",
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "optional field specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "serviceAccountToken": {
+                              "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "audience": {
+                                  "description": "audience is the intended audience of the token.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "expirationSeconds is the requested duration of validity of the service\naccount token.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "path": {
+                                  "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    }
+                  },
+                  "quobyte": {
+                    "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                    "type": "object",
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "properties": {
+                      "group": {
+                        "description": "group to map volume access to\nDefault is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple ent",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "user to map volume access to\nDefaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "rbd": {
+                    "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.",
+                    "type": "object",
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "pool": {
+                        "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "user": {
+                        "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "scaleIO": {
+                    "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                    "type": "object",
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "gateway is the host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "sslEnabled": {
+                        "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "system is the name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "secret": {
+                    "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "items": {
+                        "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume a",
+                        "type": "array",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "path": {
+                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "optional": {
+                        "description": "optional field specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storageos": {
+                    "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                    "type": "object",
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "volumeName": {
+                        "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "volumeNamespace specifies the scope of the volume within StorageOS.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "vsphereVolume": {
+                    "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                    "type": "object",
+                    "required": [
+                      "volumePath"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "volumePath is the path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "FeatureStoreStatus defines the observed state of FeatureStore",
+      "type": "object",
+      "properties": {
+        "applied": {
+          "description": "Shows the currently applied feast configuration, including any pertinent defaults",
+          "type": "object",
+          "required": [
+            "feastProject"
+          ],
+          "properties": {
+            "authz": {
+              "description": "AuthzConfig defines the authorization settings for the deployed Feast services.",
+              "type": "object",
+              "properties": {
+                "kubernetes": {
+                  "description": "KubernetesAuthz provides a way to define the authorization settings using Kubernetes RBAC resources.\nhttps://kubernetes.",
+                  "type": "object",
+                  "properties": {
+                    "roles": {
+                      "description": "The Kubernetes RBAC roles to be deployed in the same namespace of the FeatureStore.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "oidc": {
+                  "description": "OidcAuthz defines the authorization settings for deployments using an Open ID Connect identity provider.\nhttps://auth0.",
+                  "type": "object",
+                  "required": [
+                    "secretRef"
+                  ],
+                  "properties": {
+                    "secretRef": {
+                      "description": "LocalObjectReference contains enough information to let you locate the\nreferenced object inside the same namespace.",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                          "type": "string"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    }
+                  }
+                }
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "One selection required between kubernetes or oidc.",
+                  "rule": "[has(self.kubernetes), has(self.oidc)].exists_one(c, c)"
+                }
+              ]
+            },
+            "cronJob": {
+              "description": "FeastCronJob defines a CronJob to execute against a Feature Store deployment.",
+              "type": "object",
+              "properties": {
+                "concurrencyPolicy": {
+                  "description": "Specifies how to treat concurrent executions of a Job.",
+                  "type": "string"
+                },
+                "containerConfigs": {
+                  "description": "CronJobContainerConfigs k8s container settings for the CronJob",
+                  "type": "object",
+                  "properties": {
+                    "commands": {
+                      "description": "Array of commands to be executed (in order) against a Feature Store deployment.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "env": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                            "type": "string"
+                          },
+                          "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                            "type": "object",
+                            "properties": {
+                              "configMapKeyRef": {
+                                "description": "Selects a key of a ConfigMap.",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key to select.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "fieldRef": {
+                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                "type": "object",
+                                "required": [
+                                  "fieldPath"
+                                ],
+                                "properties": {
+                                  "apiVersion": {
+                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "description": "Path of the field to select in the specified API version.",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                "type": "object",
+                                "required": [
+                                  "resource"
+                                ],
+                                "properties": {
+                                  "containerName": {
+                                    "description": "Container name: required for volumes, optional for env vars",
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "resource": {
+                                    "description": "Required: resource to select",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envFrom": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                        "type": "object",
+                        "properties": {
+                          "configMapRef": {
+                            "description": "The ConfigMap to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "prefix": {
+                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "The Secret to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "imagePullPolicy": {
+                      "description": "PullPolicy describes a policy for if/when to pull a container image",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "ResourceRequirements describes the compute resource requirements.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "failedJobsHistoryLimit": {
+                  "description": "The number of failed finished jobs to retain. Value must be non-negative integer.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "jobSpec": {
+                  "description": "Specification of the desired behavior of a job.",
+                  "type": "object",
+                  "properties": {
+                    "activeDeadlineSeconds": {
+                      "description": "Specifies the duration in seconds relative to the startTime that the job\nmay be continuously active before the system tr",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "backoffLimit": {
+                      "description": "Specifies the number of retries before marking this job failed.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "backoffLimitPerIndex": {
+                      "description": "Specifies the limit for the number of retries within an\nindex before marking this index as failed.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "completionMode": {
+                      "description": "completionMode specifies how Pod completions are tracked. It can be\n`NonIndexed` (default) or `Indexed`.",
+                      "type": "string"
+                    },
+                    "completions": {
+                      "description": "Specifies the desired number of successfully finished pods the\njob should be run with.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "maxFailedIndexes": {
+                      "description": "Specifies the maximal number of failed indexes before marking the Job as\nfailed, when backoffLimitPerIndex is set.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "parallelism": {
+                      "description": "Specifies the maximum desired number of pods the job should\nrun at any given time.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "podFailurePolicy": {
+                      "description": "Specifies the policy of handling failed pods.",
+                      "type": "object",
+                      "required": [
+                        "rules"
+                      ],
+                      "properties": {
+                        "rules": {
+                          "description": "A list of pod failure policy rules. The rules are evaluated in order.",
+                          "type": "array",
+                          "items": {
+                            "description": "PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.",
+                            "type": "object",
+                            "required": [
+                              "action"
+                            ],
+                            "properties": {
+                              "action": {
+                                "description": "Specifies the action taken on a pod failure when the requirements are satisfied.",
+                                "type": "string"
+                              },
+                              "onExitCodes": {
+                                "description": "Represents the requirement on the container exit codes.",
+                                "type": "object",
+                                "required": [
+                                  "operator",
+                                  "values"
+                                ],
+                                "properties": {
+                                  "containerName": {
+                                    "description": "Restricts the check for exit codes to the container with the\nspecified name.",
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "description": "Represents the relationship between the container exit code(s) and the\nspecified values.",
+                                    "type": "string"
+                                  },
+                                  "values": {
+                                    "description": "Specifies the set of values.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "integer",
+                                      "format": "int32"
+                                    },
+                                    "x-kubernetes-list-type": "set"
+                                  }
+                                }
+                              },
+                              "onPodConditions": {
+                                "description": "Represents the requirement on the pod conditions. The requirement is represented\nas a list of pod condition patterns.",
+                                "type": "array",
+                                "items": {
+                                  "description": "PodFailurePolicyOnPodConditionsPattern describes a pattern for matching\nan actual pod condition type.",
+                                  "type": "object",
+                                  "required": [
+                                    "status",
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "status": {
+                                      "description": "Specifies the required Pod condition status.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "Specifies the required Pod condition type.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    },
+                    "podReplacementPolicy": {
+                      "description": "podReplacementPolicy specifies when to create replacement Pods.",
+                      "type": "string"
+                    },
+                    "suspend": {
+                      "description": "suspend specifies whether the Job controller should create Pods or not.",
+                      "type": "boolean"
+                    },
+                    "ttlSecondsAfterFinished": {
+                      "description": "ttlSecondsAfterFinished limits the lifetime of a Job that has finished\nexecution (either Complete or Failed).",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "schedule": {
+                  "description": "The schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
+                  "type": "string"
+                },
+                "startingDeadlineSeconds": {
+                  "description": "Optional deadline in seconds for starting the job if it misses scheduled\ntime for any reason.",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "successfulJobsHistoryLimit": {
+                  "description": "The number of successful finished jobs to retain. Value must be non-negative integer.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "suspend": {
+                  "description": "This flag tells the controller to suspend subsequent executions, it does\nnot apply to already started executions.",
+                  "type": "boolean"
+                },
+                "timeZone": {
+                  "description": "The time zone name for the given schedule, see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones.",
+                  "type": "string"
+                }
+              }
+            },
+            "feastProject": {
+              "description": "FeastProject is the Feast project id.",
+              "type": "string",
+              "pattern": "^[A-Za-z0-9][A-Za-z0-9_]*$"
+            },
+            "feastProjectDir": {
+              "description": "FeastProjectDir defines how to create the feast project directory.",
+              "type": "object",
+              "properties": {
+                "git": {
+                  "description": "GitCloneOptions describes how a clone should be performed.",
+                  "type": "object",
+                  "required": [
+                    "url"
+                  ],
+                  "properties": {
+                    "configs": {
+                      "description": "Configs passed to git via `-c`\ne.g. http.sslVerify: 'false'\nOR 'url.\"https://api:\\${TOKEN}@github.com/\".",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "env": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                            "type": "string"
+                          },
+                          "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                            "type": "object",
+                            "properties": {
+                              "configMapKeyRef": {
+                                "description": "Selects a key of a ConfigMap.",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key to select.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "fieldRef": {
+                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                "type": "object",
+                                "required": [
+                                  "fieldPath"
+                                ],
+                                "properties": {
+                                  "apiVersion": {
+                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "description": "Path of the field to select in the specified API version.",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                "type": "object",
+                                "required": [
+                                  "resource"
+                                ],
+                                "properties": {
+                                  "containerName": {
+                                    "description": "Container name: required for volumes, optional for env vars",
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "resource": {
+                                    "description": "Required: resource to select",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envFrom": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                        "type": "object",
+                        "properties": {
+                          "configMapRef": {
+                            "description": "The ConfigMap to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "prefix": {
+                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "The Secret to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    },
+                    "featureRepoPath": {
+                      "description": "FeatureRepoPath is the relative path to the feature repo subdirectory. Default is 'feature_repo'.",
+                      "type": "string"
+                    },
+                    "ref": {
+                      "description": "Reference to a branch / tag / commit",
+                      "type": "string"
+                    },
+                    "url": {
+                      "description": "The repository URL to clone from.",
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "RepoPath must be a file name only, with no slashes.",
+                      "rule": "has(self.featureRepoPath) ? !self.featureRepoPath.startsWith('/') : true"
+                    }
+                  ]
+                },
+                "init": {
+                  "description": "FeastInitOptions defines how to run a `feast init`.",
+                  "type": "object",
+                  "properties": {
+                    "minimal": {
+                      "type": "boolean"
+                    },
+                    "template": {
+                      "description": "Template for the created project",
+                      "type": "string",
+                      "enum": [
+                        "local",
+                        "gcp",
+                        "aws",
+                        "snowflake",
+                        "spark",
+                        "postgres",
+                        "hbase",
+                        "cassandra",
+                        "hazelcast",
+                        "ikv",
+                        "couchbase"
+                      ]
+                    }
+                  }
+                }
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "One selection required between init or git.",
+                  "rule": "[has(self.git), has(self.init)].exists_one(c, c)"
+                }
+              ]
+            },
+            "services": {
+              "description": "FeatureStoreServices defines the desired feast services. An ephemeral onlineStore feature server is deployed by default.",
+              "type": "object",
+              "properties": {
+                "deploymentStrategy": {
+                  "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+                  "type": "object",
+                  "properties": {
+                    "rollingUpdate": {
+                      "description": "Rolling update config params. Present only if DeploymentStrategyType =\nRollingUpdate.",
+                      "type": "object",
+                      "properties": {
+                        "maxSurge": {
+                          "description": "The maximum number of pods that can be scheduled above the desired number of\npods.",
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "maxUnavailable": {
+                          "description": "The maximum number of pods that can be unavailable during the update.",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
+                    },
+                    "type": {
+                      "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "disableInitContainers": {
+                  "description": "Disable the 'feast repo initialization' initContainer",
+                  "type": "boolean"
+                },
+                "offlineStore": {
+                  "description": "OfflineStore configures the offline store service",
+                  "type": "object",
+                  "properties": {
+                    "persistence": {
+                      "description": "OfflineStorePersistence configures the persistence settings for the offline store service",
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "description": "OfflineStoreFilePersistence configures the file-based persistence for the offline store service",
+                          "type": "object",
+                          "properties": {
+                            "pvc": {
+                              "description": "PvcConfig defines the settings for a persistent file store based on PVCs.",
+                              "type": "object",
+                              "required": [
+                                "mountPath"
+                              ],
+                              "properties": {
+                                "create": {
+                                  "description": "Settings for creating a new PVC",
+                                  "type": "object",
+                                  "properties": {
+                                    "accessModes": {
+                                      "description": "AccessModes k8s persistent volume access modes. Defaults to [\"ReadWriteOnce\"].",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "resources": {
+                                      "description": "Resources describes the storage resource requirements for a volume.",
+                                      "type": "object",
+                                      "properties": {
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "storageClassName": {
+                                      "description": "StorageClassName is the name of an existing StorageClass to which this persistent volume belongs.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "PvcCreate is immutable",
+                                      "rule": "self == oldSelf"
+                                    }
+                                  ]
+                                },
+                                "mountPath": {
+                                  "description": "MountPath within the container at which the volume should be mounted.\nMust start by \"/\" and cannot contain ':'.",
+                                  "type": "string"
+                                },
+                                "ref": {
+                                  "description": "Reference to an existing field",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "One selection is required between ref and create.",
+                                  "rule": "[has(self.ref), has(self.create)].exists_one(c, c)"
+                                },
+                                {
+                                  "message": "Mount path must start with '/' and must not contain ':'",
+                                  "rule": "self.mountPath.matches('^/[^:]*$')"
+                                }
+                              ]
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
+                                "file",
+                                "dask",
+                                "duckdb"
+                              ]
+                            }
+                          }
+                        },
+                        "store": {
+                          "description": "OfflineStoreDBStorePersistence configures the DB store persistence for the offline store service",
+                          "type": "object",
+                          "required": [
+                            "secretRef",
+                            "type"
+                          ],
+                          "properties": {
+                            "secretKeyName": {
+                              "description": "By default, the selected store \"type\" is used as the SecretKeyName",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "Data store parameters should be placed as-is from the \"feature_store.yaml\" under the secret key.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "type": {
+                              "description": "Type of the persistence type you want to use.",
+                              "type": "string",
+                              "enum": [
+                                "snowflake.offline",
+                                "bigquery",
+                                "redshift",
+                                "spark",
+                                "postgres",
+                                "trino",
+                                "athena",
+                                "mssql",
+                                "couchbase.offline"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "One selection required between file or store.",
+                          "rule": "[has(self.file), has(self.store)].exists_one(c, c)"
+                        }
+                      ]
+                    },
+                    "server": {
+                      "description": "Creates a remote offline server container",
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "array",
+                          "items": {
+                            "description": "EnvVar represents an environment variable present in a Container.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                "type": "object",
+                                "properties": {
+                                  "configMapKeyRef": {
+                                    "description": "Selects a key of a ConfigMap.",
+                                    "type": "object",
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to select.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "fieldRef": {
+                                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                    "type": "object",
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                    "type": "object",
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "type": "object",
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "envFrom": {
+                          "type": "array",
+                          "items": {
+                            "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                            "type": "object",
+                            "properties": {
+                              "configMapRef": {
+                                "description": "The ConfigMap to select from",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "prefix": {
+                                "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "description": "The Secret to select from",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imagePullPolicy": {
+                          "description": "PullPolicy describes a policy for if/when to pull a container image",
+                          "type": "string"
+                        },
+                        "logLevel": {
+                          "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                          "type": "string",
+                          "enum": [
+                            "debug",
+                            "info",
+                            "warning",
+                            "error",
+                            "critical"
+                          ]
+                        },
+                        "resources": {
+                          "description": "ResourceRequirements describes the compute resource requirements.",
+                          "type": "object",
+                          "properties": {
+                            "claims": {
+                              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                              "type": "array",
+                              "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "limits": {
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "requests": {
+                              "description": "Requests describes the minimum amount of compute resources required.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          }
+                        },
+                        "tls": {
+                          "description": "TlsConfigs configures server TLS for a feast service.",
+                          "type": "object",
+                          "properties": {
+                            "disable": {
+                              "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                              "type": "boolean"
+                            },
+                            "secretKeyNames": {
+                              "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                              "type": "object",
+                              "properties": {
+                                "tlsCrt": {
+                                  "description": "defaults to \"tls.crt\"",
+                                  "type": "string"
+                                },
+                                "tlsKey": {
+                                  "description": "defaults to \"tls.key\"",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "secretRef": {
+                              "description": "references the local k8s secret where the TLS key and cert reside",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "`secretRef` required if `disable` is false.",
+                              "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                            }
+                          ]
+                        },
+                        "volumeMounts": {
+                          "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                          "type": "array",
+                          "items": {
+                            "description": "VolumeMount describes a mounting of a Volume within a container.",
+                            "type": "object",
+                            "required": [
+                              "mountPath",
+                              "name"
+                            ],
+                            "properties": {
+                              "mountPath": {
+                                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                "type": "string"
+                              },
+                              "mountPropagation": {
+                                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "This must match the Name of a Volume.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                                "type": "string"
+                              },
+                              "subPath": {
+                                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                "type": "string"
+                              },
+                              "subPathExpr": {
+                                "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "onlineStore": {
+                  "description": "OnlineStore configures the online store service",
+                  "type": "object",
+                  "properties": {
+                    "persistence": {
+                      "description": "OnlineStorePersistence configures the persistence settings for the online store service",
+                      "type": "object",
+                      "properties": {
+                        "file": {
+                          "description": "OnlineStoreFilePersistence configures the file-based persistence for the online store service",
+                          "type": "object",
+                          "properties": {
+                            "path": {
+                              "type": "string"
+                            },
+                            "pvc": {
+                              "description": "PvcConfig defines the settings for a persistent file store based on PVCs.",
+                              "type": "object",
+                              "required": [
+                                "mountPath"
+                              ],
+                              "properties": {
+                                "create": {
+                                  "description": "Settings for creating a new PVC",
+                                  "type": "object",
+                                  "properties": {
+                                    "accessModes": {
+                                      "description": "AccessModes k8s persistent volume access modes. Defaults to [\"ReadWriteOnce\"].",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "resources": {
+                                      "description": "Resources describes the storage resource requirements for a volume.",
+                                      "type": "object",
+                                      "properties": {
+                                        "limits": {
+                                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        },
+                                        "requests": {
+                                          "description": "Requests describes the minimum amount of compute resources required.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "storageClassName": {
+                                      "description": "StorageClassName is the name of an existing StorageClass to which this persistent volume belongs.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "PvcCreate is immutable",
+                                      "rule": "self == oldSelf"
+                                    }
+                                  ]
+                                },
+                                "mountPath": {
+                                  "description": "MountPath within the container at which the volume should be mounted.\nMust start by \"/\" and cannot contain ':'.",
+                                  "type": "string"
+                                },
+                                "ref": {
+                                  "description": "Reference to an existing field",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "One selection is required between ref and create.",
+                                  "rule": "[has(self.ref), has(self.create)].exists_one(c, c)"
+                                },
+                                {
+                                  "message": "Mount path must start with '/' and must not contain ':'",
+                                  "rule": "self.mountPath.matches('^/[^:]*$')"
+                                }
+                              ]
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "Ephemeral stores must have absolute paths.",
+                              "rule": "(!has(self.pvc) && has(self.path)) ? self.path.startsWith('/') : true"
+                            },
+                            {
+                              "message": "PVC path must be a file name only, with no slashes.",
+                              "rule": "(has(self.pvc) && has(self.path)) ? !self.path.startsWith('/') : true"
+                            },
+                            {
+                              "message": "Online store does not support S3 or GS buckets.",
+                              "rule": "has(self.path) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true"
+                            }
+                          ]
+                        },
+                        "store": {
+                          "description": "OnlineStoreDBStorePersistence configures the DB store persistence for the online store service",
+                          "type": "object",
+                          "required": [
+                            "secretRef",
+                            "type"
+                          ],
+                          "properties": {
+                            "secretKeyName": {
+                              "description": "By default, the selected store \"type\" is used as the SecretKeyName",
+                              "type": "string"
+                            },
+                            "secretRef": {
+                              "description": "Data store parameters should be placed as-is from the \"feature_store.yaml\" under the secret key.",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "type": {
+                              "description": "Type of the persistence type you want to use.",
+                              "type": "string",
+                              "enum": [
+                                "snowflake.online",
+                                "redis",
+                                "ikv",
+                                "datastore",
+                                "dynamodb",
+                                "bigtable",
+                                "postgres",
+                                "cassandra",
+                                "mysql",
+                                "hazelcast",
+                                "singlestore",
+                                "hbase",
+                                "elasticsearch",
+                                "qdrant",
+                                "couchbase.online",
+                                "milvus"
+                              ]
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "One selection required between file or store.",
+                          "rule": "[has(self.file), has(self.store)].exists_one(c, c)"
+                        }
+                      ]
+                    },
+                    "server": {
+                      "description": "Creates a feature server container",
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "array",
+                          "items": {
+                            "description": "EnvVar represents an environment variable present in a Container.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                "type": "object",
+                                "properties": {
+                                  "configMapKeyRef": {
+                                    "description": "Selects a key of a ConfigMap.",
+                                    "type": "object",
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key to select.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "fieldRef": {
+                                    "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                    "type": "object",
+                                    "required": [
+                                      "fieldPath"
+                                    ],
+                                    "properties": {
+                                      "apiVersion": {
+                                        "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                        "type": "string"
+                                      },
+                                      "fieldPath": {
+                                        "description": "Path of the field to select in the specified API version.",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "resourceFieldRef": {
+                                    "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                    "type": "object",
+                                    "required": [
+                                      "resource"
+                                    ],
+                                    "properties": {
+                                      "containerName": {
+                                        "description": "Container name: required for volumes, optional for env vars",
+                                        "type": "string"
+                                      },
+                                      "divisor": {
+                                        "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                        "x-kubernetes-int-or-string": true
+                                      },
+                                      "resource": {
+                                        "description": "Required: resource to select",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "secretKeyRef": {
+                                    "description": "Selects a key of a secret in the pod's namespace",
+                                    "type": "object",
+                                    "required": [
+                                      "key"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret or its key must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "envFrom": {
+                          "type": "array",
+                          "items": {
+                            "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                            "type": "object",
+                            "properties": {
+                              "configMapRef": {
+                                "description": "The ConfigMap to select from",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "prefix": {
+                                "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                "type": "string"
+                              },
+                              "secretRef": {
+                                "description": "The Secret to select from",
+                                "type": "object",
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "imagePullPolicy": {
+                          "description": "PullPolicy describes a policy for if/when to pull a container image",
+                          "type": "string"
+                        },
+                        "logLevel": {
+                          "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                          "type": "string",
+                          "enum": [
+                            "debug",
+                            "info",
+                            "warning",
+                            "error",
+                            "critical"
+                          ]
+                        },
+                        "resources": {
+                          "description": "ResourceRequirements describes the compute resource requirements.",
+                          "type": "object",
+                          "properties": {
+                            "claims": {
+                              "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                              "type": "array",
+                              "items": {
+                                "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "limits": {
+                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "requests": {
+                              "description": "Requests describes the minimum amount of compute resources required.",
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          }
+                        },
+                        "tls": {
+                          "description": "TlsConfigs configures server TLS for a feast service.",
+                          "type": "object",
+                          "properties": {
+                            "disable": {
+                              "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                              "type": "boolean"
+                            },
+                            "secretKeyNames": {
+                              "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                              "type": "object",
+                              "properties": {
+                                "tlsCrt": {
+                                  "description": "defaults to \"tls.crt\"",
+                                  "type": "string"
+                                },
+                                "tlsKey": {
+                                  "description": "defaults to \"tls.key\"",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "secretRef": {
+                              "description": "references the local k8s secret where the TLS key and cert reside",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "`secretRef` required if `disable` is false.",
+                              "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                            }
+                          ]
+                        },
+                        "volumeMounts": {
+                          "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                          "type": "array",
+                          "items": {
+                            "description": "VolumeMount describes a mounting of a Volume within a container.",
+                            "type": "object",
+                            "required": [
+                              "mountPath",
+                              "name"
+                            ],
+                            "properties": {
+                              "mountPath": {
+                                "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                "type": "string"
+                              },
+                              "mountPropagation": {
+                                "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                                "type": "string"
+                              },
+                              "name": {
+                                "description": "This must match the Name of a Volume.",
+                                "type": "string"
+                              },
+                              "readOnly": {
+                                "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                "type": "boolean"
+                              },
+                              "recursiveReadOnly": {
+                                "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                                "type": "string"
+                              },
+                              "subPath": {
+                                "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                "type": "string"
+                              },
+                              "subPathExpr": {
+                                "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "registry": {
+                  "description": "Registry configures the registry service. One selection is required. Local is the default setting.",
+                  "type": "object",
+                  "properties": {
+                    "local": {
+                      "description": "LocalRegistryConfig configures the registry service",
+                      "type": "object",
+                      "properties": {
+                        "persistence": {
+                          "description": "RegistryPersistence configures the persistence settings for the registry service",
+                          "type": "object",
+                          "properties": {
+                            "file": {
+                              "description": "RegistryFilePersistence configures the file-based persistence for the registry service",
+                              "type": "object",
+                              "properties": {
+                                "path": {
+                                  "type": "string"
+                                },
+                                "pvc": {
+                                  "description": "PvcConfig defines the settings for a persistent file store based on PVCs.",
+                                  "type": "object",
+                                  "required": [
+                                    "mountPath"
+                                  ],
+                                  "properties": {
+                                    "create": {
+                                      "description": "Settings for creating a new PVC",
+                                      "type": "object",
+                                      "properties": {
+                                        "accessModes": {
+                                          "description": "AccessModes k8s persistent volume access modes. Defaults to [\"ReadWriteOnce\"].",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "resources": {
+                                          "description": "Resources describes the storage resource requirements for a volume.",
+                                          "type": "object",
+                                          "properties": {
+                                            "limits": {
+                                              "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            },
+                                            "requests": {
+                                              "description": "Requests describes the minimum amount of compute resources required.",
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "storageClassName": {
+                                          "description": "StorageClassName is the name of an existing StorageClass to which this persistent volume belongs.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "PvcCreate is immutable",
+                                          "rule": "self == oldSelf"
+                                        }
+                                      ]
+                                    },
+                                    "mountPath": {
+                                      "description": "MountPath within the container at which the volume should be mounted.\nMust start by \"/\" and cannot contain ':'.",
+                                      "type": "string"
+                                    },
+                                    "ref": {
+                                      "description": "Reference to an existing field",
+                                      "type": "object",
+                                      "properties": {
+                                        "name": {
+                                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    }
+                                  },
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "One selection is required between ref and create.",
+                                      "rule": "[has(self.ref), has(self.create)].exists_one(c, c)"
+                                    },
+                                    {
+                                      "message": "Mount path must start with '/' and must not contain ':'",
+                                      "rule": "self.mountPath.matches('^/[^:]*$')"
+                                    }
+                                  ]
+                                },
+                                "s3_additional_kwargs": {
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "Registry files must use absolute paths or be S3 ('s3://') or GS ('gs://') object store URIs.",
+                                  "rule": "(!has(self.pvc) && has(self.path)) ? (self.path.startsWith('/') || self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true"
+                                },
+                                {
+                                  "message": "PVC path must be a file name only, with no slashes.",
+                                  "rule": "(has(self.pvc) && has(self.path)) ? !self.path.startsWith('/') : true"
+                                },
+                                {
+                                  "message": "PVC persistence does not support S3 or GS object store URIs.",
+                                  "rule": "(has(self.pvc) && has(self.path)) ? !(self.path.startsWith('s3://') || self.path.startsWith('gs://')) : true"
+                                },
+                                {
+                                  "message": "Additional S3 settings are available only for S3 object store URIs.",
+                                  "rule": "(has(self.s3_additional_kwargs) && has(self.path)) ? self.path.startsWith('s3://') : true"
+                                }
+                              ]
+                            },
+                            "store": {
+                              "description": "RegistryDBStorePersistence configures the DB store persistence for the registry service",
+                              "type": "object",
+                              "required": [
+                                "secretRef",
+                                "type"
+                              ],
+                              "properties": {
+                                "secretKeyName": {
+                                  "description": "By default, the selected store \"type\" is used as the SecretKeyName",
+                                  "type": "string"
+                                },
+                                "secretRef": {
+                                  "description": "Data store parameters should be placed as-is from the \"feature_store.yaml\" under the secret key.",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "type": {
+                                  "description": "Type of the persistence type you want to use.",
+                                  "type": "string",
+                                  "enum": [
+                                    "sql",
+                                    "snowflake.registry"
+                                  ]
+                                }
+                              }
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "One selection required between file or store.",
+                              "rule": "[has(self.file), has(self.store)].exists_one(c, c)"
+                            }
+                          ]
+                        },
+                        "server": {
+                          "description": "Creates a registry server container",
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "array",
+                              "items": {
+                                "description": "EnvVar represents an environment variable present in a Container.",
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                                    "type": "string"
+                                  },
+                                  "valueFrom": {
+                                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                                    "type": "object",
+                                    "properties": {
+                                      "configMapKeyRef": {
+                                        "description": "Selects a key of a ConfigMap.",
+                                        "type": "object",
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key to select.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the ConfigMap or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "fieldRef": {
+                                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                        "type": "object",
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                        "type": "object",
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "secretKeyRef": {
+                                        "description": "Selects a key of a secret in the pod's namespace",
+                                        "type": "object",
+                                        "required": [
+                                          "key"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                            "type": "string"
+                                          },
+                                          "name": {
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "description": "Specify whether the Secret or its key must be defined",
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "envFrom": {
+                              "type": "array",
+                              "items": {
+                                "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                                "type": "object",
+                                "properties": {
+                                  "configMapRef": {
+                                    "description": "The ConfigMap to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the ConfigMap must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "prefix": {
+                                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                                    "type": "string"
+                                  },
+                                  "secretRef": {
+                                    "description": "The Secret to select from",
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                        "type": "string"
+                                      },
+                                      "optional": {
+                                        "description": "Specify whether the Secret must be defined",
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  }
+                                }
+                              }
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "imagePullPolicy": {
+                              "description": "PullPolicy describes a policy for if/when to pull a container image",
+                              "type": "string"
+                            },
+                            "logLevel": {
+                              "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                              "type": "string",
+                              "enum": [
+                                "debug",
+                                "info",
+                                "warning",
+                                "error",
+                                "critical"
+                              ]
+                            },
+                            "resources": {
+                              "description": "ResourceRequirements describes the compute resource requirements.",
+                              "type": "object",
+                              "properties": {
+                                "claims": {
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                                    "type": "object",
+                                    "required": [
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
+                                },
+                                "limits": {
+                                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                },
+                                "requests": {
+                                  "description": "Requests describes the minimum amount of compute resources required.",
+                                  "type": "object",
+                                  "additionalProperties": {
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  }
+                                }
+                              }
+                            },
+                            "tls": {
+                              "description": "TlsConfigs configures server TLS for a feast service.",
+                              "type": "object",
+                              "properties": {
+                                "disable": {
+                                  "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                                  "type": "boolean"
+                                },
+                                "secretKeyNames": {
+                                  "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                                  "type": "object",
+                                  "properties": {
+                                    "tlsCrt": {
+                                      "description": "defaults to \"tls.crt\"",
+                                      "type": "string"
+                                    },
+                                    "tlsKey": {
+                                      "description": "defaults to \"tls.key\"",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "secretRef": {
+                                  "description": "references the local k8s secret where the TLS key and cert reside",
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              },
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "`secretRef` required if `disable` is false.",
+                                  "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                                }
+                              ]
+                            },
+                            "volumeMounts": {
+                              "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                              "type": "array",
+                              "items": {
+                                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                                "type": "object",
+                                "required": [
+                                  "mountPath",
+                                  "name"
+                                ],
+                                "properties": {
+                                  "mountPath": {
+                                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                                    "type": "string"
+                                  },
+                                  "mountPropagation": {
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "This must match the Name of a Volume.",
+                                    "type": "string"
+                                  },
+                                  "readOnly": {
+                                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                                    "type": "boolean"
+                                  },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                                    "type": "string"
+                                  },
+                                  "subPath": {
+                                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                                    "type": "string"
+                                  },
+                                  "subPathExpr": {
+                                    "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "remote": {
+                      "description": "RemoteRegistryConfig points to a remote feast registry server.",
+                      "type": "object",
+                      "properties": {
+                        "feastRef": {
+                          "description": "Reference to an existing `FeatureStore` CR in the same k8s cluster.",
+                          "type": "object",
+                          "required": [
+                            "name"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "Name of the FeatureStore",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace of the FeatureStore",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "hostname": {
+                          "description": "Host address of the remote registry service - <domain>:<port>, e.g. `registry.<namespace>.svc.cluster.local:80`",
+                          "type": "string"
+                        },
+                        "tls": {
+                          "description": "TlsRemoteRegistryConfigs configures client TLS for a remote feast registry.",
+                          "type": "object",
+                          "required": [
+                            "certName",
+                            "configMapRef"
+                          ],
+                          "properties": {
+                            "certName": {
+                              "description": "defines the configmap key name for the client TLS cert.",
+                              "type": "string"
+                            },
+                            "configMapRef": {
+                              "description": "references the local k8s configmap where the TLS cert resides",
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "One selection required.",
+                          "rule": "[has(self.hostname), has(self.feastRef)].exists_one(c, c)"
+                        }
+                      ]
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "One selection required.",
+                      "rule": "[has(self.local), has(self.remote)].exists_one(c, c)"
+                    }
+                  ]
+                },
+                "ui": {
+                  "description": "Creates a UI server container",
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvVar represents an environment variable present in a Container.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "value": {
+                            "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany",
+                            "type": "string"
+                          },
+                          "valueFrom": {
+                            "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                            "type": "object",
+                            "properties": {
+                              "configMapKeyRef": {
+                                "description": "Selects a key of a ConfigMap.",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key to select.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the ConfigMap or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "fieldRef": {
+                                "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.",
+                                "type": "object",
+                                "required": [
+                                  "fieldPath"
+                                ],
+                                "properties": {
+                                  "apiVersion": {
+                                    "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "description": "Path of the field to select in the specified API version.",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "resourceFieldRef": {
+                                "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.",
+                                "type": "object",
+                                "required": [
+                                  "resource"
+                                ],
+                                "properties": {
+                                  "containerName": {
+                                    "description": "Container name: required for volumes, optional for env vars",
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                    "x-kubernetes-int-or-string": true
+                                  },
+                                  "resource": {
+                                    "description": "Required: resource to select",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "secretKeyRef": {
+                                "description": "Selects a key of a secret in the pod's namespace",
+                                "type": "object",
+                                "required": [
+                                  "key"
+                                ],
+                                "properties": {
+                                  "key": {
+                                    "description": "The key of the secret to select from.  Must be a valid secret key.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "description": "Specify whether the Secret or its key must be defined",
+                                    "type": "boolean"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envFrom": {
+                      "type": "array",
+                      "items": {
+                        "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                        "type": "object",
+                        "properties": {
+                          "configMapRef": {
+                            "description": "The ConfigMap to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the ConfigMap must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "prefix": {
+                            "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "The Secret to select from",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              },
+                              "optional": {
+                                "description": "Specify whether the Secret must be defined",
+                                "type": "boolean"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      }
+                    },
+                    "image": {
+                      "type": "string"
+                    },
+                    "imagePullPolicy": {
+                      "description": "PullPolicy describes a policy for if/when to pull a container image",
+                      "type": "string"
+                    },
+                    "logLevel": {
+                      "description": "LogLevel sets the logging level for the server\nAllowed values: \"debug\", \"info\", \"warning\", \"error\", \"critical\".",
+                      "type": "string",
+                      "enum": [
+                        "debug",
+                        "info",
+                        "warning",
+                        "error",
+                        "critical"
+                      ]
+                    },
+                    "resources": {
+                      "description": "ResourceRequirements describes the compute resource requirements.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "tls": {
+                      "description": "TlsConfigs configures server TLS for a feast service.",
+                      "type": "object",
+                      "properties": {
+                        "disable": {
+                          "description": "will disable TLS for the feast service. useful in an openshift cluster, for example, where TLS is configured by default",
+                          "type": "boolean"
+                        },
+                        "secretKeyNames": {
+                          "description": "SecretKeyNames defines the secret key names for the TLS key and cert.",
+                          "type": "object",
+                          "properties": {
+                            "tlsCrt": {
+                              "description": "defaults to \"tls.crt\"",
+                              "type": "string"
+                            },
+                            "tlsKey": {
+                              "description": "defaults to \"tls.key\"",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "secretRef": {
+                          "description": "references the local k8s secret where the TLS key and cert reside",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "`secretRef` required if `disable` is false.",
+                          "rule": "(!has(self.disable) || !self.disable) ? has(self.secretRef) : true"
+                        }
+                      ]
+                    },
+                    "volumeMounts": {
+                      "description": "VolumeMounts defines the list of volumes that should be mounted into the feast container.",
+                      "type": "array",
+                      "items": {
+                        "description": "VolumeMount describes a mounting of a Volume within a container.",
+                        "type": "object",
+                        "required": [
+                          "mountPath",
+                          "name"
+                        ],
+                        "properties": {
+                          "mountPath": {
+                            "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                            "type": "string"
+                          },
+                          "mountPropagation": {
+                            "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "This must match the Name of a Volume.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "recursiveReadOnly": {
+                            "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.",
+                            "type": "string"
+                          },
+                          "subPath": {
+                            "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                            "type": "string"
+                          },
+                          "subPathExpr": {
+                            "description": "Expanded path within the volume from which the container's volume should be mounted.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "volumes": {
+                  "description": "Volumes specifies the volumes to mount in the FeatureStore deployment.",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to th",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "azureDisk": {
+                        "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+                        "type": "object",
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "properties": {
+                          "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage accoun",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "azureFile": {
+                        "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+                        "type": "object",
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "properties": {
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "description": "shareName is the azure share Name",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cephfs": {
+                        "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime",
+                        "type": "object",
+                        "required": [
+                          "monitors"
+                        ],
+                        "properties": {
+                          "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cinder": {
+                        "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nMore info: https://examples.k8s.",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volum",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "csi": {
+                        "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta fea",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".",
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to c",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "downwardAPI": {
+                        "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "Items is a list of downward API volume file",
+                            "type": "array",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                  "type": "object",
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal valu",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path.",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.",
+                                  "type": "object",
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "emptyDir": {
+                        "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.",
+                        "type": "object",
+                        "properties": {
+                          "medium": {
+                            "description": "medium represents what type of storage medium should back this directory.",
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      },
+                      "ephemeral": {
+                        "description": "ephemeral represents a volume that is handled by a cluster storage driver.",
+                        "type": "object",
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume.",
+                            "type": "object",
+                            "required": [
+                              "spec"
+                            ],
+                            "properties": {
+                              "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it.",
+                                "type": "object"
+                              },
+                              "spec": {
+                                "description": "The specification for the PersistentVolumeClaim.",
+                                "type": "object",
+                                "properties": {
+                                  "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "dataSource": {
+                                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "dataSourceRef": {
+                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "resources represents the minimum resources the volume should have.",
+                                    "type": "object",
+                                    "properties": {
+                                      "limits": {
+                                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      },
+                                      "requests": {
+                                        "description": "Requests describes the minimum amount of compute resources required.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "selector": {
+                                    "description": "selector is a label query over volumes to consider for binding.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.",
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
+                                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.",
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim.",
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "fc": {
+                        "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun is Optional: FC target lun number",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, ",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "flexVolume": {
+                        "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "options": {
+                            "description": "options is Optional: this field holds extra command options if any.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugi",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "flocker": {
+                        "description": "flocker represents a Flocker volume attached to a kubelet's host machine.",
+                        "type": "object",
+                        "properties": {
+                          "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as depreca",
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "gcePersistentDisk": {
+                        "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the po",
+                        "type": "object",
+                        "required": [
+                          "pdName"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount.",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "gitRepo": {
+                        "description": "gitRepo represents a git repository at a particular revision.\nDEPRECATED: GitRepo is deprecated.",
+                        "type": "object",
+                        "required": [
+                          "repository"
+                        ],
+                        "properties": {
+                          "directory": {
+                            "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.",
+                            "type": "string"
+                          },
+                          "repository": {
+                            "description": "repository is the URL",
+                            "type": "string"
+                          },
+                          "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "glusterfs": {
+                        "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.",
+                        "type": "object",
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "properties": {
+                          "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "hostPath": {
+                        "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container.",
+                        "type": "object",
+                        "required": [
+                          "path"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "iscsi": {
+                        "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.",
+                        "type": "object",
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.",
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name.",
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "portals": {
+                            "description": "portals is the iSCSI Target Portal List.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.",
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.",
+                        "type": "object",
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.",
+                        "type": "object",
+                        "required": [
+                          "claimName"
+                        ],
+                        "properties": {
+                          "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "photonPersistentDisk": {
+                        "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine",
+                        "type": "object",
+                        "required": [
+                          "pdID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "portworxVolume": {
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "sources is the list of volume projections",
+                            "type": "array",
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types",
+                              "type": "object",
+                              "properties": {
+                                "clusterTrustBundle": {
+                                  "description": "ClusterTrustBundle allows a pod to access the `.spec.",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "type": "object",
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.",
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "description": "Relative path from the volume root to write the bundle.",
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "configMap": {
+                                  "description": "configMap information about the configMap data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volum",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal valu",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path.",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.",
+                                            "type": "object",
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "secret": {
+                                  "description": "secret information about the secret data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume a",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "audience is the intended audience of the token.",
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service\naccount token.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "quobyte": {
+                        "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime",
+                        "type": "object",
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "properties": {
+                          "group": {
+                            "description": "group to map volume access to\nDefault is no group",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple ent",
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by",
+                            "type": "string"
+                          },
+                          "user": {
+                            "description": "user to map volume access to\nDefaults to serivceaccount user",
+                            "type": "string"
+                          },
+                          "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "rbd": {
+                        "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nMore info: https://examples.k8s.",
+                        "type": "object",
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.",
+                            "type": "string"
+                          },
+                          "image": {
+                            "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.",
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "pool": {
+                            "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "scaleIO": {
+                        "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.",
+                        "type": "object",
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.",
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                            "type": "string"
+                          },
+                          "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "secret": {
+                        "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume a",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "storageos": {
+                        "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty.",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "vsphereVolume": {
+                        "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine",
+                        "type": "object",
+                        "required": [
+                          "volumePath"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx.",
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "clientConfigMap": {
+          "description": "ConfigMap in this namespace containing a client `feature_store.yaml` for this feast deployment",
+          "type": "string"
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "type": "object",
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "type": "string",
+                "maxLength": 32768
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.",
+                "type": "string",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+              }
+            }
+          }
+        },
+        "cronJob": {
+          "description": "CronJob in this namespace for this feast deployment",
+          "type": "string"
+        },
+        "feastVersion": {
+          "type": "string"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "serviceHostnames": {
+          "description": "ServiceHostnames defines the service hostnames in the format of <domain>:<port>, e.g. example.svc.cluster.local:80",
+          "type": "object",
+          "properties": {
+            "offlineStore": {
+              "type": "string"
+            },
+            "onlineStore": {
+              "type": "string"
+            },
+            "registry": {
+              "type": "string"
+            },
+            "ui": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "feast.dev",
+      "kind": "FeatureStore",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/featurestorelist.json
+++ b/class_generator/schema/featurestorelist.json
@@ -1,0 +1,36 @@
+{
+  "description": "FeatureStoreList is a list of FeatureStore",
+  "type": "object",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "items": {
+      "description": "List of featurestores. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": "array",
+      "items": {
+        "$ref": "_definitions.json#/definitions/dev.feast.v1alpha1.FeatureStore"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "feast.dev",
+      "kind": "FeatureStoreList",
+      "version": "v1alpha1"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/guardrailsorchestrator.json
+++ b/class_generator/schema/guardrailsorchestrator.json
@@ -22,6 +22,18 @@
         "replicas"
       ],
       "properties": {
+        "enableBuiltInDetectors": {
+          "description": "Boolean flag to enable/disable built-in detectors",
+          "type": "boolean"
+        },
+        "enableGuardrailsGateway": {
+          "description": "Boolean flag to enable/disable the guardrails sidecar gateway",
+          "type": "boolean"
+        },
+        "guardrailsGatewayConfig": {
+          "description": " Name of the configmap containing guadrails sidecar gateway arguments",
+          "type": "string"
+        },
         "orchestratorConfig": {
           "description": "Name of configmap containing generator,detector,and chunker arguments",
           "type": "string"
@@ -64,10 +76,6 @@
           "description": "Number of replicas",
           "type": "integer",
           "format": "int32"
-        },
-        "vllmGatewayConfig": {
-          "description": " Name of the configmap containg vLLM gateway arguments",
-          "type": "string"
         }
       }
     },
@@ -116,5 +124,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/guardrailsorchestratorlist.json
+++ b/class_generator/schema/guardrailsorchestratorlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/hardwareprofile.json
+++ b/class_generator/schema/hardwareprofile.json
@@ -44,7 +44,6 @@
               "displayName",
               "identifier",
               "minCount",
-              "maxCount",
               "defaultCount"
             ],
             "properties": {
@@ -69,31 +68,23 @@
                 "x-kubernetes-int-or-string": true
               },
               "resourceType": {
-                "description": "The type of identifier. could be \"CPU\" or \"Memory\". Leave it undefined for the other types.",
+                "description": "The type of identifier. could be \"CPU\", \"Memory\", or \"Accelerator\". Leave it undefined for the other types.",
                 "type": "string",
                 "enum": [
                   "CPU",
-                  "Memory"
+                  "Memory",
+                  "Accelerator"
                 ]
               }
             }
           }
         },
-        "nodeSelectors": {
-          "description": "Number of node selector available.",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "key": {
-                "description": "The key for the node selector.",
-                "type": "string"
-              },
-              "value": {
-                "description": "The value for the node selector.",
-                "type": "string"
-              }
-            }
+        "nodeSelector": {
+          "description": "The node selector available.",
+          "type": "object",
+          "additionalProperties": {
+            "description": "The value for the node selector key.",
+            "type": "string"
           }
         },
         "tolerations": {
@@ -138,5 +129,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/hardwareprofilelist.json
+++ b/class_generator/schema/hardwareprofilelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/inferencegraph.json
+++ b/class_generator/schema/inferencegraph.json
@@ -735,6 +735,9 @@
                 "properties": {
                   "name": {
                     "type": "string"
+                  },
+                  "request": {
+                    "type": "string"
                   }
                 }
               },
@@ -815,6 +818,9 @@
               }
             }
           }
+        },
+        "deploymentMode": {
+          "type": "string"
         },
         "observedGeneration": {
           "type": "integer",

--- a/class_generator/schema/jaxjob.json
+++ b/class_generator/schema/jaxjob.json
@@ -6475,5 +6475,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/jaxjoblist.json
+++ b/class_generator/schema/jaxjoblist.json
@@ -32,5 +32,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/kserve.json
+++ b/class_generator/schema/kserve.json
@@ -68,6 +68,15 @@
             }
           }
         },
+        "rawDeploymentServiceConfig": {
+          "description": "Configures the type of service that is created for InferenceServices using RawDeployment.\nThe values for RawDeploymentServiceConfig can be \"Headless\" or \"Headed\".\nHeadless : sets \"ServiceClusterIPNone = true\" in the 'inferenceservice-config' configmap for Kserve.\nHeaded : sets \"ServiceClusterIPNone = false\" in the 'inferenceservice-config' configmap for Kserve.",
+          "type": "string",
+          "pattern": "^(Headless|Headed)$",
+          "enum": [
+            "Headless",
+            "Headed"
+          ]
+        },
         "serving": {
           "description": "Serving configures the KNative-Serving stack used for model serving. A Service\nMesh (Istio) is prerequisite, since it is used as networking layer.",
           "type": "object",
@@ -125,38 +134,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -175,21 +185,44 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "defaultDeploymentMode": {
           "description": "DefaultDeploymentMode is the value of the defaultDeploymentMode field\nas read from the \"deploy\" JSON in the inferenceservice-config ConfigMap",
           "type": "string"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         },
         "serverlessMode": {
           "type": "string",
@@ -205,6 +238,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "Kserve name must be default-kserve",

--- a/class_generator/schema/kservelist.json
+++ b/class_generator/schema/kservelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/kueue.json
+++ b/class_generator/schema/kueue.json
@@ -54,38 +54,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,17 +105,40 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -126,6 +150,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "Kueue name must be default-kueue",

--- a/class_generator/schema/kueuelist.json
+++ b/class_generator/schema/kueuelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/lmevaljob.json
+++ b/class_generator/schema/lmevaljob.json
@@ -22,6 +22,14 @@
         "taskList"
       ],
       "properties": {
+        "allowCodeExecution": {
+          "description": "AllowCodeExecution specifies whether the LMEvalJob can execute remote code. Default is false.",
+          "type": "boolean"
+        },
+        "allowOnline": {
+          "description": "AllowOnly specifies whether the LMEvalJob can directly download remote code, datasets and metrics. Default is false.",
+          "type": "boolean"
+        },
         "batchSize": {
           "description": "Batch size for the evaluation. This is used by the models that run and are loaded\nlocally and not apply for the commercial APIs.",
           "type": "string"
@@ -79,7 +87,7 @@
           "type": "integer"
         },
         "offline": {
-          "description": "Offline specifies settings for running LMEvalJobs in a offline mode",
+          "description": "Offline specifies settings for running LMEvalJobs in an offline mode",
           "type": "object",
           "required": [
             "storage"
@@ -88,12 +96,160 @@
             "storage": {
               "description": "OfflineStorageSpec defines the storage configuration for LMEvalJob's offline mode",
               "type": "object",
-              "required": [
-                "pvcName"
-              ],
               "properties": {
                 "pvcName": {
                   "type": "string"
+                },
+                "s3": {
+                  "type": "object",
+                  "required": [
+                    "accessKeyId",
+                    "bucket",
+                    "endpoint",
+                    "path",
+                    "region",
+                    "secretAccessKey"
+                  ],
+                  "properties": {
+                    "accessKeyId": {
+                      "description": "SecretKeySelector selects a key of a Secret.",
+                      "type": "object",
+                      "required": [
+                        "key"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "bucket": {
+                      "description": "SecretKeySelector selects a key of a Secret.",
+                      "type": "object",
+                      "required": [
+                        "key"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "caBundle": {
+                      "description": "SecretKeySelector selects a key of a Secret.",
+                      "type": "object",
+                      "required": [
+                        "key"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "endpoint": {
+                      "description": "SecretKeySelector selects a key of a Secret.",
+                      "type": "object",
+                      "required": [
+                        "key"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "region": {
+                      "description": "SecretKeySelector selects a key of a Secret.",
+                      "type": "object",
+                      "required": [
+                        "key"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "secretAccessKey": {
+                      "description": "SecretKeySelector selects a key of a Secret.",
+                      "type": "object",
+                      "required": [
+                        "key"
+                      ],
+                      "properties": {
+                        "key": {
+                          "description": "The key of the secret to select from.  Must be a valid secret key.",
+                          "type": "string"
+                        },
+                        "name": {
+                          "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                          "type": "string"
+                        },
+                        "optional": {
+                          "description": "Specify whether the Secret or its key must be defined",
+                          "type": "boolean"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "verifySSL": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -3730,8 +3886,88 @@
           "description": "Evaluation task list",
           "type": "object",
           "properties": {
+            "custom": {
+              "description": "Custom Unitxt artifacts that can be used in a TaskRecipe",
+              "type": "object",
+              "properties": {
+                "systemPrompts": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the custom artifact",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of the custom artifact. It could be a JSON string or plain text\ndepending on the artifact type",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "templates": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the custom artifact",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of the custom artifact. It could be a JSON string or plain text\ndepending on the artifact type",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "customTasks": {
+              "description": "CustomTasks is a list of external tasks",
+              "type": "object",
+              "properties": {
+                "source": {
+                  "description": "Source specifies the source location of custom tasks",
+                  "type": "object",
+                  "properties": {
+                    "git": {
+                      "description": "GitSource specifies the git location of external tasks",
+                      "type": "object",
+                      "properties": {
+                        "branch": {
+                          "description": "Branch specifies the git branch to use",
+                          "type": "string"
+                        },
+                        "commit": {
+                          "description": "Commit specifies the git commit to use",
+                          "type": "string"
+                        },
+                        "path": {
+                          "description": "Path specifies the path to the task file",
+                          "type": "string"
+                        },
+                        "url": {
+                          "description": "URL specifies the git repository URL",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "taskNames": {
-              "description": "TaskNames from lm-eval's task list",
+              "description": "TaskNames from lm-eval's task list and/or from custom tasks if CustomTasks is defined",
               "type": "array",
               "items": {
                 "type": "string"
@@ -3744,8 +3980,7 @@
                 "description": "Use a task recipe to form a custom task. It maps to the Unitxt Recipe\nFind details of the Unitxt Recipe here:\nhttps://www.unitxt.ai/en/latest/unitxt.standard.html#unitxt.standard.StandardRecipe",
                 "type": "object",
                 "required": [
-                  "card",
-                  "template"
+                  "card"
                 ],
                 "properties": {
                   "card": {
@@ -3785,13 +4020,37 @@
                     "description": "Number of fewshot",
                     "type": "integer"
                   },
+                  "systemPrompt": {
+                    "description": "The Unitxt System Prompt",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Unitxt System Prompt id",
+                        "type": "string"
+                      },
+                      "ref": {
+                        "description": "The name of the custom systemPrompt in the custom field. Its value is a custom system prompt string",
+                        "type": "string"
+                      }
+                    }
+                  },
                   "task": {
                     "description": "The Unitxt Task",
                     "type": "string"
                   },
                   "template": {
                     "description": "The Unitxt template",
-                    "type": "string"
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Unitxt template ID",
+                        "type": "string"
+                      },
+                      "ref": {
+                        "description": "The name of the custom template in the custom field. Its value is a JSON string\nfor a custom Unitxt template. Use the documentation here: https://www.unitxt.ai/en/latest/docs/adding_template.html\nto compose a custom template, store it as a JSON file by calling the\nadd_to_catalog API: https://www.unitxt.ai/en/latest/docs/saving_and_loading_from_catalog.html#adding-assets-to-the-catalog,\nand use the JSON content as the value here.",
+                        "type": "string"
+                      }
+                    }
                   }
                 }
               }

--- a/class_generator/schema/localqueue.json
+++ b/class_generator/schema/localqueue.json
@@ -31,7 +31,7 @@
           ]
         },
         "stopPolicy": {
-          "description": "stopPolicy - if set to a value different from None, the LocalQueue is considered Inactive,\nno new reservation being made.\n\n\nDepending on its value, its associated workloads will:\n\n\n- None - Workloads are admitted\n- HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.\n- Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.",
+          "description": "stopPolicy - if set to a value different from None, the LocalQueue is considered Inactive,\nno new reservation being made.\n\nDepending on its value, its associated workloads will:\n\n- None - Workloads are admitted\n- HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.\n- Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.",
           "type": "string",
           "enum": [
             "None",
@@ -54,7 +54,7 @@
           "description": "Conditions hold the latest available observations of the LocalQueue\ncurrent state.",
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -97,7 +97,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"

--- a/class_generator/schema/modelcontroller.json
+++ b/class_generator/schema/modelcontroller.json
@@ -105,6 +105,15 @@
               "pattern": "^(Managed|Unmanaged|Force|Removed)$"
             }
           }
+        },
+        "modelRegistry": {
+          "type": "object",
+          "properties": {
+            "managementState": {
+              "type": "string",
+              "pattern": "^(Managed|Unmanaged|Force|Removed)$"
+            }
+          }
         }
       }
     },
@@ -115,38 +124,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -165,12 +175,10 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
@@ -187,6 +195,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "ModelController name must be default-modelcontroller",

--- a/class_generator/schema/modelcontrollerlist.json
+++ b/class_generator/schema/modelcontrollerlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/modelmeshserving.json
+++ b/class_generator/schema/modelmeshserving.json
@@ -54,38 +54,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,17 +105,40 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -126,6 +150,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "ModelMeshServing name must be default-modelmeshserving",

--- a/class_generator/schema/modelmeshservinglist.json
+++ b/class_generator/schema/modelmeshservinglist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/modelregistry.json
+++ b/class_generator/schema/modelregistry.json
@@ -15,577 +15,41 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "ModelRegistrySpec defines the desired state of ModelRegistry. One of `postgres` or `mysql` database configurations MUST be provided!",
+      "description": "ModelRegistrySpec defines the desired state of ModelRegistry",
       "type": "object",
-      "required": [
-        "grpc",
-        "rest"
-      ],
       "properties": {
-        "downgrade_db_schema_version": {
-          "description": "Database downgrade schema version value. If set the database schema version is downgraded to the set value during initialization (Optional Parameter)",
-          "type": "integer",
-          "format": "int64"
-        },
-        "enable_database_upgrade": {
-          "description": "Flag specifying database upgrade option. If set to true, it enables database migration during initialization (Optional parameter)",
-          "type": "boolean"
-        },
-        "grpc": {
-          "description": "Configuration for gRPC endpoint",
+        "devFlags": {
+          "description": "Add developer fields",
           "type": "object",
           "properties": {
-            "image": {
-              "description": "Optional image to support overriding the image deployed by the operator.",
-              "type": "string"
-            },
-            "port": {
-              "description": "Listen port for gRPC connections, defaults to 9090.",
-              "type": "integer",
-              "format": "int32",
-              "maximum": 65535,
-              "minimum": 0
-            },
-            "resources": {
-              "description": "Resource requirements",
-              "type": "object",
-              "properties": {
-                "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
-                  "type": "array",
-                  "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
-                        "type": "string"
-                      }
-                    }
-                  },
-                  "x-kubernetes-list-map-keys": [
-                    "name"
-                  ],
-                  "x-kubernetes-list-type": "map"
-                },
-                "limits": {
-                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                  "type": "object",
-                  "additionalProperties": {
-                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                    "x-kubernetes-int-or-string": true
-                  }
-                },
-                "requests": {
-                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                  "type": "object",
-                  "additionalProperties": {
-                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                    "x-kubernetes-int-or-string": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "istio": {
-          "description": "Istio servicemesh configuration options",
-          "type": "object",
-          "properties": {
-            "audiences": {
-              "description": "Optional Authorino AuthConfig credential audiences. This depends on the cluster identity provider. If not specified, operator will determine the cluster's audience using its own service account.",
+            "manifests": {
+              "description": "List of custom manifests for the given component",
               "type": "array",
               "items": {
-                "type": "string"
-              }
-            },
-            "authConfigLabels": {
-              "description": "Authorino AuthConfig selector labels. \n If missing, it is set using the operator environment property DEFAULT_AUTH_CONFIG_LABELS",
-              "type": "object",
-              "additionalProperties": {
-                "type": "string"
-              }
-            },
-            "authProvider": {
-              "description": "Authorino authentication provider name \n If missing, it is set using the operator environment property DEFAULT_AUTH_PROVIDER Model registry will have an error status if the operator property is also missing",
-              "type": "string"
-            },
-            "gateway": {
-              "description": "Optional Istio Gateway for registry services. Gateway is not created if set to null (default).",
-              "type": "object",
-              "required": [
-                "grpc",
-                "rest"
-              ],
-              "properties": {
-                "controlPlane": {
-                  "description": "Maistra/OpenShift Servicemesh control plane name",
-                  "type": "string"
-                },
-                "domain": {
-                  "description": "Domain name for Gateway configuration. If not provided, it is set automatically using model registry operator env variable DEFAULT_DOMAIN. If the env variable is not set, it is set to the OpenShift `cluster` ingress domain in an OpenShift cluster.",
-                  "type": "string"
-                },
-                "grpc": {
-                  "description": "gRPC  gateway server config",
-                  "type": "object",
-                  "properties": {
-                    "gatewayRoute": {
-                      "description": "Creates an OpenShift Route for Gateway Service when set to enabled (default).",
-                      "type": "string",
-                      "enum": [
-                        "disabled",
-                        "enabled"
-                      ]
-                    },
-                    "port": {
-                      "description": "Listen port for server connections, defaults to 80 without TLS and 443 when TLS settings are present.",
-                      "type": "integer",
-                      "format": "int32",
-                      "maximum": 65535,
-                      "minimum": 0
-                    },
-                    "tls": {
-                      "description": "Set of TLS related options that govern the server's behavior. Use these options to control if all http requests should be redirected to https, and the TLS modes to use.",
-                      "type": "object",
-                      "properties": {
-                        "credentialName": {
-                          "description": "The name of the secret that holds the TLS certs including the CA certificates. If not provided, it is set automatically using model registry operator env variable DEFAULT_CERT. An Opaque secret should contain the following keys and values: `tls.key: <privateKey>` and `tls.crt: <serverCert>` or `key: <privateKey>` and `cert: <serverCert>`. For mutual TLS, `cacert: <CACertificate>` and `crl: <CertificateRevocationList>` can be provided in the same secret or a separate secret named `<secret>-cacert`. A TLS secret for server certificates with an additional `tls.ocsp-staple` key for specifying OCSP staple information, `ca.crt` key for CA certificates and `ca.crl` for certificate revocation list is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
-                          "type": "string"
-                        },
-                        "mode": {
-                          "description": "The value of this field determines how TLS is enforced. SIMPLE: Secure connections with standard TLS semantics. In this mode client certificate is not requested during handshake. \n MUTUAL: Secure connections to the downstream using mutual TLS by presenting server certificates for authentication. A client certificate will also be requested during the handshake and at least one valid certificate is required to be sent by the client. \n ISTIO_MUTUAL: Secure connections from the downstream using mutual TLS by presenting server certificates for authentication. Compared to Mutual mode, this mode uses certificates, representing gateway workload identity, generated automatically by Istio for mTLS authentication. When this mode is used, all other TLS fields should be empty. \n OPTIONAL_MUTUAL: Similar to MUTUAL mode, except that the client certificate is optional. Unlike SIMPLE mode, A client certificate will still be explicitly requested during handshake, but the client is not required to send a certificate. If a client certificate is presented, it will be validated. ca_certificates should be specified for validating client certificates.",
-                          "type": "string",
-                          "enum": [
-                            "SIMPLE",
-                            "MUTUAL",
-                            "ISTIO_MUTUAL",
-                            "OPTIONAL_MUTUAL"
-                          ]
-                        }
-                      }
-                    }
-                  }
-                },
-                "istioIngress": {
-                  "description": "Value of label `istio` used to identify the Ingress Gateway",
-                  "type": "string"
-                },
-                "rest": {
-                  "description": "Rest gateway server config",
-                  "type": "object",
-                  "properties": {
-                    "gatewayRoute": {
-                      "description": "Creates an OpenShift Route for Gateway Service when set to enabled (default).",
-                      "type": "string",
-                      "enum": [
-                        "disabled",
-                        "enabled"
-                      ]
-                    },
-                    "port": {
-                      "description": "Listen port for server connections, defaults to 80 without TLS and 443 when TLS settings are present.",
-                      "type": "integer",
-                      "format": "int32",
-                      "maximum": 65535,
-                      "minimum": 0
-                    },
-                    "tls": {
-                      "description": "Set of TLS related options that govern the server's behavior. Use these options to control if all http requests should be redirected to https, and the TLS modes to use.",
-                      "type": "object",
-                      "properties": {
-                        "credentialName": {
-                          "description": "The name of the secret that holds the TLS certs including the CA certificates. If not provided, it is set automatically using model registry operator env variable DEFAULT_CERT. An Opaque secret should contain the following keys and values: `tls.key: <privateKey>` and `tls.crt: <serverCert>` or `key: <privateKey>` and `cert: <serverCert>`. For mutual TLS, `cacert: <CACertificate>` and `crl: <CertificateRevocationList>` can be provided in the same secret or a separate secret named `<secret>-cacert`. A TLS secret for server certificates with an additional `tls.ocsp-staple` key for specifying OCSP staple information, `ca.crt` key for CA certificates and `ca.crl` for certificate revocation list is also supported. Only one of server certificates and CA certificate or credentialName can be specified.",
-                          "type": "string"
-                        },
-                        "mode": {
-                          "description": "The value of this field determines how TLS is enforced. SIMPLE: Secure connections with standard TLS semantics. In this mode client certificate is not requested during handshake. \n MUTUAL: Secure connections to the downstream using mutual TLS by presenting server certificates for authentication. A client certificate will also be requested during the handshake and at least one valid certificate is required to be sent by the client. \n ISTIO_MUTUAL: Secure connections from the downstream using mutual TLS by presenting server certificates for authentication. Compared to Mutual mode, this mode uses certificates, representing gateway workload identity, generated automatically by Istio for mTLS authentication. When this mode is used, all other TLS fields should be empty. \n OPTIONAL_MUTUAL: Similar to MUTUAL mode, except that the client certificate is optional. Unlike SIMPLE mode, A client certificate will still be explicitly requested during handshake, but the client is not required to send a certificate. If a client certificate is presented, it will be validated. ca_certificates should be specified for validating client certificates.",
-                          "type": "string",
-                          "enum": [
-                            "SIMPLE",
-                            "MUTUAL",
-                            "ISTIO_MUTUAL",
-                            "OPTIONAL_MUTUAL"
-                          ]
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "tlsMode": {
-              "description": "DestinationRule TLS mode. Defaults to ISTIO_MUTUAL. \n DISABLE: Do not setup a TLS connection to the upstream endpoint. \n SIMPLE: Originate a TLS connection to the upstream endpoint. \n MUTUAL: Secure connections to the upstream using mutual TLS by presenting client certificates for authentication. \n ISTIO_MUTUAL: Secure connections to the upstream using mutual TLS by presenting client certificates for authentication. Compared to Mutual mode, this mode uses certificates generated automatically by Istio for mTLS authentication. When this mode is used, all other fields in `ClientTLSSettings` should be empty.",
-              "type": "string"
-            }
-          }
-        },
-        "mysql": {
-          "description": "MySQL configuration options",
-          "type": "object",
-          "required": [
-            "database",
-            "host",
-            "username"
-          ],
-          "properties": {
-            "database": {
-              "description": "The database to connect to. Must be specified. After connecting to the MYSQL server, this database is created if not already present unless SkipDBCreation is set. All queries after Connect() are assumed to be for this database.",
-              "type": "string"
-            },
-            "host": {
-              "description": "The hostname or IP address of the MYSQL server: If unspecified, a connection to the local host is assumed. Currently, a replicated MYSQL backend is not supported.",
-              "type": "string"
-            },
-            "passwordSecret": {
-              "description": "The password to use for `Username`. If empty, only MYSQL user ids that don't have a password set are allowed to connect.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "port": {
-              "description": "Port number to connect to at the server host. The TCP Port number that the MYSQL server accepts connections on. If unspecified, the default MYSQL port (3306) is used.",
-              "type": "integer",
-              "format": "int32",
-              "maximum": 65535,
-              "minimum": 1
-            },
-            "skipDBCreation": {
-              "description": "True if skipping database instance creation during ML Metadata service initialization. By default, it is false.",
-              "type": "boolean"
-            },
-            "sslCertificateSecret": {
-              "description": "This parameter specifies the Kubernetes Secret name and key of the client public key certificate.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslCipher": {
-              "description": "This parameter specifies the list of permissible ciphers for SSL encryption.",
-              "type": "string"
-            },
-            "sslKeySecret": {
-              "description": "This parameter specifies the Kubernetes Secret name and key used for the client private key.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslRootCertificateConfigMap": {
-              "description": "This parameter specifies the Kubernetes ConfigMap name and key containing certificate authority (CA) certificate.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in configmap",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes configmap name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslRootCertificateSecret": {
-              "description": "This parameter specifies the Kubernetes Secret name and key containing certificate authority (CA) certificate.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslRootCertificatesConfigMapName": {
-              "description": "This parameter specifies the Kubernetes ConfigMap name containing multiple certificate authority (CA) certificate(s) as keys.",
-              "type": "string"
-            },
-            "sslRootCertificatesSecretName": {
-              "description": "This parameter specifies the Kubernetes Secret name containing multiple certificate authority (CA) certificate(s) as keys.",
-              "type": "string"
-            },
-            "username": {
-              "description": "The MYSQL login id.",
-              "type": "string"
-            },
-            "verifyServerCert": {
-              "description": "If set, enable verification of the server certificate against the host name used when connecting to the server.",
-              "type": "boolean"
-            }
-          }
-        },
-        "postgres": {
-          "description": "PostgreSQL configuration options",
-          "type": "object",
-          "required": [
-            "database"
-          ],
-          "properties": {
-            "database": {
-              "description": "The database name.",
-              "type": "string"
-            },
-            "host": {
-              "description": "Name of host to connect to.",
-              "type": "string"
-            },
-            "hostAddress": {
-              "description": "Numeric IP address of host to connect to. If this field is provided, \"host\" field is ignored.",
-              "type": "string"
-            },
-            "passwordSecret": {
-              "description": "Password to be used if required by the PostgreSQL server.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "port": {
-              "description": "Port number to connect to at the server host.",
-              "type": "integer",
-              "format": "int32",
-              "maximum": 65535,
-              "minimum": 1
-            },
-            "skipDBCreation": {
-              "description": "True if skipping database instance creation during ML Metadata service initialization. By default, it is false.",
-              "type": "boolean"
-            },
-            "sslCertificateSecret": {
-              "description": "This parameter specifies the Kubernetes Secret name and key of the client SSL certificate.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslKeySecret": {
-              "description": "This parameter specifies the Kubernetes Secret name and key used for the client certificate SSL secret key.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslMode": {
-              "description": "PostgreSQL sslmode setup. Values can be disable, allow, prefer, require, verify-ca, verify-full.",
-              "type": "string",
-              "enum": [
-                "disable",
-                "allow",
-                "prefer",
-                "require",
-                "verify-ca",
-                "verify-full"
-              ]
-            },
-            "sslPasswordSecret": {
-              "description": "This parameter specifies the Kubernetes Secret name and key of the password for the SSL secret key specified in sslKeySecret, allowing client certificate private keys to be stored in encrypted form on disk even when interactive passphrase input is not practical.",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslRootCertificateConfigMap": {
-              "description": "This parameter specifies the Kubernetes ConfigMap name and key containing SSL certificate authority (CA) certificate(s).",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in configmap",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes configmap name",
-                  "type": "string"
-                }
-              }
-            },
-            "sslRootCertificateSecret": {
-              "description": "This parameter specifies the Kubernetes Secret name and key containing SSL certificate authority (CA) certificate(s).",
-              "type": "object",
-              "required": [
-                "key",
-                "name"
-              ],
-              "properties": {
-                "key": {
-                  "description": "Key name in secret",
-                  "type": "string"
-                },
-                "name": {
-                  "description": "Kubernetes secret name",
-                  "type": "string"
-                }
-              }
-            },
-            "username": {
-              "description": "PostgreSQL username to connect as.",
-              "type": "string"
-            }
-          }
-        },
-        "rest": {
-          "description": "Configuration for REST endpoint",
-          "type": "object",
-          "properties": {
-            "image": {
-              "description": "Optional image to support overriding the image deployed by the operator.",
-              "type": "string"
-            },
-            "port": {
-              "description": "Listen port for REST connections, defaults to 8080.",
-              "type": "integer",
-              "format": "int32",
-              "maximum": 65535,
-              "minimum": 1
-            },
-            "resources": {
-              "description": "Resource requirements",
-              "type": "object",
-              "properties": {
-                "claims": {
-                  "description": "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable. It can only be set for containers.",
-                  "type": "array",
-                  "items": {
-                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
-                    "type": "object",
-                    "required": [
-                      "name"
-                    ],
-                    "properties": {
-                      "name": {
-                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.",
-                        "type": "string"
-                      }
-                    }
+                "type": "object",
+                "properties": {
+                  "contextDir": {
+                    "description": "contextDir is the relative path to the folder containing manifests in a repository, default value \"manifests\"",
+                    "type": "string"
                   },
-                  "x-kubernetes-list-map-keys": [
-                    "name"
-                  ],
-                  "x-kubernetes-list-type": "map"
-                },
-                "limits": {
-                  "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                  "type": "object",
-                  "additionalProperties": {
-                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                    "x-kubernetes-int-or-string": true
-                  }
-                },
-                "requests": {
-                  "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
-                  "type": "object",
-                  "additionalProperties": {
-                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
-                    "x-kubernetes-int-or-string": true
+                  "sourcePath": {
+                    "description": "sourcePath is the subpath within contextDir where kustomize builds start. Examples include any sub-folder or path: `base`, `overlays/dev`, `default`, `odh` etc.",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "uri is the URI point to a git repo with tag/branch. e.g.  https://github.com/org/repo/tarball/<tag/branch>",
+                    "type": "string"
                   }
                 }
               }
-            },
-            "serviceRoute": {
-              "description": "Create an OpenShift Route for REST Service",
-              "type": "string",
-              "enum": [
-                "disabled",
-                "enabled"
-              ]
             }
           }
+        },
+        "registriesNamespace": {
+          "description": "Namespace for model registries to be installed, configurable only once when model registry is enabled, defaults to \"rhoai-model-registries\"",
+          "type": "string",
+          "maxLength": 63,
+          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
         }
       }
     },
@@ -596,38 +60,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition. This may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -639,39 +104,67 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
               }
             }
-          }
+          },
+          "x-kubernetes-list-type": "atomic"
         },
-        "hosts": {
-          "description": "Hosts where model registry services are available NOTE: Gateway service names are different for gRPC and REST service routes",
+        "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "phase": {
+          "type": "string"
+        },
+        "registriesNamespace": {
+          "type": "string"
+        },
+        "releases": {
           "type": "array",
           "items": {
-            "type": "string"
-          }
-        },
-        "hostsStr": {
-          "description": "Formatted Host names separated by comma",
-          "type": "string"
-        },
-        "specDefaults": {
-          "description": "SpecDefaults is a JSON string containing default spec values that were used for model registry deployment",
-          "type": "string"
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "modelregistry.opendatahub.io",
+      "group": "components.platform.opendatahub.io",
       "kind": "ModelRegistry",
       "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],
+  "x-kubernetes-validations": [
+    {
+      "message": "ModelRegistry name must be default-modelregistry",
+      "rule": "self.metadata.name == 'default-modelregistry'"
+    }
+  ],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/modelregistrylist.json
+++ b/class_generator/schema/modelregistrylist.json
@@ -13,7 +13,7 @@
       "description": "List of modelregistries. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.opendatahub.modelregistry.v1alpha1.ModelRegistry"
+        "$ref": "_definitions.json#/definitions/io.opendatahub.platform.components.v1alpha1.ModelRegistry"
       }
     },
     "kind": {
@@ -27,7 +27,7 @@
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "modelregistry.opendatahub.io",
+      "group": "components.platform.opendatahub.io",
       "kind": "ModelRegistryList",
       "version": "v1alpha1"
     }

--- a/class_generator/schema/monitoring.json
+++ b/class_generator/schema/monitoring.json
@@ -22,7 +22,13 @@
           "description": "monitoring spec exposed to DSCI api\nNamespace for monitoring if it is enabled",
           "type": "string",
           "maxLength": 63,
-          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
+          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$",
+          "x-kubernetes-validations": [
+            {
+              "message": "MonitoringNamespace is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
         }
       }
     },
@@ -33,38 +39,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -83,12 +90,10 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
@@ -108,6 +113,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "Monitoring name must be default-monitoring",

--- a/class_generator/schema/monitoringlist.json
+++ b/class_generator/schema/monitoringlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/mpijob.json
+++ b/class_generator/schema/mpijob.json
@@ -136,10 +136,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -165,10 +167,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
@@ -179,7 +183,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
@@ -219,10 +224,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -248,14 +255,17 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
@@ -312,10 +322,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -328,7 +340,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -336,7 +348,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -371,10 +383,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -391,7 +405,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -405,7 +420,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -445,10 +461,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -461,7 +479,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -469,7 +487,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -504,10 +522,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -524,14 +544,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -585,10 +607,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -601,7 +625,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -609,7 +633,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -644,10 +668,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -664,7 +690,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -678,7 +705,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -718,10 +746,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -734,7 +764,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -742,7 +772,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -777,10 +807,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -797,14 +829,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           }
@@ -829,14 +863,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -872,7 +908,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -935,7 +971,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -948,7 +984,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -962,7 +1002,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -981,7 +1021,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -992,7 +1032,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -1019,7 +1060,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1054,7 +1096,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1116,7 +1159,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1151,7 +1195,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1215,7 +1260,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1237,7 +1283,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1273,7 +1319,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1390,7 +1437,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1412,7 +1460,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1448,7 +1496,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1536,7 +1585,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -1547,6 +1596,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -1586,6 +1639,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -1596,7 +1666,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -1604,7 +1675,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1613,7 +1685,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -1668,7 +1740,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -1710,7 +1782,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1732,7 +1805,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1768,7 +1841,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1868,7 +1942,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -1886,7 +1964,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -1897,6 +1975,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -1906,14 +1988,22 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "dnsConfig": {
                         "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
@@ -1924,7 +2014,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "options": {
                             "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
@@ -1941,14 +2032,16 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "searches": {
                             "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -1975,14 +2068,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -2018,7 +2113,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2081,7 +2176,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2094,7 +2189,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -2108,7 +2207,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2127,7 +2226,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2138,7 +2237,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
@@ -2165,7 +2265,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2200,7 +2301,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2262,7 +2364,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2297,7 +2400,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2361,7 +2465,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2383,7 +2488,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2419,7 +2524,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2536,7 +2642,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2558,7 +2665,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2594,7 +2701,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2682,7 +2790,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -2693,6 +2801,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -2732,6 +2844,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -2742,7 +2871,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -2750,7 +2880,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2759,7 +2890,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -2814,7 +2945,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -2856,7 +2987,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2878,7 +3010,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2914,7 +3046,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2983,7 +3116,7 @@
                               "type": "boolean"
                             },
                             "targetContainerName": {
-                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\n\nThe container runtime must implement support for this feature.",
+                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature.",
                               "type": "string"
                             },
                             "terminationMessagePath": {
@@ -3018,7 +3151,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.\nCannot be updated.",
@@ -3036,7 +3173,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -3047,6 +3184,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -3056,35 +3197,51 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostAliases": {
-                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified.",
                         "type": "array",
                         "items": {
                           "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                           "type": "object",
+                          "required": [
+                            "ip"
+                          ],
                           "properties": {
                             "hostnames": {
                               "description": "Hostnames for the above IP address.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "ip": {
                               "description": "IP address of the host file entry.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "ip"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostIPC": {
                         "description": "Use the host's ipc namespace.\nOptional: Default to false.",
@@ -3114,12 +3271,16 @@
                           "type": "object",
                           "properties": {
                             "name": {
-                              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             }
                           },
                           "x-kubernetes-map-type": "atomic"
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "initContainers": {
                         "description": "List of initialization containers belonging to the pod.\nInit containers are executed in order prior to containers being started. If any\ninit container fails, the pod is considered to have failed and is handled according\nto its restartPolicy. The name for an init container or normal container must be\nunique among all containers.",
@@ -3136,14 +3297,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -3179,7 +3342,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3242,7 +3405,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3255,7 +3418,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -3269,7 +3436,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3288,7 +3455,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3299,7 +3466,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -3326,7 +3494,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3361,7 +3530,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3423,7 +3593,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3458,7 +3629,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3522,7 +3694,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3544,7 +3717,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3580,7 +3753,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3697,7 +3871,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3719,7 +3894,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3755,7 +3930,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3843,7 +4019,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -3854,6 +4030,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -3893,6 +4073,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -3903,7 +4100,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -3911,7 +4109,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3920,7 +4119,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -3975,7 +4174,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -4017,7 +4216,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4039,7 +4239,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4075,7 +4275,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4175,7 +4376,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -4193,7 +4398,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -4204,6 +4409,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -4213,17 +4422,25 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
-                        "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty,\nthe scheduler simply schedules this pod onto that node, assuming that it fits resource\nrequirements.",
+                        "description": "NodeName indicates in which node this pod is scheduled.\nIf empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.\nOnce this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.\nThis field should not be used to express a desire for the pod to be scheduled on a specific node.\nhttps://kubernetes.",
                         "type": "string"
                       },
                       "nodeSelector": {
@@ -4235,7 +4452,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.",
+                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.appArmorProfile\n- spec.securityContext.",
                         "type": "object",
                         "required": [
                           "name"
@@ -4283,13 +4500,14 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
-                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable.",
+                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
                         "type": "array",
                         "items": {
-                          "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource.\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
+                          "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                           "type": "object",
                           "required": [
                             "name"
@@ -4299,19 +4517,13 @@
                               "description": "Name uniquely identifies this resource claim inside the pod.\nThis must be a DNS_LABEL.",
                               "type": "string"
                             },
-                            "source": {
-                              "description": "Source describes where to find the ResourceClaim.",
-                              "type": "object",
-                              "properties": {
-                                "resourceClaimName": {
-                                  "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.",
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
-                                  "type": "string"
-                                }
-                              }
+                            "resourceClaimName": {
+                              "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
+                              "type": "string"
                             }
                           }
                         },
@@ -4333,7 +4545,7 @@
                         "type": "string"
                       },
                       "schedulingGates": {
-                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.\n\n\nThis is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
                         "type": "array",
                         "items": {
                           "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
@@ -4357,8 +4569,25 @@
                         "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.",
                         "type": "object",
                         "properties": {
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            }
+                          },
                           "fsGroup": {
-                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
+                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
                             "type": "integer",
                             "format": "int64"
                           },
@@ -4414,18 +4643,23 @@
                                 "type": "string"
                               },
                               "type": {
-                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                 "type": "string"
                               }
                             }
                           },
                           "supplementalGroups": {
-                            "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container.",
+                            "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.",
                             "type": "array",
                             "items": {
                               "type": "integer",
                               "format": "int64"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
                           },
                           "sysctls": {
                             "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
@@ -4447,7 +4681,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "windowsOptions": {
                             "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
@@ -4474,7 +4709,7 @@
                         }
                       },
                       "serviceAccount": {
-                        "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
+                        "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
                         "type": "string"
                       },
                       "serviceAccountName": {
@@ -4527,7 +4762,8 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologySpreadConstraints": {
                         "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology\ndomains. Scheduler will schedule pods in a way which abides by the constraints.\nAll topologySpreadConstraints are ANDed.",
@@ -4569,10 +4805,12 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -4603,11 +4841,11 @@
                               "format": "int32"
                             },
                             "nodeAffinityPolicy": {
-                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
                               "type": "string"
                             },
                             "nodeTaintsPolicy": {
-                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
                               "type": "string"
                             },
                             "topologyKey": {
@@ -4644,7 +4882,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -4730,7 +4968,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "path": {
                                   "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
@@ -4749,7 +4988,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4781,7 +5020,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4827,10 +5066,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
-                                  "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -4860,7 +5100,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4899,7 +5139,7 @@
                                     ],
                                     "properties": {
                                       "fieldRef": {
-                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                         "type": "object",
                                         "required": [
                                           "fieldPath"
@@ -4949,7 +5189,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5018,7 +5259,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "dataSource": {
                                           "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.",
@@ -5119,10 +5361,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5161,7 +5405,7 @@
                               "type": "object",
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                   "type": "string"
                                 },
                                 "lun": {
@@ -5178,14 +5422,16 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "wwids": {
                                   "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5220,7 +5466,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5250,7 +5496,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5312,7 +5558,7 @@
                               }
                             },
                             "hostPath": {
-                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.",
+                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                               "type": "object",
                               "required": [
                                 "path"
@@ -5324,6 +5570,20 @@
                                 },
                                 "type": {
                                   "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact.",
+                              "type": "object",
+                              "properties": {
+                                "pullPolicy": {
+                                  "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk.",
+                                  "type": "string"
+                                },
+                                "reference": {
+                                  "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.",
                                   "type": "string"
                                 }
                               }
@@ -5346,7 +5606,7 @@
                                   "type": "boolean"
                                 },
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                                   "type": "string"
                                 },
                                 "initiatorName": {
@@ -5371,7 +5631,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
@@ -5382,7 +5643,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5485,14 +5746,14 @@
                                   "format": "int32"
                                 },
                                 "sources": {
-                                  "description": "sources is the list of volume projections",
+                                  "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                                   "type": "array",
                                   "items": {
-                                    "description": "Projection that may be projected along with other supported volume types",
+                                    "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                                     "type": "object",
                                     "properties": {
                                       "clusterTrustBundle": {
-                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
+                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
                                         "type": "object",
                                         "required": [
                                           "path"
@@ -5526,10 +5787,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5588,10 +5851,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -5616,7 +5880,7 @@
                                               ],
                                               "properties": {
                                                 "fieldRef": {
-                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                                   "type": "object",
                                                   "required": [
                                                     "fieldPath"
@@ -5666,7 +5930,8 @@
                                                   "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -5699,10 +5964,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -5735,7 +6001,8 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5782,7 +6049,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                                   "type": "string"
                                 },
                                 "image": {
@@ -5798,7 +6065,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "pool": {
                                   "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -5813,7 +6081,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5855,7 +6123,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5917,7 +6185,8 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "optional": {
                                   "description": "optional field specify whether the Secret or its keys must be defined",
@@ -5946,7 +6215,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5988,7 +6257,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       }
                     }
                   }
@@ -6015,6 +6288,10 @@
               "description": "CleanPodPolicy defines the policy to kill pods after the job completes.\nDefault to None.",
               "type": "string"
             },
+            "managedBy": {
+              "description": "ManagedBy is used to indicate the controller or entity that manages a job.\nThe value must be either an empty, 'kubeflow.org/training-operator' or\n'kueue.x-k8s.io/multikueue'.\nThe training-operator reconciles a job which doesn't have this\nfield at all or the field value is the reserved string\n'kubeflow.org/training-operator', but delegates reconciling the job\nwith 'kueue.x-k8s.",
+              "type": "string"
+            },
             "schedulingPolicy": {
               "description": "SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling",
               "type": "object",
@@ -6034,7 +6311,13 @@
                   "type": "string"
                 },
                 "queue": {
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "spec.runPolicy.schedulingPolicy.queue is immutable",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
                 },
                 "scheduleTimeoutSeconds": {
                   "type": "integer",
@@ -6159,10 +6442,12 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
-                    }
+                    },
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -6201,5 +6486,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/mpijoblist.json
+++ b/class_generator/schema/mpijoblist.json
@@ -32,5 +32,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/multikueuecluster.json
+++ b/class_generator/schema/multikueuecluster.json
@@ -29,7 +29,7 @@
           ],
           "properties": {
             "location": {
-              "description": "Location of the KubeConfig.\n\n\nIf LocationType is Secret then Location is the name of the secret inside the namespace in\nwhich the kueue controller manager is running. The config should be stored in the \"kubeconfig\" key.",
+              "description": "Location of the KubeConfig.\n\nIf LocationType is Secret then Location is the name of the secret inside the namespace in\nwhich the kueue controller manager is running. The config should be stored in the \"kubeconfig\" key.",
               "type": "string"
             },
             "locationType": {
@@ -50,7 +50,7 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -93,7 +93,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
@@ -112,7 +112,7 @@
     {
       "group": "kueue.x-k8s.io",
       "kind": "MultiKueueCluster",
-      "version": "v1alpha1"
+      "version": "v1beta1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/multikueueclusterlist.json
+++ b/class_generator/schema/multikueueclusterlist.json
@@ -13,7 +13,7 @@
       "description": "List of multikueueclusters. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1alpha1.MultiKueueCluster"
+        "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.MultiKueueCluster"
       }
     },
     "kind": {
@@ -29,7 +29,7 @@
     {
       "group": "kueue.x-k8s.io",
       "kind": "MultiKueueClusterList",
-      "version": "v1alpha1"
+      "version": "v1beta1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/multikueueconfig.json
+++ b/class_generator/schema/multikueueconfig.json
@@ -38,7 +38,7 @@
     {
       "group": "kueue.x-k8s.io",
       "kind": "MultiKueueConfig",
-      "version": "v1alpha1"
+      "version": "v1beta1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/multikueueconfiglist.json
+++ b/class_generator/schema/multikueueconfiglist.json
@@ -13,7 +13,7 @@
       "description": "List of multikueueconfigs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1alpha1.MultiKueueConfig"
+        "$ref": "_definitions.json#/definitions/io.x-k8s.kueue.v1beta1.MultiKueueConfig"
       }
     },
     "kind": {
@@ -29,7 +29,7 @@
     {
       "group": "kueue.x-k8s.io",
       "kind": "MultiKueueConfigList",
-      "version": "v1alpha1"
+      "version": "v1beta1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/network.json
+++ b/class_generator/schema/network.json
@@ -348,6 +348,21 @@
                   "description": "ipsecConfig enables and configures IPsec for pods on the pod network within the\ncluster.",
                   "type": "object",
                   "properties": {
+                    "full": {
+                      "description": "full defines configuration parameters for the IPsec `Full` mode.\nThis is permitted only when mode is configured with `Full`,\nand forbidden otherwise.",
+                      "type": "object",
+                      "minProperties": 1,
+                      "properties": {
+                        "encapsulation": {
+                          "description": "encapsulation option to configure libreswan on how inter-pod traffic across nodes\nare encapsulated to handle NAT traversal. When configured it uses UDP port 4500\nfor the encapsulation.\nValid values are Always, Auto and omitted.\nAlways means enable UDP encapsulation regardless of whether NAT is detected.\nAuto means enable UDP encapsulation based on the detection of NAT.\nWhen omitted, this means no opinion and the platform is left to choose a reasonable\ndefault, which is subject to change over time. The current default is Auto.",
+                          "type": "string",
+                          "enum": [
+                            "Always",
+                            "Auto"
+                          ]
+                        }
+                      }
+                    },
                     "mode": {
                       "description": "mode defines the behaviour of the ipsec configuration within the platform.\nValid values are `Disabled`, `External` and `Full`.\nWhen 'Disabled', ipsec will not be enabled at the node level.\nWhen 'External', ipsec is enabled on the node level but requires the user to configure the secure communication parameters.\nThis mode is for external secure communications and the configuration can be done using the k8s-nmstate operator.\nWhen 'Full', ipsec is configured on the node level and inter-pod secure communication within the cluster is configured.\nNote with `Full`, if ipsec is desired for communication with external (to the cluster) entities (such as storage arrays),\nthis is left to the user to configure.",
                       "type": "string",
@@ -362,6 +377,10 @@
                     {
                       "message": "ipsecConfig.mode is required",
                       "rule": "self == oldSelf || has(self.mode)"
+                    },
+                    {
+                      "message": "full is forbidden when mode is not Full",
+                      "rule": "has(self.mode) && self.mode == 'Full' ?  true : !has(self.full)"
                     }
                   ]
                 },
@@ -414,7 +433,7 @@
                   "type": "object",
                   "properties": {
                     "internalJoinSubnet": {
-                      "description": "internalJoinSubnet is a v6 subnet used internally by ovn-kubernetes in case the\ndefault one is being already used by something else. It must not overlap with\nany other subnet being used by OpenShift or by the node network. The size of the\nsubnet must be larger than the number of nodes. The value cannot be changed\nafter installation.\nThe subnet must be large enough to accomadate one IP per node in your cluster\nThe current default value is fd98::/48\nThe value must be in proper IPV6 CIDR format\nNote that IPV6 dual addresses are not permitted",
+                      "description": "internalJoinSubnet is a v6 subnet used internally by ovn-kubernetes in case the\ndefault one is being already used by something else. It must not overlap with\nany other subnet being used by OpenShift or by the node network. The size of the\nsubnet must be larger than the number of nodes. The value cannot be changed\nafter installation.\nThe subnet must be large enough to accomadate one IP per node in your cluster\nThe current default value is fd98::/64\nThe value must be in proper IPV6 CIDR format\nNote that IPV6 dual addresses are not permitted",
                       "type": "string",
                       "maxLength": 48,
                       "x-kubernetes-validations": [
@@ -488,7 +507,7 @@
                   "type": "string"
                 },
                 "v6InternalSubnet": {
-                  "description": "v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the\ndefault one is being already used by something else. It must not overlap with\nany other subnet being used by OpenShift or by the node network. The size of the\nsubnet must be larger than the number of nodes. The value cannot be changed\nafter installation.\nDefault is fd98::/48",
+                  "description": "v6InternalSubnet is a v6 subnet used internally by ovn-kubernetes in case the\ndefault one is being already used by something else. It must not overlap with\nany other subnet being used by OpenShift or by the node network. The size of the\nsubnet must be larger than the number of nodes. The value cannot be changed\nafter installation.\nDefault is fd98::/64",
                   "type": "string"
                 }
               }
@@ -504,7 +523,7 @@
           "type": "boolean"
         },
         "disableMultiNetwork": {
-          "description": "disableMultiNetwork specifies whether or not multiple pod network\nsupport should be disabled. If unset, this property defaults to\n'false' and multiple network support is enabled.",
+          "description": "disableMultiNetwork defaults to 'false' and this setting enables the pod multi-networking capability.\ndisableMultiNetwork when set to 'true' at cluster install time does not install the components, typically the Multus CNI and the network-attachment-definition CRD,\nthat enable the pod multi-networking capability. Setting the parameter to 'true' might be useful when you need install third-party CNI plugins,\nbut these plugins are not supported by Red Hat. Changing the parameter value as a postinstallation cluster task has no effect.",
           "type": "boolean"
         },
         "disableNetworkDiagnostics": {

--- a/class_generator/schema/node.json
+++ b/class_generator/schema/node.json
@@ -25,7 +25,6 @@
           "description": "cgroupMode determines the cgroups version on the node",
           "type": "string",
           "enum": [
-            "v1",
             "v2",
             ""
           ]

--- a/class_generator/schema/odhapplication.json
+++ b/class_generator/schema/odhapplication.json
@@ -67,6 +67,9 @@
             "description": {
               "type": "string"
             },
+            "inProgressText": {
+              "type": "string"
+            },
             "link": {
               "type": "string"
             },

--- a/class_generator/schema/odhdashboardconfig.json
+++ b/class_generator/schema/odhdashboardconfig.json
@@ -25,6 +25,9 @@
             "disableAcceleratorProfiles": {
               "type": "boolean"
             },
+            "disableAdminConnectionTypes": {
+              "type": "boolean"
+            },
             "disableBYONImageStream": {
               "type": "boolean"
             },
@@ -35,6 +38,12 @@
               "type": "boolean"
             },
             "disableDistributedWorkloads": {
+              "type": "boolean"
+            },
+            "disableFineTuning": {
+              "type": "boolean"
+            },
+            "disableHardwareProfiles": {
               "type": "boolean"
             },
             "disableHome": {
@@ -55,10 +64,19 @@
             "disableKServeMetrics": {
               "type": "boolean"
             },
+            "disableKServeRaw": {
+              "type": "boolean"
+            },
+            "disableModelCatalog": {
+              "type": "boolean"
+            },
             "disableModelMesh": {
               "type": "boolean"
             },
             "disableModelRegistry": {
+              "type": "boolean"
+            },
+            "disableModelRegistrySecureDB": {
               "type": "boolean"
             },
             "disableModelServing": {
@@ -71,6 +89,9 @@
               "type": "boolean"
             },
             "disablePipelines": {
+              "type": "boolean"
+            },
+            "disableProjectScoped": {
               "type": "boolean"
             },
             "disableProjectSharing": {
@@ -115,7 +136,13 @@
             "allowedGroups": {
               "type": "string"
             }
-          }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Can no longer modify group configurations here, see the Auth resource instead",
+              "rule": "self == oldSelf"
+            }
+          ]
         },
         "modelServerSizes": {
           "type": "array",

--- a/class_generator/schema/paddlejob.json
+++ b/class_generator/schema/paddlejob.json
@@ -139,10 +139,12 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -256,10 +258,12 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -350,10 +354,12 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -562,10 +568,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -591,10 +599,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
@@ -605,7 +615,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
@@ -645,10 +656,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -674,14 +687,17 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
@@ -738,10 +754,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -754,7 +772,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -762,7 +780,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -797,10 +815,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -817,7 +837,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -831,7 +852,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -871,10 +893,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -887,7 +911,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -895,7 +919,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -930,10 +954,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -950,14 +976,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -1011,10 +1039,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1027,7 +1057,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -1035,7 +1065,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -1070,10 +1100,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1090,7 +1122,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -1104,7 +1137,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -1144,10 +1178,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1160,7 +1196,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -1168,7 +1204,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -1203,10 +1239,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1223,14 +1261,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           }
@@ -1255,14 +1295,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -1298,7 +1340,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1361,7 +1403,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1374,7 +1416,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -1388,7 +1434,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1407,7 +1453,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1418,7 +1464,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -1445,7 +1492,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1480,7 +1528,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1542,7 +1591,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1577,7 +1627,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1641,7 +1692,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1663,7 +1715,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1699,7 +1751,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1816,7 +1869,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1838,7 +1892,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1874,7 +1928,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1962,7 +2017,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -1973,6 +2028,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -2012,6 +2071,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -2022,7 +2098,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -2030,7 +2107,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2039,7 +2117,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -2094,7 +2172,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -2136,7 +2214,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2158,7 +2237,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2194,7 +2273,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2294,7 +2374,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -2312,7 +2396,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -2323,6 +2407,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -2332,14 +2420,22 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "dnsConfig": {
                         "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
@@ -2350,7 +2446,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "options": {
                             "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
@@ -2367,14 +2464,16 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "searches": {
                             "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -2401,14 +2500,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -2444,7 +2545,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2507,7 +2608,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2520,7 +2621,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -2534,7 +2639,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2553,7 +2658,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2564,7 +2669,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
@@ -2591,7 +2697,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2626,7 +2733,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2688,7 +2796,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2723,7 +2832,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2787,7 +2897,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2809,7 +2920,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2845,7 +2956,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2962,7 +3074,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2984,7 +3097,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3020,7 +3133,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3108,7 +3222,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -3119,6 +3233,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -3158,6 +3276,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -3168,7 +3303,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -3176,7 +3312,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3185,7 +3322,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -3240,7 +3377,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -3282,7 +3419,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3304,7 +3442,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3340,7 +3478,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3409,7 +3548,7 @@
                               "type": "boolean"
                             },
                             "targetContainerName": {
-                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\n\nThe container runtime must implement support for this feature.",
+                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature.",
                               "type": "string"
                             },
                             "terminationMessagePath": {
@@ -3444,7 +3583,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.\nCannot be updated.",
@@ -3462,7 +3605,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -3473,6 +3616,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -3482,35 +3629,51 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostAliases": {
-                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified.",
                         "type": "array",
                         "items": {
                           "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                           "type": "object",
+                          "required": [
+                            "ip"
+                          ],
                           "properties": {
                             "hostnames": {
                               "description": "Hostnames for the above IP address.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "ip": {
                               "description": "IP address of the host file entry.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "ip"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostIPC": {
                         "description": "Use the host's ipc namespace.\nOptional: Default to false.",
@@ -3540,12 +3703,16 @@
                           "type": "object",
                           "properties": {
                             "name": {
-                              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             }
                           },
                           "x-kubernetes-map-type": "atomic"
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "initContainers": {
                         "description": "List of initialization containers belonging to the pod.\nInit containers are executed in order prior to containers being started. If any\ninit container fails, the pod is considered to have failed and is handled according\nto its restartPolicy. The name for an init container or normal container must be\nunique among all containers.",
@@ -3562,14 +3729,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -3605,7 +3774,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3668,7 +3837,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3681,7 +3850,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -3695,7 +3868,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3714,7 +3887,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3725,7 +3898,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -3752,7 +3926,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3787,7 +3962,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3849,7 +4025,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3884,7 +4061,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3948,7 +4126,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3970,7 +4149,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4006,7 +4185,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4123,7 +4303,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4145,7 +4326,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4181,7 +4362,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4269,7 +4451,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -4280,6 +4462,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -4319,6 +4505,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -4329,7 +4532,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -4337,7 +4541,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4346,7 +4551,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -4401,7 +4606,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -4443,7 +4648,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4465,7 +4671,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4501,7 +4707,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4601,7 +4808,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -4619,7 +4830,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -4630,6 +4841,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -4639,17 +4854,25 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
-                        "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty,\nthe scheduler simply schedules this pod onto that node, assuming that it fits resource\nrequirements.",
+                        "description": "NodeName indicates in which node this pod is scheduled.\nIf empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.\nOnce this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.\nThis field should not be used to express a desire for the pod to be scheduled on a specific node.\nhttps://kubernetes.",
                         "type": "string"
                       },
                       "nodeSelector": {
@@ -4661,7 +4884,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.",
+                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.appArmorProfile\n- spec.securityContext.",
                         "type": "object",
                         "required": [
                           "name"
@@ -4709,13 +4932,14 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
-                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable.",
+                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
                         "type": "array",
                         "items": {
-                          "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource.\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
+                          "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                           "type": "object",
                           "required": [
                             "name"
@@ -4725,19 +4949,13 @@
                               "description": "Name uniquely identifies this resource claim inside the pod.\nThis must be a DNS_LABEL.",
                               "type": "string"
                             },
-                            "source": {
-                              "description": "Source describes where to find the ResourceClaim.",
-                              "type": "object",
-                              "properties": {
-                                "resourceClaimName": {
-                                  "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.",
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
-                                  "type": "string"
-                                }
-                              }
+                            "resourceClaimName": {
+                              "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
+                              "type": "string"
                             }
                           }
                         },
@@ -4759,7 +4977,7 @@
                         "type": "string"
                       },
                       "schedulingGates": {
-                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.\n\n\nThis is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
                         "type": "array",
                         "items": {
                           "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
@@ -4783,8 +5001,25 @@
                         "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.",
                         "type": "object",
                         "properties": {
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            }
+                          },
                           "fsGroup": {
-                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
+                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
                             "type": "integer",
                             "format": "int64"
                           },
@@ -4840,18 +5075,23 @@
                                 "type": "string"
                               },
                               "type": {
-                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                 "type": "string"
                               }
                             }
                           },
                           "supplementalGroups": {
-                            "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container.",
+                            "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.",
                             "type": "array",
                             "items": {
                               "type": "integer",
                               "format": "int64"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
                           },
                           "sysctls": {
                             "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
@@ -4873,7 +5113,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "windowsOptions": {
                             "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
@@ -4900,7 +5141,7 @@
                         }
                       },
                       "serviceAccount": {
-                        "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
+                        "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
                         "type": "string"
                       },
                       "serviceAccountName": {
@@ -4953,7 +5194,8 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologySpreadConstraints": {
                         "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology\ndomains. Scheduler will schedule pods in a way which abides by the constraints.\nAll topologySpreadConstraints are ANDed.",
@@ -4995,10 +5237,12 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5029,11 +5273,11 @@
                               "format": "int32"
                             },
                             "nodeAffinityPolicy": {
-                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
                               "type": "string"
                             },
                             "nodeTaintsPolicy": {
-                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
                               "type": "string"
                             },
                             "topologyKey": {
@@ -5070,7 +5314,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5156,7 +5400,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "path": {
                                   "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
@@ -5175,7 +5420,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5207,7 +5452,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5253,10 +5498,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
-                                  "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -5286,7 +5532,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5325,7 +5571,7 @@
                                     ],
                                     "properties": {
                                       "fieldRef": {
-                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                         "type": "object",
                                         "required": [
                                           "fieldPath"
@@ -5375,7 +5621,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5444,7 +5691,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "dataSource": {
                                           "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.",
@@ -5545,10 +5793,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5587,7 +5837,7 @@
                               "type": "object",
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                   "type": "string"
                                 },
                                 "lun": {
@@ -5604,14 +5854,16 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "wwids": {
                                   "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5646,7 +5898,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5676,7 +5928,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5738,7 +5990,7 @@
                               }
                             },
                             "hostPath": {
-                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.",
+                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                               "type": "object",
                               "required": [
                                 "path"
@@ -5750,6 +6002,20 @@
                                 },
                                 "type": {
                                   "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact.",
+                              "type": "object",
+                              "properties": {
+                                "pullPolicy": {
+                                  "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk.",
+                                  "type": "string"
+                                },
+                                "reference": {
+                                  "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.",
                                   "type": "string"
                                 }
                               }
@@ -5772,7 +6038,7 @@
                                   "type": "boolean"
                                 },
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                                   "type": "string"
                                 },
                                 "initiatorName": {
@@ -5797,7 +6063,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
@@ -5808,7 +6075,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5911,14 +6178,14 @@
                                   "format": "int32"
                                 },
                                 "sources": {
-                                  "description": "sources is the list of volume projections",
+                                  "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                                   "type": "array",
                                   "items": {
-                                    "description": "Projection that may be projected along with other supported volume types",
+                                    "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                                     "type": "object",
                                     "properties": {
                                       "clusterTrustBundle": {
-                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
+                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
                                         "type": "object",
                                         "required": [
                                           "path"
@@ -5952,10 +6219,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -6014,10 +6283,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -6042,7 +6312,7 @@
                                               ],
                                               "properties": {
                                                 "fieldRef": {
-                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                                   "type": "object",
                                                   "required": [
                                                     "fieldPath"
@@ -6092,7 +6362,8 @@
                                                   "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -6125,10 +6396,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -6161,7 +6433,8 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -6208,7 +6481,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                                   "type": "string"
                                 },
                                 "image": {
@@ -6224,7 +6497,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "pool": {
                                   "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -6239,7 +6513,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6281,7 +6555,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6343,7 +6617,8 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "optional": {
                                   "description": "optional field specify whether the Secret or its keys must be defined",
@@ -6372,7 +6647,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6414,7 +6689,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       }
                     }
                   }
@@ -6441,6 +6720,10 @@
               "description": "CleanPodPolicy defines the policy to kill pods after the job completes.\nDefault to None.",
               "type": "string"
             },
+            "managedBy": {
+              "description": "ManagedBy is used to indicate the controller or entity that manages a job.\nThe value must be either an empty, 'kubeflow.org/training-operator' or\n'kueue.x-k8s.io/multikueue'.\nThe training-operator reconciles a job which doesn't have this\nfield at all or the field value is the reserved string\n'kubeflow.org/training-operator', but delegates reconciling the job\nwith 'kueue.x-k8s.",
+              "type": "string"
+            },
             "schedulingPolicy": {
               "description": "SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling",
               "type": "object",
@@ -6460,7 +6743,13 @@
                   "type": "string"
                 },
                 "queue": {
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "spec.runPolicy.schedulingPolicy.queue is immutable",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
                 },
                 "scheduleTimeoutSeconds": {
                   "type": "integer",
@@ -6580,10 +6869,12 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
-                    }
+                    },
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -6622,5 +6913,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/paddlejoblist.json
+++ b/class_generator/schema/paddlejoblist.json
@@ -32,5 +32,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/persistentvolumeclaimvolumesource.json
+++ b/class_generator/schema/persistentvolumeclaimvolumesource.json
@@ -1,5 +1,5 @@
 {
-  "description": "PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. Directly attached to the vmi via qemu. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+  "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
   "type": "object",
   "required": [
     "claimName"
@@ -7,12 +7,7 @@
   "properties": {
     "claimName": {
       "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
-      "type": "string",
-      "default": ""
-    },
-    "hotpluggable": {
-      "description": "Hotpluggable indicates whether the volume can be hotplugged and hotunplugged.",
-      "type": "boolean"
+      "type": "string"
     },
     "readOnly": {
       "description": "readOnly Will force the ReadOnly setting in VolumeMounts. Default false.",

--- a/class_generator/schema/podnetworkconnectivitycheck.json
+++ b/class_generator/schema/podnetworkconnectivitycheck.json
@@ -18,7 +18,7 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "Spec defines the source and target of the connectivity check",
+      "description": "spec defines the source and target of the connectivity check",
       "type": "object",
       "required": [
         "sourcePod",
@@ -26,7 +26,7 @@
       ],
       "properties": {
         "sourcePod": {
-          "description": "SourcePod names the pod from which the condition will be checked",
+          "description": "sourcePod names the pod from which the condition will be checked",
           "type": "string",
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
         },
@@ -51,11 +51,11 @@
       }
     },
     "status": {
-      "description": "Status contains the observed status of the connectivity check",
+      "description": "status contains the observed status of the connectivity check",
       "type": "object",
       "properties": {
         "conditions": {
-          "description": "Conditions summarize the status of the check",
+          "description": "conditions summarize the status of the check",
           "type": "array",
           "items": {
             "description": "PodNetworkConnectivityCheckCondition represents the overall status of the pod network connectivity.",
@@ -70,26 +70,26 @@
                 "format": "date-time"
               },
               "message": {
-                "description": "Message indicating details about last transition in a human readable format.",
+                "description": "message indicating details about last transition in a human readable format.",
                 "type": "string"
               },
               "reason": {
-                "description": "Reason for the condition's last status transition in a machine readable format.",
+                "description": "reason for the condition's last status transition in a machine readable format.",
                 "type": "string"
               },
               "status": {
-                "description": "Status of the condition",
+                "description": "status of the condition",
                 "type": "string"
               },
               "type": {
-                "description": "Type of the condition",
+                "description": "type of the condition",
                 "type": "string"
               }
             }
           }
         },
         "failures": {
-          "description": "Failures contains logs of unsuccessful check actions",
+          "description": "failures contains logs of unsuccessful check actions",
           "type": "array",
           "items": {
             "description": "LogEntry records events",
@@ -99,18 +99,18 @@
             ],
             "properties": {
               "latency": {
-                "description": "Latency records how long the action mentioned in the entry took."
+                "description": "latency records how long the action mentioned in the entry took."
               },
               "message": {
-                "description": "Message explaining status in a human readable format.",
+                "description": "message explaining status in a human readable format.",
                 "type": "string"
               },
               "reason": {
-                "description": "Reason for status in a machine readable format.",
+                "description": "reason for status in a machine readable format.",
                 "type": "string"
               },
               "success": {
-                "description": "Success indicates if the log entry indicates a success or failure.",
+                "description": "success indicates if the log entry indicates a success or failure.",
                 "type": "boolean"
               },
               "time": {
@@ -121,18 +121,18 @@
           }
         },
         "outages": {
-          "description": "Outages contains logs of time periods of outages",
+          "description": "outages contains logs of time periods of outages",
           "type": "array",
           "items": {
             "description": "OutageEntry records time period of an outage",
             "type": "object",
             "properties": {
               "end": {
-                "description": "End of outage detected",
+                "description": "end of outage detected",
                 "format": "date-time"
               },
               "endLogs": {
-                "description": "EndLogs contains log entries related to the end of this outage. Should contain the success\nentry that resolved the outage and possibly a few of the failure log entries that preceded it.",
+                "description": "endLogs contains log entries related to the end of this outage. Should contain the success\nentry that resolved the outage and possibly a few of the failure log entries that preceded it.",
                 "type": "array",
                 "items": {
                   "description": "LogEntry records events",
@@ -142,18 +142,18 @@
                   ],
                   "properties": {
                     "latency": {
-                      "description": "Latency records how long the action mentioned in the entry took."
+                      "description": "latency records how long the action mentioned in the entry took."
                     },
                     "message": {
-                      "description": "Message explaining status in a human readable format.",
+                      "description": "message explaining status in a human readable format.",
                       "type": "string"
                     },
                     "reason": {
-                      "description": "Reason for status in a machine readable format.",
+                      "description": "reason for status in a machine readable format.",
                       "type": "string"
                     },
                     "success": {
-                      "description": "Success indicates if the log entry indicates a success or failure.",
+                      "description": "success indicates if the log entry indicates a success or failure.",
                       "type": "boolean"
                     },
                     "time": {
@@ -164,15 +164,15 @@
                 }
               },
               "message": {
-                "description": "Message summarizes outage details in a human readable format.",
+                "description": "message summarizes outage details in a human readable format.",
                 "type": "string"
               },
               "start": {
-                "description": "Start of outage detected",
+                "description": "start of outage detected",
                 "format": "date-time"
               },
               "startLogs": {
-                "description": "StartLogs contains log entries related to the start of this outage. Should contain\nthe original failure, any entries where the failure mode changed.",
+                "description": "startLogs contains log entries related to the start of this outage. Should contain\nthe original failure, any entries where the failure mode changed.",
                 "type": "array",
                 "items": {
                   "description": "LogEntry records events",
@@ -182,18 +182,18 @@
                   ],
                   "properties": {
                     "latency": {
-                      "description": "Latency records how long the action mentioned in the entry took."
+                      "description": "latency records how long the action mentioned in the entry took."
                     },
                     "message": {
-                      "description": "Message explaining status in a human readable format.",
+                      "description": "message explaining status in a human readable format.",
                       "type": "string"
                     },
                     "reason": {
-                      "description": "Reason for status in a machine readable format.",
+                      "description": "reason for status in a machine readable format.",
                       "type": "string"
                     },
                     "success": {
-                      "description": "Success indicates if the log entry indicates a success or failure.",
+                      "description": "success indicates if the log entry indicates a success or failure.",
                       "type": "boolean"
                     },
                     "time": {
@@ -207,7 +207,7 @@
           }
         },
         "successes": {
-          "description": "Successes contains logs successful check actions",
+          "description": "successes contains logs successful check actions",
           "type": "array",
           "items": {
             "description": "LogEntry records events",
@@ -217,18 +217,18 @@
             ],
             "properties": {
               "latency": {
-                "description": "Latency records how long the action mentioned in the entry took."
+                "description": "latency records how long the action mentioned in the entry took."
               },
               "message": {
-                "description": "Message explaining status in a human readable format.",
+                "description": "message explaining status in a human readable format.",
                 "type": "string"
               },
               "reason": {
-                "description": "Reason for status in a machine readable format.",
+                "description": "reason for status in a machine readable format.",
                 "type": "string"
               },
               "success": {
-                "description": "Success indicates if the log entry indicates a success or failure.",
+                "description": "success indicates if the log entry indicates a success or failure.",
                 "type": "boolean"
               },
               "time": {

--- a/class_generator/schema/provisioningrequestconfig.json
+++ b/class_generator/schema/provisioningrequestconfig.json
@@ -22,7 +22,7 @@
       ],
       "properties": {
         "managedResources": {
-          "description": "managedResources contains the list of resources managed by the autoscaling.\n\n\nIf empty, all resources are considered managed.\n\n\nIf not empty, the ProvisioningRequest will contain only the podsets that are\nrequesting at least one of them.\n\n\nIf none of the workloads podsets is requesting at least a managed resource,\nthe workload is considered ready.",
+          "description": "managedResources contains the list of resources managed by the autoscaling.\n\nIf empty, all resources are considered managed.\n\nIf not empty, the ProvisioningRequest will contain only the podsets that are\nrequesting at least one of them.\n\nIf none of the workloads podsets is requesting at least a managed resource,\nthe workload is considered ready.",
           "type": "array",
           "maxItems": 100,
           "items": {
@@ -46,6 +46,27 @@
           "type": "string",
           "maxLength": 253,
           "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+        },
+        "retryStrategy": {
+          "description": "retryStrategy defines strategy for retrying ProvisioningRequest.\nIf null, then the default configuration is applied with the following parameter values:\nbackoffLimitCount:  3\nbackoffBaseSeconds: 60 - 1 min\nbackoffMaxSeconds:  1800 - 30 mins\n\nTo switch off retry mechanism\nset retryStrategy.backoffLimitCount to 0.",
+          "type": "object",
+          "properties": {
+            "backoffBaseSeconds": {
+              "description": "BackoffBaseSeconds defines the base for the exponential backoff for\nre-queuing an evicted workload.\n\nDefaults to 60.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "backoffLimitCount": {
+              "description": "BackoffLimitCount defines the maximum number of re-queuing retries.\nOnce the number is reached, the workload is deactivated (`.spec.activate`=`false`).\n\nEvery backoff duration is about \"b*2^(n-1)+Rand\" where:\n- \"b\" represents the base set by \"BackoffBaseSeconds\" parameter,\n- \"n\" represents the \"workloadStatus.requeueState.count\",\n- \"Rand\" represents the random jitter.\nDuring this time, the workload is taken as an inadmissible and\nother workloads will have a chance to be admitted.\nBy default, the consecutive requeue delays are around: (60s, 120s, 240s, ...).\n\nDefaults to 3.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "backoffMaxSeconds": {
+              "description": "BackoffMaxSeconds defines the maximum backoff time to re-queue an evicted workload.\n\nDefaults to 1800.",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
         }
       }
     }

--- a/class_generator/schema/pytorchjob.json
+++ b/class_generator/schema/pytorchjob.json
@@ -137,10 +137,12 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -254,10 +256,12 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -348,10 +352,12 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -601,10 +607,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -630,10 +638,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
@@ -644,7 +654,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
@@ -684,10 +695,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -713,14 +726,17 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
@@ -777,10 +793,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -793,7 +811,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -801,7 +819,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -836,10 +854,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -856,7 +876,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -870,7 +891,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -910,10 +932,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -926,7 +950,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -934,7 +958,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -969,10 +993,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -989,14 +1015,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -1050,10 +1078,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1066,7 +1096,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -1074,7 +1104,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -1109,10 +1139,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1129,7 +1161,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -1143,7 +1176,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -1183,10 +1217,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1199,7 +1235,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -1207,7 +1243,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -1242,10 +1278,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -1262,14 +1300,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           }
@@ -1294,14 +1334,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -1337,7 +1379,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1400,7 +1442,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1413,7 +1455,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -1427,7 +1473,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1446,7 +1492,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1457,7 +1503,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -1484,7 +1531,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1519,7 +1567,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1581,7 +1630,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1616,7 +1666,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1680,7 +1731,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1702,7 +1754,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1738,7 +1790,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1855,7 +1908,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1877,7 +1931,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1913,7 +1967,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2001,7 +2056,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -2012,6 +2067,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -2051,6 +2110,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -2061,7 +2137,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -2069,7 +2146,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2078,7 +2156,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -2133,7 +2211,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -2175,7 +2253,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2197,7 +2276,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2233,7 +2312,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2333,7 +2413,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -2351,7 +2435,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -2362,6 +2446,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -2371,14 +2459,22 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "dnsConfig": {
                         "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
@@ -2389,7 +2485,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "options": {
                             "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
@@ -2406,14 +2503,16 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "searches": {
                             "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -2440,14 +2539,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -2483,7 +2584,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2546,7 +2647,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2559,7 +2660,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -2573,7 +2678,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2592,7 +2697,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2603,7 +2708,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
@@ -2630,7 +2736,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2665,7 +2772,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2727,7 +2835,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2762,7 +2871,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2826,7 +2936,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2848,7 +2959,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2884,7 +2995,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3001,7 +3113,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3023,7 +3136,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3059,7 +3172,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3147,7 +3261,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -3158,6 +3272,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -3197,6 +3315,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -3207,7 +3342,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -3215,7 +3351,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3224,7 +3361,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -3279,7 +3416,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -3321,7 +3458,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3343,7 +3481,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3379,7 +3517,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3448,7 +3587,7 @@
                               "type": "boolean"
                             },
                             "targetContainerName": {
-                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\n\nThe container runtime must implement support for this feature.",
+                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature.",
                               "type": "string"
                             },
                             "terminationMessagePath": {
@@ -3483,7 +3622,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.\nCannot be updated.",
@@ -3501,7 +3644,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -3512,6 +3655,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -3521,35 +3668,51 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostAliases": {
-                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified.",
                         "type": "array",
                         "items": {
                           "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                           "type": "object",
+                          "required": [
+                            "ip"
+                          ],
                           "properties": {
                             "hostnames": {
                               "description": "Hostnames for the above IP address.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "ip": {
                               "description": "IP address of the host file entry.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "ip"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostIPC": {
                         "description": "Use the host's ipc namespace.\nOptional: Default to false.",
@@ -3579,12 +3742,16 @@
                           "type": "object",
                           "properties": {
                             "name": {
-                              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             }
                           },
                           "x-kubernetes-map-type": "atomic"
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "initContainers": {
                         "description": "List of initialization containers belonging to the pod.\nInit containers are executed in order prior to containers being started. If any\ninit container fails, the pod is considered to have failed and is handled according\nto its restartPolicy. The name for an init container or normal container must be\nunique among all containers.",
@@ -3601,14 +3768,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -3644,7 +3813,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3707,7 +3876,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3720,7 +3889,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -3734,7 +3907,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3753,7 +3926,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3764,7 +3937,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -3791,7 +3965,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3826,7 +4001,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3888,7 +4064,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3923,7 +4100,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3987,7 +4165,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4009,7 +4188,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4045,7 +4224,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4162,7 +4342,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4184,7 +4365,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4220,7 +4401,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4308,7 +4490,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -4319,6 +4501,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -4358,6 +4544,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -4368,7 +4571,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -4376,7 +4580,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4385,7 +4590,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -4440,7 +4645,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -4482,7 +4687,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4504,7 +4710,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4540,7 +4746,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4640,7 +4847,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -4658,7 +4869,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -4669,6 +4880,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -4678,17 +4893,25 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
-                        "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty,\nthe scheduler simply schedules this pod onto that node, assuming that it fits resource\nrequirements.",
+                        "description": "NodeName indicates in which node this pod is scheduled.\nIf empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.\nOnce this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.\nThis field should not be used to express a desire for the pod to be scheduled on a specific node.\nhttps://kubernetes.",
                         "type": "string"
                       },
                       "nodeSelector": {
@@ -4700,7 +4923,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.",
+                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.appArmorProfile\n- spec.securityContext.",
                         "type": "object",
                         "required": [
                           "name"
@@ -4748,13 +4971,14 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
-                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable.",
+                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
                         "type": "array",
                         "items": {
-                          "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource.\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
+                          "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                           "type": "object",
                           "required": [
                             "name"
@@ -4764,19 +4988,13 @@
                               "description": "Name uniquely identifies this resource claim inside the pod.\nThis must be a DNS_LABEL.",
                               "type": "string"
                             },
-                            "source": {
-                              "description": "Source describes where to find the ResourceClaim.",
-                              "type": "object",
-                              "properties": {
-                                "resourceClaimName": {
-                                  "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.",
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
-                                  "type": "string"
-                                }
-                              }
+                            "resourceClaimName": {
+                              "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
+                              "type": "string"
                             }
                           }
                         },
@@ -4798,7 +5016,7 @@
                         "type": "string"
                       },
                       "schedulingGates": {
-                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.\n\n\nThis is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
                         "type": "array",
                         "items": {
                           "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
@@ -4822,8 +5040,25 @@
                         "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.",
                         "type": "object",
                         "properties": {
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            }
+                          },
                           "fsGroup": {
-                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
+                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
                             "type": "integer",
                             "format": "int64"
                           },
@@ -4879,18 +5114,23 @@
                                 "type": "string"
                               },
                               "type": {
-                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                 "type": "string"
                               }
                             }
                           },
                           "supplementalGroups": {
-                            "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container.",
+                            "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.",
                             "type": "array",
                             "items": {
                               "type": "integer",
                               "format": "int64"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
                           },
                           "sysctls": {
                             "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
@@ -4912,7 +5152,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "windowsOptions": {
                             "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
@@ -4939,7 +5180,7 @@
                         }
                       },
                       "serviceAccount": {
-                        "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
+                        "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
                         "type": "string"
                       },
                       "serviceAccountName": {
@@ -4992,7 +5233,8 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologySpreadConstraints": {
                         "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology\ndomains. Scheduler will schedule pods in a way which abides by the constraints.\nAll topologySpreadConstraints are ANDed.",
@@ -5034,10 +5276,12 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5068,11 +5312,11 @@
                               "format": "int32"
                             },
                             "nodeAffinityPolicy": {
-                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
                               "type": "string"
                             },
                             "nodeTaintsPolicy": {
-                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
                               "type": "string"
                             },
                             "topologyKey": {
@@ -5109,7 +5353,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5195,7 +5439,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "path": {
                                   "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
@@ -5214,7 +5459,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5246,7 +5491,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5292,10 +5537,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
-                                  "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -5325,7 +5571,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5364,7 +5610,7 @@
                                     ],
                                     "properties": {
                                       "fieldRef": {
-                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                         "type": "object",
                                         "required": [
                                           "fieldPath"
@@ -5414,7 +5660,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5483,7 +5730,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "dataSource": {
                                           "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.",
@@ -5584,10 +5832,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5626,7 +5876,7 @@
                               "type": "object",
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                   "type": "string"
                                 },
                                 "lun": {
@@ -5643,14 +5893,16 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "wwids": {
                                   "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5685,7 +5937,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5715,7 +5967,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5777,7 +6029,7 @@
                               }
                             },
                             "hostPath": {
-                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.",
+                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                               "type": "object",
                               "required": [
                                 "path"
@@ -5789,6 +6041,20 @@
                                 },
                                 "type": {
                                   "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact.",
+                              "type": "object",
+                              "properties": {
+                                "pullPolicy": {
+                                  "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk.",
+                                  "type": "string"
+                                },
+                                "reference": {
+                                  "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.",
                                   "type": "string"
                                 }
                               }
@@ -5811,7 +6077,7 @@
                                   "type": "boolean"
                                 },
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                                   "type": "string"
                                 },
                                 "initiatorName": {
@@ -5836,7 +6102,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
@@ -5847,7 +6114,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5950,14 +6217,14 @@
                                   "format": "int32"
                                 },
                                 "sources": {
-                                  "description": "sources is the list of volume projections",
+                                  "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                                   "type": "array",
                                   "items": {
-                                    "description": "Projection that may be projected along with other supported volume types",
+                                    "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                                     "type": "object",
                                     "properties": {
                                       "clusterTrustBundle": {
-                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
+                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
                                         "type": "object",
                                         "required": [
                                           "path"
@@ -5991,10 +6258,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -6053,10 +6322,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -6081,7 +6351,7 @@
                                               ],
                                               "properties": {
                                                 "fieldRef": {
-                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                                   "type": "object",
                                                   "required": [
                                                     "fieldPath"
@@ -6131,7 +6401,8 @@
                                                   "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -6164,10 +6435,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -6200,7 +6472,8 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -6247,7 +6520,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                                   "type": "string"
                                 },
                                 "image": {
@@ -6263,7 +6536,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "pool": {
                                   "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -6278,7 +6552,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6320,7 +6594,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6382,7 +6656,8 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "optional": {
                                   "description": "optional field specify whether the Secret or its keys must be defined",
@@ -6411,7 +6686,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6453,7 +6728,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       }
                     }
                   }
@@ -6480,6 +6759,10 @@
               "description": "CleanPodPolicy defines the policy to kill pods after the job completes.\nDefault to None.",
               "type": "string"
             },
+            "managedBy": {
+              "description": "ManagedBy is used to indicate the controller or entity that manages a job.\nThe value must be either an empty, 'kubeflow.org/training-operator' or\n'kueue.x-k8s.io/multikueue'.\nThe training-operator reconciles a job which doesn't have this\nfield at all or the field value is the reserved string\n'kubeflow.org/training-operator', but delegates reconciling the job\nwith 'kueue.x-k8s.",
+              "type": "string"
+            },
             "schedulingPolicy": {
               "description": "SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling",
               "type": "object",
@@ -6499,7 +6782,13 @@
                   "type": "string"
                 },
                 "queue": {
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "spec.runPolicy.schedulingPolicy.queue is immutable",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
                 },
                 "scheduleTimeoutSeconds": {
                   "type": "integer",
@@ -6619,10 +6908,12 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
-                    }
+                    },
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -6661,5 +6952,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/pytorchjoblist.json
+++ b/class_generator/schema/pytorchjoblist.json
@@ -32,5 +32,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/ray.json
+++ b/class_generator/schema/ray.json
@@ -54,38 +54,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,17 +105,40 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -126,6 +150,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "Ray name must be default-ray",

--- a/class_generator/schema/raycluster.json
+++ b/class_generator/schema/raycluster.json
@@ -202,6 +202,20 @@
                 "allowPrivilegeEscalation": {
                   "type": "boolean"
                 },
+                "appArmorProfile": {
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "localhostProfile": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    }
+                  }
+                },
                 "capabilities": {
                   "type": "object",
                   "properties": {
@@ -209,13 +223,15 @@
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "drop": {
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     }
                   }
                 },
@@ -318,6 +334,9 @@
                   "readOnly": {
                     "type": "boolean"
                   },
+                  "recursiveReadOnly": {
+                    "type": "string"
+                  },
                   "subPath": {
                     "type": "string"
                   },
@@ -400,7 +419,8 @@
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "externalName": {
                       "type": "string"
@@ -435,7 +455,8 @@
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "ports": {
                       "type": "array",
@@ -499,6 +520,9 @@
                           }
                         }
                       }
+                    },
+                    "trafficDistribution": {
+                      "type": "string"
                     },
                     "type": {
                       "type": "string"
@@ -573,6 +597,9 @@
                               "ip": {
                                 "type": "string"
                               },
+                              "ipMode": {
+                                "type": "string"
+                              },
                               "ports": {
                                 "type": "array",
                                 "items": {
@@ -599,7 +626,8 @@
                                 "x-kubernetes-list-type": "atomic"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
                     }
@@ -695,10 +723,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchFields": {
                                         "type": "array",
@@ -719,10 +749,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
@@ -732,7 +764,8 @@
                                     "format": "int32"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "requiredDuringSchedulingIgnoredDuringExecution": {
                               "type": "object",
@@ -764,10 +797,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchFields": {
                                         "type": "array",
@@ -788,14 +823,17 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               },
                               "x-kubernetes-map-type": "atomic"
@@ -842,10 +880,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -855,6 +895,20 @@
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "namespaceSelector": {
                                         "type": "object",
@@ -878,10 +932,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -896,7 +952,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "topologyKey": {
                                         "type": "string"
@@ -908,7 +965,8 @@
                                     "format": "int32"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "requiredDuringSchedulingIgnoredDuringExecution": {
                               "type": "array",
@@ -940,10 +998,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -953,6 +1013,20 @@
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "namespaceSelector": {
                                     "type": "object",
@@ -976,10 +1050,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -994,13 +1070,15 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             }
                           }
                         },
@@ -1044,10 +1122,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1057,6 +1137,20 @@
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "namespaceSelector": {
                                         "type": "object",
@@ -1080,10 +1174,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1098,7 +1194,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "topologyKey": {
                                         "type": "string"
@@ -1110,7 +1207,8 @@
                                     "format": "int32"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "requiredDuringSchedulingIgnoredDuringExecution": {
                               "type": "array",
@@ -1142,10 +1240,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -1155,6 +1255,20 @@
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "namespaceSelector": {
                                     "type": "object",
@@ -1178,10 +1292,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -1196,13 +1312,15 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             }
                           }
                         }
@@ -1223,13 +1341,15 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "command": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "env": {
                             "type": "array",
@@ -1321,7 +1441,11 @@
                                   }
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "envFrom": {
                             "type": "array",
@@ -1356,7 +1480,8 @@
                                   "x-kubernetes-map-type": "atomic"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "image": {
                             "type": "string"
@@ -1377,7 +1502,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1406,7 +1532,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -1416,6 +1543,18 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "sleep": {
+                                    "type": "object",
+                                    "required": [
+                                      "seconds"
+                                    ],
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer",
+                                        "format": "int64"
                                       }
                                     }
                                   },
@@ -1445,7 +1584,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1474,7 +1614,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -1484,6 +1625,18 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "sleep": {
+                                    "type": "object",
+                                    "required": [
+                                      "seconds"
+                                    ],
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer",
+                                        "format": "int64"
                                       }
                                     }
                                   },
@@ -1515,7 +1668,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -1563,7 +1717,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -1658,7 +1813,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -1706,7 +1862,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -1820,6 +1977,20 @@
                               "allowPrivilegeEscalation": {
                                 "type": "boolean"
                               },
+                              "appArmorProfile": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
                               "capabilities": {
                                 "type": "object",
                                 "properties": {
@@ -1827,13 +1998,15 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "drop": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -1917,7 +2090,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -1965,7 +2139,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -2045,7 +2220,11 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "devicePath"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "volumeMounts": {
                             "type": "array",
@@ -2068,6 +2247,9 @@
                                 "readOnly": {
                                   "type": "boolean"
                                 },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
                                 "subPath": {
                                   "type": "string"
                                 },
@@ -2075,13 +2257,21 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "mountPath"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "workingDir": {
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
                     },
                     "dnsConfig": {
                       "type": "object",
@@ -2090,7 +2280,8 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "options": {
                           "type": "array",
@@ -2104,13 +2295,15 @@
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "searches": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
                     },
@@ -2132,13 +2325,15 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "command": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "env": {
                             "type": "array",
@@ -2230,7 +2425,11 @@
                                   }
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "envFrom": {
                             "type": "array",
@@ -2265,7 +2464,8 @@
                                   "x-kubernetes-map-type": "atomic"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "image": {
                             "type": "string"
@@ -2286,7 +2486,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2315,7 +2516,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2325,6 +2527,18 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "sleep": {
+                                    "type": "object",
+                                    "required": [
+                                      "seconds"
+                                    ],
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer",
+                                        "format": "int64"
                                       }
                                     }
                                   },
@@ -2354,7 +2568,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2383,7 +2598,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2393,6 +2609,18 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "sleep": {
+                                    "type": "object",
+                                    "required": [
+                                      "seconds"
+                                    ],
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer",
+                                        "format": "int64"
                                       }
                                     }
                                   },
@@ -2424,7 +2652,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -2472,7 +2701,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -2567,7 +2797,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -2615,7 +2846,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -2729,6 +2961,20 @@
                               "allowPrivilegeEscalation": {
                                 "type": "boolean"
                               },
+                              "appArmorProfile": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
                               "capabilities": {
                                 "type": "object",
                                 "properties": {
@@ -2736,13 +2982,15 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "drop": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -2826,7 +3074,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -2874,7 +3123,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -2957,7 +3207,11 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "devicePath"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "volumeMounts": {
                             "type": "array",
@@ -2980,6 +3234,9 @@
                                 "readOnly": {
                                   "type": "boolean"
                                 },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
                                 "subPath": {
                                   "type": "string"
                                 },
@@ -2987,30 +3244,46 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "mountPath"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "workingDir": {
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
                     },
                     "hostAliases": {
                       "type": "array",
                       "items": {
                         "type": "object",
+                        "required": [
+                          "ip"
+                        ],
                         "properties": {
                           "hostnames": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "ip": {
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "ip"
+                      ],
+                      "x-kubernetes-list-type": "map"
                     },
                     "hostIPC": {
                       "type": "boolean"
@@ -3037,7 +3310,11 @@
                           }
                         },
                         "x-kubernetes-map-type": "atomic"
-                      }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
                     },
                     "initContainers": {
                       "type": "array",
@@ -3051,13 +3328,15 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "command": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "env": {
                             "type": "array",
@@ -3149,7 +3428,11 @@
                                   }
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "envFrom": {
                             "type": "array",
@@ -3184,7 +3467,8 @@
                                   "x-kubernetes-map-type": "atomic"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "image": {
                             "type": "string"
@@ -3205,7 +3489,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3234,7 +3519,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3244,6 +3530,18 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "sleep": {
+                                    "type": "object",
+                                    "required": [
+                                      "seconds"
+                                    ],
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer",
+                                        "format": "int64"
                                       }
                                     }
                                   },
@@ -3273,7 +3571,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3302,7 +3601,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3312,6 +3612,18 @@
                                       },
                                       "scheme": {
                                         "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "sleep": {
+                                    "type": "object",
+                                    "required": [
+                                      "seconds"
+                                    ],
+                                    "properties": {
+                                      "seconds": {
+                                        "type": "integer",
+                                        "format": "int64"
                                       }
                                     }
                                   },
@@ -3343,7 +3655,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -3391,7 +3704,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -3486,7 +3800,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -3534,7 +3849,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -3648,6 +3964,20 @@
                               "allowPrivilegeEscalation": {
                                 "type": "boolean"
                               },
+                              "appArmorProfile": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
                               "capabilities": {
                                 "type": "object",
                                 "properties": {
@@ -3655,13 +3985,15 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "drop": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -3745,7 +4077,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -3793,7 +4126,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -3873,7 +4207,11 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "devicePath"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "volumeMounts": {
                             "type": "array",
@@ -3896,6 +4234,9 @@
                                 "readOnly": {
                                   "type": "boolean"
                                 },
+                                "recursiveReadOnly": {
+                                  "type": "string"
+                                },
                                 "subPath": {
                                   "type": "string"
                                 },
@@ -3903,13 +4244,21 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "mountPath"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "workingDir": {
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
                     },
                     "nodeName": {
                       "type": "string"
@@ -3961,7 +4310,8 @@
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "resourceClaims": {
                       "type": "array",
@@ -4022,6 +4372,20 @@
                     "securityContext": {
                       "type": "object",
                       "properties": {
+                        "appArmorProfile": {
+                          "type": "object",
+                          "required": [
+                            "type"
+                          ],
+                          "properties": {
+                            "localhostProfile": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          }
+                        },
                         "fsGroup": {
                           "type": "integer",
                           "format": "int64"
@@ -4076,7 +4440,8 @@
                           "items": {
                             "type": "integer",
                             "format": "int64"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "sysctls": {
                           "type": "array",
@@ -4094,7 +4459,8 @@
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "windowsOptions": {
                           "type": "object",
@@ -4156,7 +4522,8 @@
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "topologySpreadConstraints": {
                       "type": "array",
@@ -4190,10 +4557,12 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
                                 "type": "object",
@@ -4323,7 +4692,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -4401,7 +4771,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "name": {
                                 "type": "string"
@@ -4501,7 +4872,8 @@
                                       "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -4562,7 +4934,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "dataSource": {
                                         "type": "object",
@@ -4607,24 +4980,6 @@
                                       "resources": {
                                         "type": "object",
                                         "properties": {
-                                          "claims": {
-                                            "type": "array",
-                                            "items": {
-                                              "type": "object",
-                                              "required": [
-                                                "name"
-                                              ],
-                                              "properties": {
-                                                "name": {
-                                                  "type": "string"
-                                                }
-                                              }
-                                            },
-                                            "x-kubernetes-list-map-keys": [
-                                              "name"
-                                            ],
-                                            "x-kubernetes-list-type": "map"
-                                          },
                                           "limits": {
                                             "type": "object",
                                             "additionalProperties": {
@@ -4663,10 +5018,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -4678,6 +5035,9 @@
                                         "x-kubernetes-map-type": "atomic"
                                       },
                                       "storageClassName": {
+                                        "type": "string"
+                                      },
+                                      "volumeAttributesClassName": {
                                         "type": "string"
                                       },
                                       "volumeMode": {
@@ -4709,13 +5069,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "wwids": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -4866,7 +5228,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "readOnly": {
                                 "type": "boolean"
@@ -4963,6 +5326,64 @@
                                 "items": {
                                   "type": "object",
                                   "properties": {
+                                    "clusterTrustBundle": {
+                                      "type": "object",
+                                      "required": [
+                                        "path"
+                                      ],
+                                      "properties": {
+                                        "labelSelector": {
+                                          "type": "object",
+                                          "properties": {
+                                            "matchExpressions": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "required": [
+                                                  "key",
+                                                  "operator"
+                                                ],
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string"
+                                                  },
+                                                  "operator": {
+                                                    "type": "string"
+                                                  },
+                                                  "values": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "matchLabels": {
+                                              "type": "object",
+                                              "additionalProperties": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "optional": {
+                                          "type": "boolean"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        },
+                                        "signerName": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
                                     "configMap": {
                                       "type": "object",
                                       "properties": {
@@ -4986,7 +5407,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "name": {
                                           "type": "string"
@@ -5050,7 +5472,8 @@
                                                 "x-kubernetes-map-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -5077,7 +5500,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "name": {
                                           "type": "string"
@@ -5107,7 +5531,8 @@
                                       }
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -5158,7 +5583,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "pool": {
                                 "type": "string"
@@ -5253,7 +5679,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "optional": {
                                 "type": "boolean"
@@ -5310,7 +5737,11 @@
                             }
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
                     }
                   }
                 }
@@ -5453,10 +5884,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "type": "array",
@@ -5477,10 +5910,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
@@ -5490,7 +5925,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "type": "object",
@@ -5522,10 +5958,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "type": "array",
@@ -5546,14 +5984,17 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
@@ -5600,10 +6041,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5613,6 +6056,20 @@
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "matchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "mismatchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "type": "object",
@@ -5636,10 +6093,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5654,7 +6113,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
@@ -5666,7 +6126,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "type": "array",
@@ -5698,10 +6159,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "type": "object",
@@ -5711,6 +6174,20 @@
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "matchLabelKeys": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "mismatchLabelKeys": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "type": "object",
@@ -5734,10 +6211,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "type": "object",
@@ -5752,13 +6231,15 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -5802,10 +6283,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5815,6 +6298,20 @@
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "matchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "mismatchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "type": "object",
@@ -5838,10 +6335,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5856,7 +6355,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
@@ -5868,7 +6368,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "type": "array",
@@ -5900,10 +6401,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "type": "object",
@@ -5913,6 +6416,20 @@
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "matchLabelKeys": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "mismatchLabelKeys": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "namespaceSelector": {
                                       "type": "object",
@@ -5936,10 +6453,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "type": "object",
@@ -5954,13 +6473,15 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           }
@@ -5981,13 +6502,15 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "type": "array",
@@ -6079,7 +6602,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "type": "array",
@@ -6114,7 +6641,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "type": "string"
@@ -6135,7 +6663,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6164,7 +6693,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6174,6 +6704,18 @@
                                         },
                                         "scheme": {
                                           "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "sleep": {
+                                      "type": "object",
+                                      "required": [
+                                        "seconds"
+                                      ],
+                                      "properties": {
+                                        "seconds": {
+                                          "type": "integer",
+                                          "format": "int64"
                                         }
                                       }
                                     },
@@ -6203,7 +6745,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6232,7 +6775,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6242,6 +6786,18 @@
                                         },
                                         "scheme": {
                                           "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "sleep": {
+                                      "type": "object",
+                                      "required": [
+                                        "seconds"
+                                      ],
+                                      "properties": {
+                                        "seconds": {
+                                          "type": "integer",
+                                          "format": "int64"
                                         }
                                       }
                                     },
@@ -6273,7 +6829,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -6321,7 +6878,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -6416,7 +6974,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -6464,7 +7023,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -6578,6 +7138,20 @@
                                 "allowPrivilegeEscalation": {
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "type": "object",
                                   "properties": {
@@ -6585,13 +7159,15 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -6675,7 +7251,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -6723,7 +7300,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -6803,7 +7381,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "type": "array",
@@ -6826,6 +7408,9 @@
                                   "readOnly": {
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "type": "string"
                                   },
@@ -6833,13 +7418,21 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "dnsConfig": {
                         "type": "object",
@@ -6848,7 +7441,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "options": {
                             "type": "array",
@@ -6862,13 +7456,15 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "searches": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -6890,13 +7486,15 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "type": "array",
@@ -6988,7 +7586,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "type": "array",
@@ -7023,7 +7625,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "type": "string"
@@ -7044,7 +7647,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7073,7 +7677,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7083,6 +7688,18 @@
                                         },
                                         "scheme": {
                                           "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "sleep": {
+                                      "type": "object",
+                                      "required": [
+                                        "seconds"
+                                      ],
+                                      "properties": {
+                                        "seconds": {
+                                          "type": "integer",
+                                          "format": "int64"
                                         }
                                       }
                                     },
@@ -7112,7 +7729,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7141,7 +7759,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7151,6 +7770,18 @@
                                         },
                                         "scheme": {
                                           "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "sleep": {
+                                      "type": "object",
+                                      "required": [
+                                        "seconds"
+                                      ],
+                                      "properties": {
+                                        "seconds": {
+                                          "type": "integer",
+                                          "format": "int64"
                                         }
                                       }
                                     },
@@ -7182,7 +7813,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -7230,7 +7862,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -7325,7 +7958,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -7373,7 +8007,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -7487,6 +8122,20 @@
                                 "allowPrivilegeEscalation": {
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "type": "object",
                                   "properties": {
@@ -7494,13 +8143,15 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -7584,7 +8235,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -7632,7 +8284,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -7715,7 +8368,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "type": "array",
@@ -7738,6 +8395,9 @@
                                   "readOnly": {
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "type": "string"
                                   },
@@ -7745,30 +8405,46 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostAliases": {
                         "type": "array",
                         "items": {
                           "type": "object",
+                          "required": [
+                            "ip"
+                          ],
                           "properties": {
                             "hostnames": {
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "ip": {
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "ip"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostIPC": {
                         "type": "boolean"
@@ -7795,7 +8471,11 @@
                             }
                           },
                           "x-kubernetes-map-type": "atomic"
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "initContainers": {
                         "type": "array",
@@ -7809,13 +8489,15 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "type": "array",
@@ -7907,7 +8589,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "type": "array",
@@ -7942,7 +8628,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "type": "string"
@@ -7963,7 +8650,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7992,7 +8680,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8002,6 +8691,18 @@
                                         },
                                         "scheme": {
                                           "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "sleep": {
+                                      "type": "object",
+                                      "required": [
+                                        "seconds"
+                                      ],
+                                      "properties": {
+                                        "seconds": {
+                                          "type": "integer",
+                                          "format": "int64"
                                         }
                                       }
                                     },
@@ -8031,7 +8732,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8060,7 +8762,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8070,6 +8773,18 @@
                                         },
                                         "scheme": {
                                           "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "sleep": {
+                                      "type": "object",
+                                      "required": [
+                                        "seconds"
+                                      ],
+                                      "properties": {
+                                        "seconds": {
+                                          "type": "integer",
+                                          "format": "int64"
                                         }
                                       }
                                     },
@@ -8101,7 +8816,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -8149,7 +8865,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -8244,7 +8961,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -8292,7 +9010,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -8406,6 +9125,20 @@
                                 "allowPrivilegeEscalation": {
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "type": "object",
                                   "properties": {
@@ -8413,13 +9146,15 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -8503,7 +9238,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -8551,7 +9287,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -8631,7 +9368,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "type": "array",
@@ -8654,6 +9395,9 @@
                                   "readOnly": {
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "type": "string"
                                   },
@@ -8661,13 +9405,21 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
                         "type": "string"
@@ -8719,7 +9471,8 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
                         "type": "array",
@@ -8780,6 +9533,20 @@
                       "securityContext": {
                         "type": "object",
                         "properties": {
+                          "appArmorProfile": {
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            }
+                          },
                           "fsGroup": {
                             "type": "integer",
                             "format": "int64"
@@ -8834,7 +9601,8 @@
                             "items": {
                               "type": "integer",
                               "format": "int64"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "sysctls": {
                             "type": "array",
@@ -8852,7 +9620,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "windowsOptions": {
                             "type": "object",
@@ -8914,7 +9683,8 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologySpreadConstraints": {
                         "type": "array",
@@ -8948,10 +9718,12 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "type": "object",
@@ -9081,7 +9853,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "path": {
                                   "type": "string"
@@ -9159,7 +9932,8 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
                                   "type": "string"
@@ -9259,7 +10033,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -9320,7 +10095,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "dataSource": {
                                           "type": "object",
@@ -9365,24 +10141,6 @@
                                         "resources": {
                                           "type": "object",
                                           "properties": {
-                                            "claims": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "object",
-                                                "required": [
-                                                  "name"
-                                                ],
-                                                "properties": {
-                                                  "name": {
-                                                    "type": "string"
-                                                  }
-                                                }
-                                              },
-                                              "x-kubernetes-list-map-keys": [
-                                                "name"
-                                              ],
-                                              "x-kubernetes-list-type": "map"
-                                            },
                                             "limits": {
                                               "type": "object",
                                               "additionalProperties": {
@@ -9421,10 +10179,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -9436,6 +10196,9 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "storageClassName": {
+                                          "type": "string"
+                                        },
+                                        "volumeAttributesClassName": {
                                           "type": "string"
                                         },
                                         "volumeMode": {
@@ -9467,13 +10230,15 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "wwids": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -9624,7 +10389,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "readOnly": {
                                   "type": "boolean"
@@ -9721,6 +10487,64 @@
                                   "items": {
                                     "type": "object",
                                     "properties": {
+                                      "clusterTrustBundle": {
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "labelSelector": {
+                                            "type": "object",
+                                            "properties": {
+                                              "matchExpressions": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "required": [
+                                                    "key",
+                                                    "operator"
+                                                  ],
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "operator": {
+                                                      "type": "string"
+                                                    },
+                                                    "values": {
+                                                      "type": "array",
+                                                      "items": {
+                                                        "type": "string"
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
+                                                    }
+                                                  }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
+                                              },
+                                              "matchLabels": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                  "type": "string"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "optional": {
+                                            "type": "boolean"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "signerName": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
                                       "configMap": {
                                         "type": "object",
                                         "properties": {
@@ -9744,7 +10568,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
                                             "type": "string"
@@ -9808,7 +10633,8 @@
                                                   "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -9835,7 +10661,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
                                             "type": "string"
@@ -9865,7 +10692,8 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -9916,7 +10744,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "pool": {
                                   "type": "string"
@@ -10011,7 +10840,8 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "optional": {
                                   "type": "boolean"
@@ -10068,7 +10898,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       }
                     }
                   }
@@ -10137,6 +10971,10 @@
         "observedGeneration": {
           "type": "integer",
           "format": "int64"
+        },
+        "readyWorkerReplicas": {
+          "type": "integer",
+          "format": "int32"
         },
         "reason": {
           "type": "string"

--- a/class_generator/schema/rayjob.json
+++ b/class_generator/schema/rayjob.json
@@ -235,6 +235,20 @@
                     "allowPrivilegeEscalation": {
                       "type": "boolean"
                     },
+                    "appArmorProfile": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "capabilities": {
                       "type": "object",
                       "properties": {
@@ -242,13 +256,15 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "drop": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
                     },
@@ -351,6 +367,9 @@
                       "readOnly": {
                         "type": "boolean"
                       },
+                      "recursiveReadOnly": {
+                        "type": "string"
+                      },
                       "subPath": {
                         "type": "string"
                       },
@@ -433,7 +452,8 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "externalName": {
                           "type": "string"
@@ -468,7 +488,8 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "ports": {
                           "type": "array",
@@ -532,6 +553,9 @@
                               }
                             }
                           }
+                        },
+                        "trafficDistribution": {
+                          "type": "string"
                         },
                         "type": {
                           "type": "string"
@@ -606,6 +630,9 @@
                                   "ip": {
                                     "type": "string"
                                   },
+                                  "ipMode": {
+                                    "type": "string"
+                                  },
                                   "ports": {
                                     "type": "array",
                                     "items": {
@@ -632,7 +659,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             }
                           }
                         }
@@ -728,10 +756,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchFields": {
                                             "type": "array",
@@ -752,10 +782,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
@@ -765,7 +797,8 @@
                                         "format": "int32"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
                                   "type": "object",
@@ -797,10 +830,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchFields": {
                                             "type": "array",
@@ -821,14 +856,17 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "x-kubernetes-map-type": "atomic"
@@ -875,10 +913,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -888,6 +928,20 @@
                                               }
                                             },
                                             "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "matchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "namespaceSelector": {
                                             "type": "object",
@@ -911,10 +965,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -929,7 +985,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "topologyKey": {
                                             "type": "string"
@@ -941,7 +998,8 @@
                                         "format": "int32"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
                                   "type": "array",
@@ -973,10 +1031,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -986,6 +1046,20 @@
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "namespaceSelector": {
                                         "type": "object",
@@ -1009,10 +1083,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1027,13 +1103,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "topologyKey": {
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -1077,10 +1155,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -1090,6 +1170,20 @@
                                               }
                                             },
                                             "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "matchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "namespaceSelector": {
                                             "type": "object",
@@ -1113,10 +1207,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -1131,7 +1227,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "topologyKey": {
                                             "type": "string"
@@ -1143,7 +1240,8 @@
                                         "format": "int32"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
                                   "type": "array",
@@ -1175,10 +1273,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1188,6 +1288,20 @@
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "namespaceSelector": {
                                         "type": "object",
@@ -1211,10 +1325,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1229,13 +1345,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "topologyKey": {
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             }
@@ -1256,13 +1374,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "command": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "env": {
                                 "type": "array",
@@ -1354,7 +1474,11 @@
                                       }
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "envFrom": {
                                 "type": "array",
@@ -1389,7 +1513,8 @@
                                       "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "image": {
                                 "type": "string"
@@ -1410,7 +1535,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -1439,7 +1565,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -1449,6 +1576,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -1478,7 +1617,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -1507,7 +1647,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -1517,6 +1658,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -1548,7 +1701,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1596,7 +1750,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -1691,7 +1846,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1739,7 +1895,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -1853,6 +2010,20 @@
                                   "allowPrivilegeEscalation": {
                                     "type": "boolean"
                                   },
+                                  "appArmorProfile": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
                                   "capabilities": {
                                     "type": "object",
                                     "properties": {
@@ -1860,13 +2031,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "drop": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1950,7 +2123,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1998,7 +2172,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2078,7 +2253,11 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "volumeMounts": {
                                 "type": "array",
@@ -2101,6 +2280,9 @@
                                     "readOnly": {
                                       "type": "boolean"
                                     },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
                                     "subPath": {
                                       "type": "string"
                                     },
@@ -2108,13 +2290,21 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "workingDir": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "dnsConfig": {
                           "type": "object",
@@ -2123,7 +2313,8 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "options": {
                               "type": "array",
@@ -2137,13 +2328,15 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "searches": {
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             }
                           }
                         },
@@ -2165,13 +2358,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "command": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "env": {
                                 "type": "array",
@@ -2263,7 +2458,11 @@
                                       }
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "envFrom": {
                                 "type": "array",
@@ -2298,7 +2497,8 @@
                                       "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "image": {
                                 "type": "string"
@@ -2319,7 +2519,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -2348,7 +2549,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -2358,6 +2560,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -2387,7 +2601,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -2416,7 +2631,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -2426,6 +2642,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -2457,7 +2685,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2505,7 +2734,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2600,7 +2830,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2648,7 +2879,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2762,6 +2994,20 @@
                                   "allowPrivilegeEscalation": {
                                     "type": "boolean"
                                   },
+                                  "appArmorProfile": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
                                   "capabilities": {
                                     "type": "object",
                                     "properties": {
@@ -2769,13 +3015,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "drop": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2859,7 +3107,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2907,7 +3156,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2990,7 +3240,11 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "volumeMounts": {
                                 "type": "array",
@@ -3013,6 +3267,9 @@
                                     "readOnly": {
                                       "type": "boolean"
                                     },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
                                     "subPath": {
                                       "type": "string"
                                     },
@@ -3020,30 +3277,46 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "workingDir": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "hostAliases": {
                           "type": "array",
                           "items": {
                             "type": "object",
+                            "required": [
+                              "ip"
+                            ],
                             "properties": {
                               "hostnames": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "ip": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "ip"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "hostIPC": {
                           "type": "boolean"
@@ -3070,7 +3343,11 @@
                               }
                             },
                             "x-kubernetes-map-type": "atomic"
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "initContainers": {
                           "type": "array",
@@ -3084,13 +3361,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "command": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "env": {
                                 "type": "array",
@@ -3182,7 +3461,11 @@
                                       }
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "envFrom": {
                                 "type": "array",
@@ -3217,7 +3500,8 @@
                                       "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "image": {
                                 "type": "string"
@@ -3238,7 +3522,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -3267,7 +3552,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -3277,6 +3563,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -3306,7 +3604,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -3335,7 +3634,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -3345,6 +3645,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -3376,7 +3688,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3424,7 +3737,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3519,7 +3833,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3567,7 +3882,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3681,6 +3997,20 @@
                                   "allowPrivilegeEscalation": {
                                     "type": "boolean"
                                   },
+                                  "appArmorProfile": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
                                   "capabilities": {
                                     "type": "object",
                                     "properties": {
@@ -3688,13 +4018,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "drop": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3778,7 +4110,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3826,7 +4159,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3906,7 +4240,11 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "volumeMounts": {
                                 "type": "array",
@@ -3929,6 +4267,9 @@
                                     "readOnly": {
                                       "type": "boolean"
                                     },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
                                     "subPath": {
                                       "type": "string"
                                     },
@@ -3936,13 +4277,21 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "workingDir": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "nodeName": {
                           "type": "string"
@@ -3994,7 +4343,8 @@
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "resourceClaims": {
                           "type": "array",
@@ -4055,6 +4405,20 @@
                         "securityContext": {
                           "type": "object",
                           "properties": {
+                            "appArmorProfile": {
+                              "type": "object",
+                              "required": [
+                                "type"
+                              ],
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            },
                             "fsGroup": {
                               "type": "integer",
                               "format": "int64"
@@ -4109,7 +4473,8 @@
                               "items": {
                                 "type": "integer",
                                 "format": "int64"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "sysctls": {
                               "type": "array",
@@ -4127,7 +4492,8 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "windowsOptions": {
                               "type": "object",
@@ -4189,7 +4555,8 @@
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "topologySpreadConstraints": {
                           "type": "array",
@@ -4223,10 +4590,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "type": "object",
@@ -4356,7 +4725,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -4434,7 +4804,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "name": {
                                     "type": "string"
@@ -4534,7 +4905,8 @@
                                           "x-kubernetes-map-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -4595,7 +4967,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "dataSource": {
                                             "type": "object",
@@ -4640,24 +5013,6 @@
                                           "resources": {
                                             "type": "object",
                                             "properties": {
-                                              "claims": {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "object",
-                                                  "required": [
-                                                    "name"
-                                                  ],
-                                                  "properties": {
-                                                    "name": {
-                                                      "type": "string"
-                                                    }
-                                                  }
-                                                },
-                                                "x-kubernetes-list-map-keys": [
-                                                  "name"
-                                                ],
-                                                "x-kubernetes-list-type": "map"
-                                              },
                                               "limits": {
                                                 "type": "object",
                                                 "additionalProperties": {
@@ -4696,10 +5051,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -4711,6 +5068,9 @@
                                             "x-kubernetes-map-type": "atomic"
                                           },
                                           "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
                                             "type": "string"
                                           },
                                           "volumeMode": {
@@ -4742,13 +5102,15 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "wwids": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -4899,7 +5261,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "readOnly": {
                                     "type": "boolean"
@@ -4996,6 +5359,64 @@
                                     "items": {
                                       "type": "object",
                                       "properties": {
+                                        "clusterTrustBundle": {
+                                          "type": "object",
+                                          "required": [
+                                            "path"
+                                          ],
+                                          "properties": {
+                                            "labelSelector": {
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                },
+                                                "matchLabels": {
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
                                         "configMap": {
                                           "type": "object",
                                           "properties": {
@@ -5019,7 +5440,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "name": {
                                               "type": "string"
@@ -5083,7 +5505,8 @@
                                                     "x-kubernetes-map-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -5110,7 +5533,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "name": {
                                               "type": "string"
@@ -5140,7 +5564,8 @@
                                           }
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -5191,7 +5616,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "pool": {
                                     "type": "string"
@@ -5286,7 +5712,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "optional": {
                                     "type": "boolean"
@@ -5343,7 +5770,11 @@
                                 }
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         }
                       }
                     }
@@ -5486,10 +5917,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchFields": {
                                               "type": "array",
@@ -5510,10 +5943,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
@@ -5523,7 +5958,8 @@
                                           "format": "int32"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "requiredDuringSchedulingIgnoredDuringExecution": {
                                     "type": "object",
@@ -5555,10 +5991,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchFields": {
                                               "type": "array",
@@ -5579,14 +6017,17 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
@@ -5633,10 +6074,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5646,6 +6089,20 @@
                                                 }
                                               },
                                               "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "matchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "namespaceSelector": {
                                               "type": "object",
@@ -5669,10 +6126,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5687,7 +6146,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "topologyKey": {
                                               "type": "string"
@@ -5699,7 +6159,8 @@
                                           "format": "int32"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "requiredDuringSchedulingIgnoredDuringExecution": {
                                     "type": "array",
@@ -5731,10 +6192,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5744,6 +6207,20 @@
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "matchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "mismatchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "type": "object",
@@ -5767,10 +6244,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5785,13 +6264,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -5835,10 +6316,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5848,6 +6331,20 @@
                                                 }
                                               },
                                               "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "matchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "namespaceSelector": {
                                               "type": "object",
@@ -5871,10 +6368,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5889,7 +6388,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "topologyKey": {
                                               "type": "string"
@@ -5901,7 +6401,8 @@
                                           "format": "int32"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "requiredDuringSchedulingIgnoredDuringExecution": {
                                     "type": "array",
@@ -5933,10 +6434,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5946,6 +6449,20 @@
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "matchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "mismatchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "type": "object",
@@ -5969,10 +6486,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5987,13 +6506,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               }
@@ -6014,13 +6535,15 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "command": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "env": {
                                   "type": "array",
@@ -6112,7 +6635,11 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "envFrom": {
                                   "type": "array",
@@ -6147,7 +6674,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "image": {
                                   "type": "string"
@@ -6168,7 +6696,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -6197,7 +6726,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -6207,6 +6737,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -6236,7 +6778,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -6265,7 +6808,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -6275,6 +6819,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -6306,7 +6862,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6354,7 +6911,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6449,7 +7007,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6497,7 +7056,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6611,6 +7171,20 @@
                                     "allowPrivilegeEscalation": {
                                       "type": "boolean"
                                     },
+                                    "appArmorProfile": {
+                                      "type": "object",
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "properties": {
+                                        "localhostProfile": {
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
                                     "capabilities": {
                                       "type": "object",
                                       "properties": {
@@ -6618,13 +7192,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "drop": {
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6708,7 +7284,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6756,7 +7333,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6836,7 +7414,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "devicePath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "volumeMounts": {
                                   "type": "array",
@@ -6859,6 +7441,9 @@
                                       "readOnly": {
                                         "type": "boolean"
                                       },
+                                      "recursiveReadOnly": {
+                                        "type": "string"
+                                      },
                                       "subPath": {
                                         "type": "string"
                                       },
@@ -6866,13 +7451,21 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "mountPath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "workingDir": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "dnsConfig": {
                             "type": "object",
@@ -6881,7 +7474,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "options": {
                                 "type": "array",
@@ -6895,13 +7489,15 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "searches": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -6923,13 +7519,15 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "command": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "env": {
                                   "type": "array",
@@ -7021,7 +7619,11 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "envFrom": {
                                   "type": "array",
@@ -7056,7 +7658,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "image": {
                                   "type": "string"
@@ -7077,7 +7680,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -7106,7 +7710,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -7116,6 +7721,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -7145,7 +7762,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -7174,7 +7792,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -7184,6 +7803,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -7215,7 +7846,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7263,7 +7895,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7358,7 +7991,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7406,7 +8040,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7520,6 +8155,20 @@
                                     "allowPrivilegeEscalation": {
                                       "type": "boolean"
                                     },
+                                    "appArmorProfile": {
+                                      "type": "object",
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "properties": {
+                                        "localhostProfile": {
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
                                     "capabilities": {
                                       "type": "object",
                                       "properties": {
@@ -7527,13 +8176,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "drop": {
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7617,7 +8268,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7665,7 +8317,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7748,7 +8401,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "devicePath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "volumeMounts": {
                                   "type": "array",
@@ -7771,6 +8428,9 @@
                                       "readOnly": {
                                         "type": "boolean"
                                       },
+                                      "recursiveReadOnly": {
+                                        "type": "string"
+                                      },
                                       "subPath": {
                                         "type": "string"
                                       },
@@ -7778,30 +8438,46 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "mountPath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "workingDir": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "hostAliases": {
                             "type": "array",
                             "items": {
                               "type": "object",
+                              "required": [
+                                "ip"
+                              ],
                               "properties": {
                                 "hostnames": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "ip": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "ip"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "hostIPC": {
                             "type": "boolean"
@@ -7828,7 +8504,11 @@
                                 }
                               },
                               "x-kubernetes-map-type": "atomic"
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "initContainers": {
                             "type": "array",
@@ -7842,13 +8522,15 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "command": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "env": {
                                   "type": "array",
@@ -7940,7 +8622,11 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "envFrom": {
                                   "type": "array",
@@ -7975,7 +8661,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "image": {
                                   "type": "string"
@@ -7996,7 +8683,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -8025,7 +8713,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -8035,6 +8724,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -8064,7 +8765,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -8093,7 +8795,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -8103,6 +8806,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -8134,7 +8849,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8182,7 +8898,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8277,7 +8994,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8325,7 +9043,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8439,6 +9158,20 @@
                                     "allowPrivilegeEscalation": {
                                       "type": "boolean"
                                     },
+                                    "appArmorProfile": {
+                                      "type": "object",
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "properties": {
+                                        "localhostProfile": {
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
                                     "capabilities": {
                                       "type": "object",
                                       "properties": {
@@ -8446,13 +9179,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "drop": {
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8536,7 +9271,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8584,7 +9320,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8664,7 +9401,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "devicePath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "volumeMounts": {
                                   "type": "array",
@@ -8687,6 +9428,9 @@
                                       "readOnly": {
                                         "type": "boolean"
                                       },
+                                      "recursiveReadOnly": {
+                                        "type": "string"
+                                      },
                                       "subPath": {
                                         "type": "string"
                                       },
@@ -8694,13 +9438,21 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "mountPath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "workingDir": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "nodeName": {
                             "type": "string"
@@ -8752,7 +9504,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "resourceClaims": {
                             "type": "array",
@@ -8813,6 +9566,20 @@
                           "securityContext": {
                             "type": "object",
                             "properties": {
+                              "appArmorProfile": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
                               "fsGroup": {
                                 "type": "integer",
                                 "format": "int64"
@@ -8867,7 +9634,8 @@
                                 "items": {
                                   "type": "integer",
                                   "format": "int64"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "sysctls": {
                                 "type": "array",
@@ -8885,7 +9653,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "windowsOptions": {
                                 "type": "object",
@@ -8947,7 +9716,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologySpreadConstraints": {
                             "type": "array",
@@ -8981,10 +9751,12 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "type": "object",
@@ -9114,7 +9886,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -9192,7 +9965,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "name": {
                                       "type": "string"
@@ -9292,7 +10066,8 @@
                                             "x-kubernetes-map-type": "atomic"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -9353,7 +10128,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "dataSource": {
                                               "type": "object",
@@ -9398,24 +10174,6 @@
                                             "resources": {
                                               "type": "object",
                                               "properties": {
-                                                "claims": {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "object",
-                                                    "required": [
-                                                      "name"
-                                                    ],
-                                                    "properties": {
-                                                      "name": {
-                                                        "type": "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "x-kubernetes-list-map-keys": [
-                                                    "name"
-                                                  ],
-                                                  "x-kubernetes-list-type": "map"
-                                                },
                                                 "limits": {
                                                   "type": "object",
                                                   "additionalProperties": {
@@ -9454,10 +10212,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -9469,6 +10229,9 @@
                                               "x-kubernetes-map-type": "atomic"
                                             },
                                             "storageClassName": {
+                                              "type": "string"
+                                            },
+                                            "volumeAttributesClassName": {
                                               "type": "string"
                                             },
                                             "volumeMode": {
@@ -9500,13 +10263,15 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "wwids": {
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -9657,7 +10422,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "readOnly": {
                                       "type": "boolean"
@@ -9754,6 +10520,64 @@
                                       "items": {
                                         "type": "object",
                                         "properties": {
+                                          "clusterTrustBundle": {
+                                            "type": "object",
+                                            "required": [
+                                              "path"
+                                            ],
+                                            "properties": {
+                                              "labelSelector": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "x-kubernetes-list-type": "atomic"
+                                                        }
+                                                      }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
+                                                  },
+                                                  "matchLabels": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "signerName": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
                                           "configMap": {
                                             "type": "object",
                                             "properties": {
@@ -9777,7 +10601,8 @@
                                                       "type": "string"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "name": {
                                                 "type": "string"
@@ -9841,7 +10666,8 @@
                                                       "x-kubernetes-map-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
                                           },
@@ -9868,7 +10694,8 @@
                                                       "type": "string"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "name": {
                                                 "type": "string"
@@ -9898,7 +10725,8 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -9949,7 +10777,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "pool": {
                                       "type": "string"
@@ -10044,7 +10873,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "optional": {
                                       "type": "boolean"
@@ -10101,7 +10931,11 @@
                                   }
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           }
                         }
                       }
@@ -10197,10 +11031,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
                                     "type": "array",
@@ -10221,10 +11057,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
@@ -10234,7 +11072,8 @@
                                 "format": "int32"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "type": "object",
@@ -10266,10 +11105,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchFields": {
                                     "type": "array",
@@ -10290,14 +11131,17 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             }
                           },
                           "x-kubernetes-map-type": "atomic"
@@ -10344,10 +11188,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -10357,6 +11203,20 @@
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "namespaceSelector": {
                                     "type": "object",
@@ -10380,10 +11240,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -10398,7 +11260,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -10410,7 +11273,8 @@
                                 "format": "int32"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "type": "array",
@@ -10442,10 +11306,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "type": "object",
@@ -10455,6 +11321,20 @@
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "type": "object",
@@ -10478,10 +11358,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "type": "object",
@@ -10496,13 +11378,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
                     },
@@ -10546,10 +11430,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -10559,6 +11445,20 @@
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "namespaceSelector": {
                                     "type": "object",
@@ -10582,10 +11482,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -10600,7 +11502,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -10612,7 +11515,8 @@
                                 "format": "int32"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "requiredDuringSchedulingIgnoredDuringExecution": {
                           "type": "array",
@@ -10644,10 +11548,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "type": "object",
@@ -10657,6 +11563,20 @@
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "namespaceSelector": {
                                 "type": "object",
@@ -10680,10 +11600,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "type": "object",
@@ -10698,13 +11620,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "topologyKey": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
                     }
@@ -10725,13 +11649,15 @@
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
                         "type": "array",
@@ -10823,7 +11749,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
                         "type": "array",
@@ -10858,7 +11788,8 @@
                               "x-kubernetes-map-type": "atomic"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
                         "type": "string"
@@ -10879,7 +11810,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -10908,7 +11840,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -10918,6 +11851,18 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                }
+                              },
+                              "sleep": {
+                                "type": "object",
+                                "required": [
+                                  "seconds"
+                                ],
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer",
+                                    "format": "int64"
                                   }
                                 }
                               },
@@ -10947,7 +11892,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -10976,7 +11922,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -10986,6 +11933,18 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                }
+                              },
+                              "sleep": {
+                                "type": "object",
+                                "required": [
+                                  "seconds"
+                                ],
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer",
+                                    "format": "int64"
                                   }
                                 }
                               },
@@ -11017,7 +11976,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -11065,7 +12025,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -11160,7 +12121,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -11208,7 +12170,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -11322,6 +12285,20 @@
                           "allowPrivilegeEscalation": {
                             "type": "boolean"
                           },
+                          "appArmorProfile": {
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            }
+                          },
                           "capabilities": {
                             "type": "object",
                             "properties": {
@@ -11329,13 +12306,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -11419,7 +12398,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -11467,7 +12447,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -11547,7 +12528,11 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
                         "type": "array",
@@ -11570,6 +12555,9 @@
                             "readOnly": {
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
                             "subPath": {
                               "type": "string"
                             },
@@ -11577,13 +12565,21 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "dnsConfig": {
                   "type": "object",
@@ -11592,7 +12588,8 @@
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "options": {
                       "type": "array",
@@ -11606,13 +12603,15 @@
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "searches": {
                       "type": "array",
                       "items": {
                         "type": "string"
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     }
                   }
                 },
@@ -11634,13 +12633,15 @@
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
                         "type": "array",
@@ -11732,7 +12733,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
                         "type": "array",
@@ -11767,7 +12772,8 @@
                               "x-kubernetes-map-type": "atomic"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
                         "type": "string"
@@ -11788,7 +12794,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -11817,7 +12824,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -11827,6 +12835,18 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                }
+                              },
+                              "sleep": {
+                                "type": "object",
+                                "required": [
+                                  "seconds"
+                                ],
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer",
+                                    "format": "int64"
                                   }
                                 }
                               },
@@ -11856,7 +12876,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -11885,7 +12906,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -11895,6 +12917,18 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                }
+                              },
+                              "sleep": {
+                                "type": "object",
+                                "required": [
+                                  "seconds"
+                                ],
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer",
+                                    "format": "int64"
                                   }
                                 }
                               },
@@ -11926,7 +12960,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -11974,7 +13009,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -12069,7 +13105,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -12117,7 +13154,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -12231,6 +13269,20 @@
                           "allowPrivilegeEscalation": {
                             "type": "boolean"
                           },
+                          "appArmorProfile": {
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            }
+                          },
                           "capabilities": {
                             "type": "object",
                             "properties": {
@@ -12238,13 +13290,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -12328,7 +13382,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -12376,7 +13431,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -12459,7 +13515,11 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
                         "type": "array",
@@ -12482,6 +13542,9 @@
                             "readOnly": {
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
                             "subPath": {
                               "type": "string"
                             },
@@ -12489,30 +13552,46 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "hostAliases": {
                   "type": "array",
                   "items": {
                     "type": "object",
+                    "required": [
+                      "ip"
+                    ],
                     "properties": {
                       "hostnames": {
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "ip": {
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "ip"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "hostIPC": {
                   "type": "boolean"
@@ -12539,7 +13618,11 @@
                       }
                     },
                     "x-kubernetes-map-type": "atomic"
-                  }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "initContainers": {
                   "type": "array",
@@ -12553,13 +13636,15 @@
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "command": {
                         "type": "array",
                         "items": {
                           "type": "string"
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "env": {
                         "type": "array",
@@ -12651,7 +13736,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "envFrom": {
                         "type": "array",
@@ -12686,7 +13775,8 @@
                               "x-kubernetes-map-type": "atomic"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "image": {
                         "type": "string"
@@ -12707,7 +13797,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -12736,7 +13827,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -12746,6 +13838,18 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                }
+                              },
+                              "sleep": {
+                                "type": "object",
+                                "required": [
+                                  "seconds"
+                                ],
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer",
+                                    "format": "int64"
                                   }
                                 }
                               },
@@ -12775,7 +13879,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -12804,7 +13909,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -12814,6 +13920,18 @@
                                   },
                                   "scheme": {
                                     "type": "string"
+                                  }
+                                }
+                              },
+                              "sleep": {
+                                "type": "object",
+                                "required": [
+                                  "seconds"
+                                ],
+                                "properties": {
+                                  "seconds": {
+                                    "type": "integer",
+                                    "format": "int64"
                                   }
                                 }
                               },
@@ -12845,7 +13963,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -12893,7 +14012,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -12988,7 +14108,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -13036,7 +14157,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -13150,6 +14272,20 @@
                           "allowPrivilegeEscalation": {
                             "type": "boolean"
                           },
+                          "appArmorProfile": {
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string"
+                              }
+                            }
+                          },
                           "capabilities": {
                             "type": "object",
                             "properties": {
@@ -13157,13 +14293,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "drop": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -13247,7 +14385,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -13295,7 +14434,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "path": {
                                 "type": "string"
@@ -13375,7 +14515,11 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "devicePath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "volumeMounts": {
                         "type": "array",
@@ -13398,6 +14542,9 @@
                             "readOnly": {
                               "type": "boolean"
                             },
+                            "recursiveReadOnly": {
+                              "type": "string"
+                            },
                             "subPath": {
                               "type": "string"
                             },
@@ -13405,13 +14552,21 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "mountPath"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "workingDir": {
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 },
                 "nodeName": {
                   "type": "string"
@@ -13463,7 +14618,8 @@
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "resourceClaims": {
                   "type": "array",
@@ -13524,6 +14680,20 @@
                 "securityContext": {
                   "type": "object",
                   "properties": {
+                    "appArmorProfile": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "fsGroup": {
                       "type": "integer",
                       "format": "int64"
@@ -13578,7 +14748,8 @@
                       "items": {
                         "type": "integer",
                         "format": "int64"
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "sysctls": {
                       "type": "array",
@@ -13596,7 +14767,8 @@
                             "type": "string"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     },
                     "windowsOptions": {
                       "type": "object",
@@ -13658,7 +14830,8 @@
                         "type": "string"
                       }
                     }
-                  }
+                  },
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "topologySpreadConstraints": {
                   "type": "array",
@@ -13692,10 +14865,12 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
                             "type": "object",
@@ -13825,7 +15000,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "path": {
                             "type": "string"
@@ -13903,7 +15079,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "name": {
                             "type": "string"
@@ -14003,7 +15180,8 @@
                                   "x-kubernetes-map-type": "atomic"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -14064,7 +15242,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "dataSource": {
                                     "type": "object",
@@ -14109,24 +15288,6 @@
                                   "resources": {
                                     "type": "object",
                                     "properties": {
-                                      "claims": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "required": [
-                                            "name"
-                                          ],
-                                          "properties": {
-                                            "name": {
-                                              "type": "string"
-                                            }
-                                          }
-                                        },
-                                        "x-kubernetes-list-map-keys": [
-                                          "name"
-                                        ],
-                                        "x-kubernetes-list-type": "map"
-                                      },
                                       "limits": {
                                         "type": "object",
                                         "additionalProperties": {
@@ -14165,10 +15326,12 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
                                         "type": "object",
@@ -14180,6 +15343,9 @@
                                     "x-kubernetes-map-type": "atomic"
                                   },
                                   "storageClassName": {
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
                                     "type": "string"
                                   },
                                   "volumeMode": {
@@ -14211,13 +15377,15 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "wwids": {
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -14368,7 +15536,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "readOnly": {
                             "type": "boolean"
@@ -14465,6 +15634,64 @@
                             "items": {
                               "type": "object",
                               "properties": {
+                                "clusterTrustBundle": {
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "configMap": {
                                   "type": "object",
                                   "properties": {
@@ -14488,7 +15715,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "name": {
                                       "type": "string"
@@ -14552,7 +15780,8 @@
                                             "x-kubernetes-map-type": "atomic"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -14579,7 +15808,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "name": {
                                       "type": "string"
@@ -14609,7 +15839,8 @@
                                   }
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -14660,7 +15891,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "pool": {
                             "type": "string"
@@ -14755,7 +15987,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "optional": {
                             "type": "boolean"
@@ -14812,7 +16045,11 @@
                         }
                       }
                     }
-                  }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
                 }
               }
             }
@@ -14914,6 +16151,10 @@
             "observedGeneration": {
               "type": "integer",
               "format": "int64"
+            },
+            "readyWorkerReplicas": {
+              "type": "integer",
+              "format": "int32"
             },
             "reason": {
               "type": "string"

--- a/class_generator/schema/raylist.json
+++ b/class_generator/schema/raylist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/rayservice.json
+++ b/class_generator/schema/rayservice.json
@@ -209,6 +209,20 @@
                     "allowPrivilegeEscalation": {
                       "type": "boolean"
                     },
+                    "appArmorProfile": {
+                      "type": "object",
+                      "required": [
+                        "type"
+                      ],
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    },
                     "capabilities": {
                       "type": "object",
                       "properties": {
@@ -216,13 +230,15 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "drop": {
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
                     },
@@ -325,6 +341,9 @@
                       "readOnly": {
                         "type": "boolean"
                       },
+                      "recursiveReadOnly": {
+                        "type": "string"
+                      },
                       "subPath": {
                         "type": "string"
                       },
@@ -407,7 +426,8 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "externalName": {
                           "type": "string"
@@ -442,7 +462,8 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "ports": {
                           "type": "array",
@@ -506,6 +527,9 @@
                               }
                             }
                           }
+                        },
+                        "trafficDistribution": {
+                          "type": "string"
                         },
                         "type": {
                           "type": "string"
@@ -580,6 +604,9 @@
                                   "ip": {
                                     "type": "string"
                                   },
+                                  "ipMode": {
+                                    "type": "string"
+                                  },
                                   "ports": {
                                     "type": "array",
                                     "items": {
@@ -606,7 +633,8 @@
                                     "x-kubernetes-list-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             }
                           }
                         }
@@ -702,10 +730,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchFields": {
                                             "type": "array",
@@ -726,10 +756,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
@@ -739,7 +771,8 @@
                                         "format": "int32"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
                                   "type": "object",
@@ -771,10 +804,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchFields": {
                                             "type": "array",
@@ -795,14 +830,17 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   },
                                   "x-kubernetes-map-type": "atomic"
@@ -849,10 +887,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -862,6 +902,20 @@
                                               }
                                             },
                                             "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "matchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "namespaceSelector": {
                                             "type": "object",
@@ -885,10 +939,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -903,7 +959,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "topologyKey": {
                                             "type": "string"
@@ -915,7 +972,8 @@
                                         "format": "int32"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
                                   "type": "array",
@@ -947,10 +1005,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -960,6 +1020,20 @@
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "namespaceSelector": {
                                         "type": "object",
@@ -983,10 +1057,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1001,13 +1077,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "topologyKey": {
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -1051,10 +1129,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -1064,6 +1144,20 @@
                                               }
                                             },
                                             "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "matchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "mismatchLabelKeys": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "namespaceSelector": {
                                             "type": "object",
@@ -1087,10 +1181,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -1105,7 +1201,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "topologyKey": {
                                             "type": "string"
@@ -1117,7 +1214,8 @@
                                         "format": "int32"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "requiredDuringSchedulingIgnoredDuringExecution": {
                                   "type": "array",
@@ -1149,10 +1247,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1162,6 +1262,20 @@
                                           }
                                         },
                                         "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "namespaceSelector": {
                                         "type": "object",
@@ -1185,10 +1299,12 @@
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
                                             "type": "object",
@@ -1203,13 +1319,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "topologyKey": {
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             }
@@ -1230,13 +1348,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "command": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "env": {
                                 "type": "array",
@@ -1328,7 +1448,11 @@
                                       }
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "envFrom": {
                                 "type": "array",
@@ -1363,7 +1487,8 @@
                                       "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "image": {
                                 "type": "string"
@@ -1384,7 +1509,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -1413,7 +1539,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -1423,6 +1550,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -1452,7 +1591,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -1481,7 +1621,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -1491,6 +1632,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -1522,7 +1675,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1570,7 +1724,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -1665,7 +1820,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1713,7 +1869,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -1827,6 +1984,20 @@
                                   "allowPrivilegeEscalation": {
                                     "type": "boolean"
                                   },
+                                  "appArmorProfile": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
                                   "capabilities": {
                                     "type": "object",
                                     "properties": {
@@ -1834,13 +2005,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "drop": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1924,7 +2097,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -1972,7 +2146,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2052,7 +2227,11 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "volumeMounts": {
                                 "type": "array",
@@ -2075,6 +2254,9 @@
                                     "readOnly": {
                                       "type": "boolean"
                                     },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
                                     "subPath": {
                                       "type": "string"
                                     },
@@ -2082,13 +2264,21 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "workingDir": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "dnsConfig": {
                           "type": "object",
@@ -2097,7 +2287,8 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "options": {
                               "type": "array",
@@ -2111,13 +2302,15 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "searches": {
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             }
                           }
                         },
@@ -2139,13 +2332,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "command": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "env": {
                                 "type": "array",
@@ -2237,7 +2432,11 @@
                                       }
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "envFrom": {
                                 "type": "array",
@@ -2272,7 +2471,8 @@
                                       "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "image": {
                                 "type": "string"
@@ -2293,7 +2493,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -2322,7 +2523,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -2332,6 +2534,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -2361,7 +2575,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -2390,7 +2605,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -2400,6 +2616,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -2431,7 +2659,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2479,7 +2708,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2574,7 +2804,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2622,7 +2853,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2736,6 +2968,20 @@
                                   "allowPrivilegeEscalation": {
                                     "type": "boolean"
                                   },
+                                  "appArmorProfile": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
                                   "capabilities": {
                                     "type": "object",
                                     "properties": {
@@ -2743,13 +2989,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "drop": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2833,7 +3081,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -2881,7 +3130,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -2964,7 +3214,11 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "volumeMounts": {
                                 "type": "array",
@@ -2987,6 +3241,9 @@
                                     "readOnly": {
                                       "type": "boolean"
                                     },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
                                     "subPath": {
                                       "type": "string"
                                     },
@@ -2994,30 +3251,46 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "workingDir": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "hostAliases": {
                           "type": "array",
                           "items": {
                             "type": "object",
+                            "required": [
+                              "ip"
+                            ],
                             "properties": {
                               "hostnames": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "ip": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "ip"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "hostIPC": {
                           "type": "boolean"
@@ -3044,7 +3317,11 @@
                               }
                             },
                             "x-kubernetes-map-type": "atomic"
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "initContainers": {
                           "type": "array",
@@ -3058,13 +3335,15 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "command": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "env": {
                                 "type": "array",
@@ -3156,7 +3435,11 @@
                                       }
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "envFrom": {
                                 "type": "array",
@@ -3191,7 +3474,8 @@
                                       "x-kubernetes-map-type": "atomic"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "image": {
                                 "type": "string"
@@ -3212,7 +3496,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -3241,7 +3526,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -3251,6 +3537,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -3280,7 +3578,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -3309,7 +3608,8 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "path": {
                                             "type": "string"
@@ -3319,6 +3619,18 @@
                                           },
                                           "scheme": {
                                             "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "sleep": {
+                                        "type": "object",
+                                        "required": [
+                                          "seconds"
+                                        ],
+                                        "properties": {
+                                          "seconds": {
+                                            "type": "integer",
+                                            "format": "int64"
                                           }
                                         }
                                       },
@@ -3350,7 +3662,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3398,7 +3711,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3493,7 +3807,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3541,7 +3856,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3655,6 +3971,20 @@
                                   "allowPrivilegeEscalation": {
                                     "type": "boolean"
                                   },
+                                  "appArmorProfile": {
+                                    "type": "object",
+                                    "required": [
+                                      "type"
+                                    ],
+                                    "properties": {
+                                      "localhostProfile": {
+                                        "type": "string"
+                                      },
+                                      "type": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
                                   "capabilities": {
                                     "type": "object",
                                     "properties": {
@@ -3662,13 +3992,15 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "drop": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3752,7 +4084,8 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
                                   },
@@ -3800,7 +4133,8 @@
                                               "type": "string"
                                             }
                                           }
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       },
                                       "path": {
                                         "type": "string"
@@ -3880,7 +4214,11 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "devicePath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "volumeMounts": {
                                 "type": "array",
@@ -3903,6 +4241,9 @@
                                     "readOnly": {
                                       "type": "boolean"
                                     },
+                                    "recursiveReadOnly": {
+                                      "type": "string"
+                                    },
                                     "subPath": {
                                       "type": "string"
                                     },
@@ -3910,13 +4251,21 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "mountPath"
+                                ],
+                                "x-kubernetes-list-type": "map"
                               },
                               "workingDir": {
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         },
                         "nodeName": {
                           "type": "string"
@@ -3968,7 +4317,8 @@
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "resourceClaims": {
                           "type": "array",
@@ -4029,6 +4379,20 @@
                         "securityContext": {
                           "type": "object",
                           "properties": {
+                            "appArmorProfile": {
+                              "type": "object",
+                              "required": [
+                                "type"
+                              ],
+                              "properties": {
+                                "localhostProfile": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                }
+                              }
+                            },
                             "fsGroup": {
                               "type": "integer",
                               "format": "int64"
@@ -4083,7 +4447,8 @@
                               "items": {
                                 "type": "integer",
                                 "format": "int64"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "sysctls": {
                               "type": "array",
@@ -4101,7 +4466,8 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "windowsOptions": {
                               "type": "object",
@@ -4163,7 +4529,8 @@
                                 "type": "string"
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         },
                         "topologySpreadConstraints": {
                           "type": "array",
@@ -4197,10 +4564,12 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
                                     "type": "object",
@@ -4330,7 +4699,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "path": {
                                     "type": "string"
@@ -4408,7 +4778,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "name": {
                                     "type": "string"
@@ -4508,7 +4879,8 @@
                                           "x-kubernetes-map-type": "atomic"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -4569,7 +4941,8 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "dataSource": {
                                             "type": "object",
@@ -4614,24 +4987,6 @@
                                           "resources": {
                                             "type": "object",
                                             "properties": {
-                                              "claims": {
-                                                "type": "array",
-                                                "items": {
-                                                  "type": "object",
-                                                  "required": [
-                                                    "name"
-                                                  ],
-                                                  "properties": {
-                                                    "name": {
-                                                      "type": "string"
-                                                    }
-                                                  }
-                                                },
-                                                "x-kubernetes-list-map-keys": [
-                                                  "name"
-                                                ],
-                                                "x-kubernetes-list-type": "map"
-                                              },
                                               "limits": {
                                                 "type": "object",
                                                 "additionalProperties": {
@@ -4670,10 +5025,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "type": "object",
@@ -4685,6 +5042,9 @@
                                             "x-kubernetes-map-type": "atomic"
                                           },
                                           "storageClassName": {
+                                            "type": "string"
+                                          },
+                                          "volumeAttributesClassName": {
                                             "type": "string"
                                           },
                                           "volumeMode": {
@@ -4716,13 +5076,15 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "wwids": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -4873,7 +5235,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "readOnly": {
                                     "type": "boolean"
@@ -4970,6 +5333,64 @@
                                     "items": {
                                       "type": "object",
                                       "properties": {
+                                        "clusterTrustBundle": {
+                                          "type": "object",
+                                          "required": [
+                                            "path"
+                                          ],
+                                          "properties": {
+                                            "labelSelector": {
+                                              "type": "object",
+                                              "properties": {
+                                                "matchExpressions": {
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "object",
+                                                    "required": [
+                                                      "key",
+                                                      "operator"
+                                                    ],
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string"
+                                                      },
+                                                      "operator": {
+                                                        "type": "string"
+                                                      },
+                                                      "values": {
+                                                        "type": "array",
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
+                                                      }
+                                                    }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                },
+                                                "matchLabels": {
+                                                  "type": "object",
+                                                  "additionalProperties": {
+                                                    "type": "string"
+                                                  }
+                                                }
+                                              },
+                                              "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "name": {
+                                              "type": "string"
+                                            },
+                                            "optional": {
+                                              "type": "boolean"
+                                            },
+                                            "path": {
+                                              "type": "string"
+                                            },
+                                            "signerName": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
                                         "configMap": {
                                           "type": "object",
                                           "properties": {
@@ -4993,7 +5414,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "name": {
                                               "type": "string"
@@ -5057,7 +5479,8 @@
                                                     "x-kubernetes-map-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -5084,7 +5507,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "name": {
                                               "type": "string"
@@ -5114,7 +5538,8 @@
                                           }
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -5165,7 +5590,8 @@
                                     "type": "array",
                                     "items": {
                                       "type": "string"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "pool": {
                                     "type": "string"
@@ -5260,7 +5686,8 @@
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "optional": {
                                     "type": "boolean"
@@ -5317,7 +5744,11 @@
                                 }
                               }
                             }
-                          }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
                         }
                       }
                     }
@@ -5460,10 +5891,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchFields": {
                                               "type": "array",
@@ -5484,10 +5917,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
@@ -5497,7 +5932,8 @@
                                           "format": "int32"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "requiredDuringSchedulingIgnoredDuringExecution": {
                                     "type": "object",
@@ -5529,10 +5965,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchFields": {
                                               "type": "array",
@@ -5553,14 +5991,17 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     },
                                     "x-kubernetes-map-type": "atomic"
@@ -5607,10 +6048,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5620,6 +6063,20 @@
                                                 }
                                               },
                                               "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "matchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "namespaceSelector": {
                                               "type": "object",
@@ -5643,10 +6100,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5661,7 +6120,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "topologyKey": {
                                               "type": "string"
@@ -5673,7 +6133,8 @@
                                           "format": "int32"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "requiredDuringSchedulingIgnoredDuringExecution": {
                                     "type": "array",
@@ -5705,10 +6166,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5718,6 +6181,20 @@
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "matchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "mismatchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "type": "object",
@@ -5741,10 +6218,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5759,13 +6238,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               },
@@ -5809,10 +6290,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5822,6 +6305,20 @@
                                                 }
                                               },
                                               "x-kubernetes-map-type": "atomic"
+                                            },
+                                            "matchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            },
+                                            "mismatchLabelKeys": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "namespaceSelector": {
                                               "type": "object",
@@ -5845,10 +6342,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -5863,7 +6362,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "topologyKey": {
                                               "type": "string"
@@ -5875,7 +6375,8 @@
                                           "format": "int32"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   },
                                   "requiredDuringSchedulingIgnoredDuringExecution": {
                                     "type": "array",
@@ -5907,10 +6408,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5920,6 +6423,20 @@
                                             }
                                           },
                                           "x-kubernetes-map-type": "atomic"
+                                        },
+                                        "matchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "mismatchLabelKeys": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "namespaceSelector": {
                                           "type": "object",
@@ -5943,10 +6460,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "type": "object",
@@ -5961,13 +6480,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "type": "string"
                                         }
                                       }
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 }
                               }
@@ -5988,13 +6509,15 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "command": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "env": {
                                   "type": "array",
@@ -6086,7 +6609,11 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "envFrom": {
                                   "type": "array",
@@ -6121,7 +6648,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "image": {
                                   "type": "string"
@@ -6142,7 +6670,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -6171,7 +6700,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -6181,6 +6711,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -6210,7 +6752,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -6239,7 +6782,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -6249,6 +6793,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -6280,7 +6836,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6328,7 +6885,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6423,7 +6981,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6471,7 +7030,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6585,6 +7145,20 @@
                                     "allowPrivilegeEscalation": {
                                       "type": "boolean"
                                     },
+                                    "appArmorProfile": {
+                                      "type": "object",
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "properties": {
+                                        "localhostProfile": {
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
                                     "capabilities": {
                                       "type": "object",
                                       "properties": {
@@ -6592,13 +7166,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "drop": {
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6682,7 +7258,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -6730,7 +7307,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -6810,7 +7388,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "devicePath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "volumeMounts": {
                                   "type": "array",
@@ -6833,6 +7415,9 @@
                                       "readOnly": {
                                         "type": "boolean"
                                       },
+                                      "recursiveReadOnly": {
+                                        "type": "string"
+                                      },
                                       "subPath": {
                                         "type": "string"
                                       },
@@ -6840,13 +7425,21 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "mountPath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "workingDir": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "dnsConfig": {
                             "type": "object",
@@ -6855,7 +7448,8 @@
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "options": {
                                 "type": "array",
@@ -6869,13 +7463,15 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "searches": {
                                 "type": "array",
                                 "items": {
                                   "type": "string"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -6897,13 +7493,15 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "command": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "env": {
                                   "type": "array",
@@ -6995,7 +7593,11 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "envFrom": {
                                   "type": "array",
@@ -7030,7 +7632,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "image": {
                                   "type": "string"
@@ -7051,7 +7654,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -7080,7 +7684,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -7090,6 +7695,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -7119,7 +7736,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -7148,7 +7766,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -7158,6 +7777,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -7189,7 +7820,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7237,7 +7869,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7332,7 +7965,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7380,7 +8014,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7494,6 +8129,20 @@
                                     "allowPrivilegeEscalation": {
                                       "type": "boolean"
                                     },
+                                    "appArmorProfile": {
+                                      "type": "object",
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "properties": {
+                                        "localhostProfile": {
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
                                     "capabilities": {
                                       "type": "object",
                                       "properties": {
@@ -7501,13 +8150,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "drop": {
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7591,7 +8242,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -7639,7 +8291,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -7722,7 +8375,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "devicePath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "volumeMounts": {
                                   "type": "array",
@@ -7745,6 +8402,9 @@
                                       "readOnly": {
                                         "type": "boolean"
                                       },
+                                      "recursiveReadOnly": {
+                                        "type": "string"
+                                      },
                                       "subPath": {
                                         "type": "string"
                                       },
@@ -7752,30 +8412,46 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "mountPath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "workingDir": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "hostAliases": {
                             "type": "array",
                             "items": {
                               "type": "object",
+                              "required": [
+                                "ip"
+                              ],
                               "properties": {
                                 "hostnames": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "ip": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "ip"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "hostIPC": {
                             "type": "boolean"
@@ -7802,7 +8478,11 @@
                                 }
                               },
                               "x-kubernetes-map-type": "atomic"
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "initContainers": {
                             "type": "array",
@@ -7816,13 +8496,15 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "command": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "env": {
                                   "type": "array",
@@ -7914,7 +8596,11 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "name"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "envFrom": {
                                   "type": "array",
@@ -7949,7 +8635,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "image": {
                                   "type": "string"
@@ -7970,7 +8657,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -7999,7 +8687,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -8009,6 +8698,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -8038,7 +8739,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             }
                                           }
                                         },
@@ -8067,7 +8769,8 @@
                                                     "type": "string"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "path": {
                                               "type": "string"
@@ -8077,6 +8780,18 @@
                                             },
                                             "scheme": {
                                               "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "sleep": {
+                                          "type": "object",
+                                          "required": [
+                                            "seconds"
+                                          ],
+                                          "properties": {
+                                            "seconds": {
+                                              "type": "integer",
+                                              "format": "int64"
                                             }
                                           }
                                         },
@@ -8108,7 +8823,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8156,7 +8872,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8251,7 +8968,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8299,7 +9017,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8413,6 +9132,20 @@
                                     "allowPrivilegeEscalation": {
                                       "type": "boolean"
                                     },
+                                    "appArmorProfile": {
+                                      "type": "object",
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "properties": {
+                                        "localhostProfile": {
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
                                     "capabilities": {
                                       "type": "object",
                                       "properties": {
@@ -8420,13 +9153,15 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "drop": {
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8510,7 +9245,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -8558,7 +9294,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "type": "string"
@@ -8638,7 +9375,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "devicePath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "volumeMounts": {
                                   "type": "array",
@@ -8661,6 +9402,9 @@
                                       "readOnly": {
                                         "type": "boolean"
                                       },
+                                      "recursiveReadOnly": {
+                                        "type": "string"
+                                      },
                                       "subPath": {
                                         "type": "string"
                                       },
@@ -8668,13 +9412,21 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-map-keys": [
+                                    "mountPath"
+                                  ],
+                                  "x-kubernetes-list-type": "map"
                                 },
                                 "workingDir": {
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           },
                           "nodeName": {
                             "type": "string"
@@ -8726,7 +9478,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "resourceClaims": {
                             "type": "array",
@@ -8787,6 +9540,20 @@
                           "securityContext": {
                             "type": "object",
                             "properties": {
+                              "appArmorProfile": {
+                                "type": "object",
+                                "required": [
+                                  "type"
+                                ],
+                                "properties": {
+                                  "localhostProfile": {
+                                    "type": "string"
+                                  },
+                                  "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
                               "fsGroup": {
                                 "type": "integer",
                                 "format": "int64"
@@ -8841,7 +9608,8 @@
                                 "items": {
                                   "type": "integer",
                                   "format": "int64"
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "sysctls": {
                                 "type": "array",
@@ -8859,7 +9627,8 @@
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "windowsOptions": {
                                 "type": "object",
@@ -8921,7 +9690,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "topologySpreadConstraints": {
                             "type": "array",
@@ -8955,10 +9725,12 @@
                                             "type": "array",
                                             "items": {
                                               "type": "string"
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "matchLabels": {
                                       "type": "object",
@@ -9088,7 +9860,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "type": "string"
@@ -9166,7 +9939,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "name": {
                                       "type": "string"
@@ -9266,7 +10040,8 @@
                                             "x-kubernetes-map-type": "atomic"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -9327,7 +10102,8 @@
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "dataSource": {
                                               "type": "object",
@@ -9372,24 +10148,6 @@
                                             "resources": {
                                               "type": "object",
                                               "properties": {
-                                                "claims": {
-                                                  "type": "array",
-                                                  "items": {
-                                                    "type": "object",
-                                                    "required": [
-                                                      "name"
-                                                    ],
-                                                    "properties": {
-                                                      "name": {
-                                                        "type": "string"
-                                                      }
-                                                    }
-                                                  },
-                                                  "x-kubernetes-list-map-keys": [
-                                                    "name"
-                                                  ],
-                                                  "x-kubernetes-list-type": "map"
-                                                },
                                                 "limits": {
                                                   "type": "object",
                                                   "additionalProperties": {
@@ -9428,10 +10186,12 @@
                                                         "type": "array",
                                                         "items": {
                                                           "type": "string"
-                                                        }
+                                                        },
+                                                        "x-kubernetes-list-type": "atomic"
                                                       }
                                                     }
-                                                  }
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
                                                 },
                                                 "matchLabels": {
                                                   "type": "object",
@@ -9443,6 +10203,9 @@
                                               "x-kubernetes-map-type": "atomic"
                                             },
                                             "storageClassName": {
+                                              "type": "string"
+                                            },
+                                            "volumeAttributesClassName": {
                                               "type": "string"
                                             },
                                             "volumeMode": {
@@ -9474,13 +10237,15 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "wwids": {
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -9631,7 +10396,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "readOnly": {
                                       "type": "boolean"
@@ -9728,6 +10494,64 @@
                                       "items": {
                                         "type": "object",
                                         "properties": {
+                                          "clusterTrustBundle": {
+                                            "type": "object",
+                                            "required": [
+                                              "path"
+                                            ],
+                                            "properties": {
+                                              "labelSelector": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "matchExpressions": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "required": [
+                                                        "key",
+                                                        "operator"
+                                                      ],
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          },
+                                                          "x-kubernetes-list-type": "atomic"
+                                                        }
+                                                      }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
+                                                  },
+                                                  "matchLabels": {
+                                                    "type": "object",
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    }
+                                                  }
+                                                },
+                                                "x-kubernetes-map-type": "atomic"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "type": "boolean"
+                                              },
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "signerName": {
+                                                "type": "string"
+                                              }
+                                            }
+                                          },
                                           "configMap": {
                                             "type": "object",
                                             "properties": {
@@ -9751,7 +10575,8 @@
                                                       "type": "string"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "name": {
                                                 "type": "string"
@@ -9815,7 +10640,8 @@
                                                       "x-kubernetes-map-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
                                           },
@@ -9842,7 +10668,8 @@
                                                       "type": "string"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "name": {
                                                 "type": "string"
@@ -9872,7 +10699,8 @@
                                             }
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -9923,7 +10751,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "pool": {
                                       "type": "string"
@@ -10018,7 +10847,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "optional": {
                                       "type": "boolean"
@@ -10075,7 +10905,11 @@
                                   }
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
                           }
                         }
                       }
@@ -10147,7 +10981,8 @@
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "externalName": {
                   "type": "string"
@@ -10182,7 +11017,8 @@
                   "type": "array",
                   "items": {
                     "type": "string"
-                  }
+                  },
+                  "x-kubernetes-list-type": "atomic"
                 },
                 "ports": {
                   "type": "array",
@@ -10246,6 +11082,9 @@
                       }
                     }
                   }
+                },
+                "trafficDistribution": {
+                  "type": "string"
                 },
                 "type": {
                   "type": "string"
@@ -10320,6 +11159,9 @@
                           "ip": {
                             "type": "string"
                           },
+                          "ipMode": {
+                            "type": "string"
+                          },
                           "ports": {
                             "type": "array",
                             "items": {
@@ -10346,7 +11188,8 @@
                             "x-kubernetes-list-type": "atomic"
                           }
                         }
-                      }
+                      },
+                      "x-kubernetes-list-type": "atomic"
                     }
                   }
                 }
@@ -10463,6 +11306,10 @@
                 "observedGeneration": {
                   "type": "integer",
                   "format": "int64"
+                },
+                "readyWorkerReplicas": {
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "reason": {
                   "type": "string"
@@ -10582,6 +11429,10 @@
                 "observedGeneration": {
                   "type": "integer",
                   "format": "int64"
+                },
+                "readyWorkerReplicas": {
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "reason": {
                   "type": "string"

--- a/class_generator/schema/resourceflavor.json
+++ b/class_generator/schema/resourceflavor.json
@@ -19,7 +19,7 @@
       "type": "object",
       "properties": {
         "nodeLabels": {
-          "description": "nodeLabels are labels that associate the ResourceFlavor with Nodes that\nhave the same labels.\nWhen a Workload is admitted, its podsets can only get assigned\nResourceFlavors whose nodeLabels match the nodeSelector and nodeAffinity\nfields.\nOnce a ResourceFlavor is assigned to a podSet, the ResourceFlavor's\nnodeLabels should be injected into the pods of the Workload by the\ncontroller that integrates with the Workload object.\n\n\nnodeLabels can be up to 8 elements.",
+          "description": "nodeLabels are labels that associate the ResourceFlavor with Nodes that\nhave the same labels.\nWhen a Workload is admitted, its podsets can only get assigned\nResourceFlavors whose nodeLabels match the nodeSelector and nodeAffinity\nfields.\nOnce a ResourceFlavor is assigned to a podSet, the ResourceFlavor's\nnodeLabels should be injected into the pods of the Workload by the\ncontroller that integrates with the Workload object.\n\nnodeLabels can be up to 8 elements.",
           "type": "object",
           "maxProperties": 8,
           "additionalProperties": {
@@ -28,7 +28,7 @@
           "x-kubernetes-map-type": "atomic"
         },
         "nodeTaints": {
-          "description": "nodeTaints are taints that the nodes associated with this ResourceFlavor\nhave.\nWorkloads' podsets must have tolerations for these nodeTaints in order to\nget assigned this ResourceFlavor during admission.\n\n\nAn example of a nodeTaint is\ncloud.provider.com/preemptible=\"true\":NoSchedule\n\n\nnodeTaints can be up to 8 elements.",
+          "description": "nodeTaints are taints that the nodes associated with this ResourceFlavor\nhave.\nWorkloads' podsets must have tolerations for these nodeTaints in order to\nget assigned this ResourceFlavor during admission.\n\nAn example of a nodeTaint is\ncloud.provider.com/preemptible=\"true\":NoSchedule\n\nnodeTaints can be up to 8 elements.",
           "type": "array",
           "maxItems": 8,
           "items": {
@@ -67,7 +67,7 @@
           ]
         },
         "tolerations": {
-          "description": "tolerations are extra tolerations that will be added to the pods admitted in\nthe quota associated with this resource flavor.\n\n\nAn example of a toleration is\ncloud.provider.com/preemptible=\"true\":NoSchedule\n\n\ntolerations can be up to 8 elements.",
+          "description": "tolerations are extra tolerations that will be added to the pods admitted in\nthe quota associated with this resource flavor.\n\nAn example of a toleration is\ncloud.provider.com/preemptible=\"true\":NoSchedule\n\ntolerations can be up to 8 elements.",
           "type": "array",
           "maxItems": 8,
           "items": {
@@ -120,8 +120,24 @@
               "rule": "self.all(x, !has(x.effect) || x.effect in ['NoSchedule', 'PreferNoSchedule', 'NoExecute'])"
             }
           ]
+        },
+        "topologyName": {
+          "description": "topologyName indicates topology for the TAS ResourceFlavor.\nWhen specified, it enables scraping of the topology information from the\nnodes matching to the Resource Flavor node labels.",
+          "type": "string",
+          "maxLength": 253,
+          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "at least one nodeLabel is required when topology is set",
+          "rule": "!has(self.topologyName) || self.nodeLabels.size() >= 1"
+        },
+        {
+          "message": "resourceFlavorSpec are immutable when topologyName is set",
+          "rule": "!has(oldSelf.topologyName) || self == oldSelf"
+        }
+      ]
     }
   },
   "x-kubernetes-group-version-kind": [

--- a/class_generator/schema/route.json
+++ b/class_generator/schema/route.json
@@ -1,9 +1,6 @@
 {
-  "description": "A route allows developers to expose services through an HTTP(S) aware load balancing and proxy layer via a public DNS entry. The route may further specify TLS options and a certificate, or specify a public CNAME that the router should also accept for HTTP and HTTPS traffic. An administrator typically configures their router to be visible outside the cluster firewall, and may also add additional security, caching, or traffic controls on the service content. Routers usually talk directly to the service endpoints.\n\nOnce a route is created, the `host` field may not be changed. Generally, routers use the oldest route with a given host when resolving conflicts.\n\nRouters are subject to additional customization and may support additional controls via the annotations field.\n\nBecause administrators may configure multiple routers, the route status field is used to return information to clients about the names and states of the route under each router. If a client chooses a duplicate name, for instance, the route status conditions are used to indicate the route cannot be chosen.\n\nTo enable HTTP/2 ALPN on a route it requires a custom (non-wildcard) certificate. This prevents connection coalescing by clients, notably web browsers. We do not support HTTP/2 ALPN on routes that use the default certificate because of the risk of connection re-use/coalescing. Routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "Route is responsible for configuring ingress over a collection of Revisions.\nSome of the Revisions a Route distributes traffic over may be specified by\nreferencing the Configuration responsible for creating them; in these cases\nthe Route is additionally responsible for monitoring the Configuration for\n\"latest ready revision\" changes, and smoothly rolling out latest revisions.\nSee also: https://github.com/knative/serving/blob/main/docs/spec/overview.md#route",
   "type": "object",
-  "required": [
-    "spec"
-  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -14,29 +11,174 @@
       "type": "string"
     },
     "metadata": {
-      "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
-      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta_v2"
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "spec is the desired state of the route",
-      "$ref": "_definitions.json#/definitions/com.github.openshift.api.route.v1.RouteSpec"
+      "description": "Spec holds the desired state of the Route (from the client).",
+      "type": "object",
+      "properties": {
+        "traffic": {
+          "description": "Traffic specifies how to distribute traffic over a collection of\nrevisions and configurations.",
+          "type": "array",
+          "items": {
+            "description": "TrafficTarget holds a single entry of the routing table for a Route.",
+            "type": "object",
+            "properties": {
+              "configurationName": {
+                "description": "ConfigurationName of a configuration to whose latest revision we will send\nthis portion of traffic. When the \"status.latestReadyRevisionName\" of the\nreferenced configuration changes, we will automatically migrate traffic\nfrom the prior \"latest ready\" revision to the new one.  This field is never\nset in Route's status, only its spec.  This is mutually exclusive with\nRevisionName.",
+                "type": "string"
+              },
+              "latestRevision": {
+                "description": "LatestRevision may be optionally provided to indicate that the latest\nready Revision of the Configuration should be used for this traffic\ntarget.  When provided LatestRevision must be true if RevisionName is\nempty; it must be false when RevisionName is non-empty.",
+                "type": "boolean"
+              },
+              "percent": {
+                "description": "Percent indicates that percentage based routing should be used and\nthe value indicates the percent of traffic that is be routed to this\nRevision or Configuration. `0` (zero) mean no traffic, `100` means all\ntraffic.\nWhen percentage based routing is being used the follow rules apply:\n- the sum of all percent values must equal 100\n- when not specified, the implied value for `percent` is zero for\n  that particular Revision or Configuration",
+                "type": "integer",
+                "format": "int64"
+              },
+              "revisionName": {
+                "description": "RevisionName of a specific revision to which to send this portion of\ntraffic.  This is mutually exclusive with ConfigurationName.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Tag is optionally used to expose a dedicated url for referencing\nthis target exclusively.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL displays the URL for accessing named traffic targets. URL is displayed in\nstatus, and is disallowed on spec. URL must contain a scheme (e.g. http://) and\na hostname, but may not contain anything else (e.g. basic auth, url path, etc.)",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
     "status": {
-      "description": "status is the current state of the route",
-      "$ref": "_definitions.json#/definitions/com.github.openshift.api.route.v1.RouteStatus"
+      "description": "Status communicates the observed state of the Route (from the controller).",
+      "type": "object",
+      "properties": {
+        "address": {
+          "description": "Address holds the information needed for a Route to be the target of an event.",
+          "type": "object",
+          "properties": {
+            "CACerts": {
+              "description": "CACerts is the Certification Authority (CA) certificates in PEM format\naccording to https://www.rfc-editor.org/rfc/rfc7468.",
+              "type": "string"
+            },
+            "audience": {
+              "description": "Audience is the OIDC audience for this address.",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name is the name of the address.",
+              "type": "string"
+            },
+            "url": {
+              "type": "string"
+            }
+          }
+        },
+        "annotations": {
+          "description": "Annotations is additional Status fields for the Resource to save some\nadditional State as well as convey more information to the user. This is\nroughly akin to Annotations on any k8s resource, just the reconciler conveying\nricher information outwards.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "conditions": {
+          "description": "Conditions the latest available observations of a resource's current state.",
+          "type": "array",
+          "items": {
+            "description": "Condition defines a readiness condition for a Knative resource.\nSee: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transitioned from one status to another.\nWe use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic\ndifferences (all other things held constant).",
+                "type": "string"
+              },
+              "message": {
+                "description": "A human readable message indicating details about the transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "The reason for the condition's last transition.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type of condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the 'Generation' of the Service that\nwas last processed by the controller.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "traffic": {
+          "description": "Traffic holds the configured traffic distribution.\nThese entries will always contain RevisionName references.\nWhen ConfigurationName appears in the spec, this will hold the\nLatestReadyRevisionName that we last observed.",
+          "type": "array",
+          "items": {
+            "description": "TrafficTarget holds a single entry of the routing table for a Route.",
+            "type": "object",
+            "properties": {
+              "configurationName": {
+                "description": "ConfigurationName of a configuration to whose latest revision we will send\nthis portion of traffic. When the \"status.latestReadyRevisionName\" of the\nreferenced configuration changes, we will automatically migrate traffic\nfrom the prior \"latest ready\" revision to the new one.  This field is never\nset in Route's status, only its spec.  This is mutually exclusive with\nRevisionName.",
+                "type": "string"
+              },
+              "latestRevision": {
+                "description": "LatestRevision may be optionally provided to indicate that the latest\nready Revision of the Configuration should be used for this traffic\ntarget.  When provided LatestRevision must be true if RevisionName is\nempty; it must be false when RevisionName is non-empty.",
+                "type": "boolean"
+              },
+              "percent": {
+                "description": "Percent indicates that percentage based routing should be used and\nthe value indicates the percent of traffic that is be routed to this\nRevision or Configuration. `0` (zero) mean no traffic, `100` means all\ntraffic.\nWhen percentage based routing is being used the follow rules apply:\n- the sum of all percent values must equal 100\n- when not specified, the implied value for `percent` is zero for\n  that particular Revision or Configuration",
+                "type": "integer",
+                "format": "int64"
+              },
+              "revisionName": {
+                "description": "RevisionName of a specific revision to which to send this portion of\ntraffic.  This is mutually exclusive with ConfigurationName.",
+                "type": "string"
+              },
+              "tag": {
+                "description": "Tag is optionally used to expose a dedicated url for referencing\nthis target exclusively.",
+                "type": "string"
+              },
+              "url": {
+                "description": "URL displays the URL for accessing named traffic targets. URL is displayed in\nstatus, and is disallowed on spec. URL must contain a scheme (e.g. http://) and\na hostname, but may not contain anything else (e.g. basic auth, url path, etc.)",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "url": {
+          "description": "URL holds the url that will distribute traffic over the provided traffic targets.\nIt generally has the form http[s]://{route-name}.{route-namespace}.{cluster-level-suffix}",
+          "type": "string"
+        }
+      }
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "",
-      "kind": "Route",
-      "version": "v1"
-    },
-    {
-      "group": "route.openshift.io",
+      "group": "serving.knative.dev",
       "kind": "Route",
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/routelist.json
+++ b/class_generator/schema/routelist.json
@@ -1,5 +1,5 @@
 {
-  "description": "RouteList is a collection of Routes.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "RouteList is a list of Route",
   "type": "object",
   "required": [
     "items"
@@ -10,10 +10,10 @@
       "type": "string"
     },
     "items": {
-      "description": "items is a list of routes",
+      "description": "List of routes. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/com.github.openshift.api.route.v1.Route"
+        "$ref": "_definitions.json#/definitions/dev.knative.serving.v1.Route"
       }
     },
     "kind": {
@@ -21,21 +21,17 @@
       "type": "string"
     },
     "metadata": {
-      "description": "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "",
-      "kind": "RouteList",
-      "version": "v1"
-    },
-    {
-      "group": "route.openshift.io",
+      "group": "serving.knative.dev",
       "kind": "RouteList",
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/subscription.json
+++ b/class_generator/schema/subscription.json
@@ -1,5 +1,5 @@
 {
-  "description": "Subscription is the Schema for the subscriptions API",
+  "description": "Subscription keeps operators up to date by tracking changes to Catalogs.",
   "type": "object",
   "required": [
     "metadata",
@@ -19,101 +19,2698 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "SubscriptionSpec defines the desired state of Subscription",
+      "description": "SubscriptionSpec defines an Application that can be installed",
       "type": "object",
       "required": [
-        "cluster",
-        "dbname",
-        "externalClusterName",
         "name",
-        "publicationName"
+        "source",
+        "sourceNamespace"
       ],
       "properties": {
-        "cluster": {
-          "description": "The name of the PostgreSQL cluster that identifies the \"subscriber\"",
+        "channel": {
+          "type": "string"
+        },
+        "config": {
+          "description": "SubscriptionConfig contains configuration specified for a subscription.",
           "type": "object",
           "properties": {
+            "affinity": {
+              "description": "If specified, overrides the pod's scheduling constraints.\nnil sub-attributes will *not* override the original values in the pod.spec for those sub-attributes.\nUse empty object ({}) to erase original sub-attribute values.",
+              "type": "object",
+              "properties": {
+                "nodeAffinity": {
+                  "description": "Describes node affinity scheduling rules for the pod.",
+                  "type": "object",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                      "type": "array",
+                      "items": {
+                        "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                        "type": "object",
+                        "required": [
+                          "preference",
+                          "weight"
+                        ],
+                        "properties": {
+                          "preference": {
+                            "description": "A node selector term, associated with the corresponding weight.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "weight": {
+                            "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                      "type": "object",
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "type": "array",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    }
+                  }
+                },
+                "podAffinity": {
+                  "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                  "type": "object",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                      "type": "array",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "type": "object",
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "type": "array",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                        "type": "object",
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                },
+                "podAntiAffinity": {
+                  "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                  "type": "object",
+                  "properties": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                      "type": "array",
+                      "items": {
+                        "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                        "type": "object",
+                        "required": [
+                          "podAffinityTerm",
+                          "weight"
+                        ],
+                        "properties": {
+                          "podAffinityTerm": {
+                            "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "weight": {
+                            "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                      "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                      "type": "array",
+                      "items": {
+                        "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                        "type": "object",
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "mismatchLabelKeys": {
+                            "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "namespaceSelector": {
+                            "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "namespaces": {
+                            "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "topologyKey": {
+                            "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                }
+              }
+            },
+            "annotations": {
+              "description": "Annotations is an unstructured key value map stored with each Deployment, Pod, APIService in the Operator.\nTypically, annotations may be set by external tools to store and retrieve arbitrary metadata.\nUse this field to pre-define annotations that OLM should add to each of the Subscription's\ndeployments, pods, and apiservices.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "env": {
+              "description": "Env is a list of environment variables to set in the container.\nCannot be updated.",
+              "type": "array",
+              "items": {
+                "description": "EnvVar represents an environment variable present in a Container.",
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "Variable references $(VAR_NAME) are expanded\nusing the previously defined environment variables in the container and\nany service environment variables. If a variable cannot be resolved,\nthe reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.\n\"$$(VAR_NAME)\" will produce the string literal \"$(VAR_NAME)\".\nEscaped references will never be expanded, regardless of whether the variable\nexists or not.\nDefaults to \"\".",
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "description": "Source for the environment variable's value. Cannot be used if value is not empty.",
+                    "type": "object",
+                    "properties": {
+                      "configMapKeyRef": {
+                        "description": "Selects a key of a ConfigMap.",
+                        "type": "object",
+                        "required": [
+                          "key"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "The key to select.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the ConfigMap or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "fieldRef": {
+                        "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,\nspec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.",
+                        "type": "object",
+                        "required": [
+                          "fieldPath"
+                        ],
+                        "properties": {
+                          "apiVersion": {
+                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                            "type": "string"
+                          },
+                          "fieldPath": {
+                            "description": "Path of the field to select in the specified API version.",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "resourceFieldRef": {
+                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.",
+                        "type": "object",
+                        "required": [
+                          "resource"
+                        ],
+                        "properties": {
+                          "containerName": {
+                            "description": "Container name: required for volumes, optional for env vars",
+                            "type": "string"
+                          },
+                          "divisor": {
+                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          },
+                          "resource": {
+                            "description": "Required: resource to select",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "secretKeyRef": {
+                        "description": "Selects a key of a secret in the pod's namespace",
+                        "type": "object",
+                        "required": [
+                          "key"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "The key of the secret to select from.  Must be a valid secret key.",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "Specify whether the Secret or its key must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "envFrom": {
+              "description": "EnvFrom is a list of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nImmutable.",
+              "type": "array",
+              "items": {
+                "description": "EnvFromSource represents the source of a set of ConfigMaps",
+                "type": "object",
+                "properties": {
+                  "configMapRef": {
+                    "description": "The ConfigMap to select from",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the ConfigMap must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "prefix": {
+                    "description": "An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.",
+                    "type": "string"
+                  },
+                  "secretRef": {
+                    "description": "The Secret to select from",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "Specify whether the Secret must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                }
+              }
+            },
+            "nodeSelector": {
+              "description": "NodeSelector is a selector which must be true for the pod to fit on a node.\nSelector which must match a node's labels for the pod to be scheduled on that node.\nMore info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "resources": {
+              "description": "Resources represents compute resources required by this container.\nImmutable.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
+              "type": "object",
+              "properties": {
+                "claims": {
+                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                  "type": "array",
+                  "items": {
+                    "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                        "type": "string"
+                      },
+                      "request": {
+                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-map-keys": [
+                    "name"
+                  ],
+                  "x-kubernetes-list-type": "map"
+                },
+                "limits": {
+                  "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                },
+                "requests": {
+                  "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                    "x-kubernetes-int-or-string": true
+                  }
+                }
+              }
+            },
+            "selector": {
+              "description": "Selector is the label selector for pods to be configured.\nExisting ReplicaSets whose pods are\nselected by this will be the ones affected by this deployment.\nIt must match the pod template's labels.",
+              "type": "object",
+              "properties": {
+                "matchExpressions": {
+                  "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                  "type": "array",
+                  "items": {
+                    "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                    "type": "object",
+                    "required": [
+                      "key",
+                      "operator"
+                    ],
+                    "properties": {
+                      "key": {
+                        "description": "key is the label key that the selector applies to.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                        "type": "string"
+                      },
+                      "values": {
+                        "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "matchLabels": {
+                  "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              },
+              "x-kubernetes-map-type": "atomic"
+            },
+            "tolerations": {
+              "description": "Tolerations are the pod's tolerations.",
+              "type": "array",
+              "items": {
+                "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                "type": "object",
+                "properties": {
+                  "effect": {
+                    "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                    "type": "string"
+                  },
+                  "key": {
+                    "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                    "type": "string"
+                  },
+                  "operator": {
+                    "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                    "type": "string"
+                  },
+                  "tolerationSeconds": {
+                    "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "value": {
+                    "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "volumeMounts": {
+              "description": "List of VolumeMounts to set in the container.",
+              "type": "array",
+              "items": {
+                "description": "VolumeMount describes a mounting of a Volume within a container.",
+                "type": "object",
+                "required": [
+                  "mountPath",
+                  "name"
+                ],
+                "properties": {
+                  "mountPath": {
+                    "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                    "type": "string"
+                  },
+                  "mountPropagation": {
+                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "This must match the Name of a Volume.",
+                    "type": "string"
+                  },
+                  "readOnly": {
+                    "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                    "type": "boolean"
+                  },
+                  "recursiveReadOnly": {
+                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                    "type": "string"
+                  },
+                  "subPath": {
+                    "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                    "type": "string"
+                  },
+                  "subPathExpr": {
+                    "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "volumes": {
+              "description": "List of Volumes to set in the podSpec.",
+              "type": "array",
+              "items": {
+                "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "awsElasticBlockStore": {
+                    "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                    "type": "object",
+                    "required": [
+                      "volumeID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "readOnly": {
+                        "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "azureDisk": {
+                    "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                    "type": "object",
+                    "required": [
+                      "diskName",
+                      "diskURI"
+                    ],
+                    "properties": {
+                      "cachingMode": {
+                        "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                        "type": "string"
+                      },
+                      "diskName": {
+                        "description": "diskName is the Name of the data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "diskURI": {
+                        "description": "diskURI is the URI of data disk in the blob storage",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "kind": {
+                        "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "azureFile": {
+                    "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                    "type": "object",
+                    "required": [
+                      "secretName",
+                      "shareName"
+                    ],
+                    "properties": {
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                        "type": "string"
+                      },
+                      "shareName": {
+                        "description": "shareName is the azure share Name",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "cephfs": {
+                    "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                    "type": "object",
+                    "required": [
+                      "monitors"
+                    ],
+                    "properties": {
+                      "monitors": {
+                        "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "path": {
+                        "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretFile": {
+                        "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "user": {
+                        "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "cinder": {
+                    "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                    "type": "object",
+                    "required": [
+                      "volumeID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "volumeID": {
+                        "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "configMap": {
+                    "description": "configMap represents a configMap that should populate this volume",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "items": {
+                        "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                        "type": "array",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "path": {
+                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "name": {
+                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "optional": {
+                        "description": "optional specify whether the ConfigMap or its keys must be defined",
+                        "type": "boolean"
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  },
+                  "csi": {
+                    "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                    "type": "object",
+                    "required": [
+                      "driver"
+                    ],
+                    "properties": {
+                      "driver": {
+                        "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                        "type": "string"
+                      },
+                      "nodePublishSecretRef": {
+                        "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "readOnly": {
+                        "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                        "type": "boolean"
+                      },
+                      "volumeAttributes": {
+                        "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "downwardAPI": {
+                    "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "items": {
+                        "description": "Items is a list of downward API volume file",
+                        "type": "array",
+                        "items": {
+                          "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                          "type": "object",
+                          "required": [
+                            "path"
+                          ],
+                          "properties": {
+                            "fieldRef": {
+                              "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                              "type": "object",
+                              "required": [
+                                "fieldPath"
+                              ],
+                              "properties": {
+                                "apiVersion": {
+                                  "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                  "type": "string"
+                                },
+                                "fieldPath": {
+                                  "description": "Path of the field to select in the specified API version.",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "mode": {
+                              "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "path": {
+                              "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                              "type": "string"
+                            },
+                            "resourceFieldRef": {
+                              "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                              "type": "object",
+                              "required": [
+                                "resource"
+                              ],
+                              "properties": {
+                                "containerName": {
+                                  "description": "Container name: required for volumes, optional for env vars",
+                                  "type": "string"
+                                },
+                                "divisor": {
+                                  "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "resource": {
+                                  "description": "Required: resource to select",
+                                  "type": "string"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    }
+                  },
+                  "emptyDir": {
+                    "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "type": "object",
+                    "properties": {
+                      "medium": {
+                        "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "string"
+                      },
+                      "sizeLimit": {
+                        "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  },
+                  "ephemeral": {
+                    "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                    "type": "object",
+                    "properties": {
+                      "volumeClaimTemplate": {
+                        "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                        "type": "object",
+                        "required": [
+                          "spec"
+                        ],
+                        "properties": {
+                          "metadata": {
+                            "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                            "type": "object"
+                          },
+                          "spec": {
+                            "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                            "type": "object",
+                            "properties": {
+                              "accessModes": {
+                                "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "dataSource": {
+                                "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                "type": "object",
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "dataSourceRef": {
+                                "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                "type": "object",
+                                "required": [
+                                  "kind",
+                                  "name"
+                                ],
+                                "properties": {
+                                  "apiGroup": {
+                                    "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                    "type": "string"
+                                  },
+                                  "kind": {
+                                    "description": "Kind is the type of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name is the name of resource being referenced",
+                                    "type": "string"
+                                  },
+                                  "namespace": {
+                                    "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "resources": {
+                                "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                "type": "object",
+                                "properties": {
+                                  "limits": {
+                                    "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  },
+                                  "requests": {
+                                    "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    }
+                                  }
+                                }
+                              },
+                              "selector": {
+                                "description": "selector is a label query over volumes to consider for binding.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "storageClassName": {
+                                "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                "type": "string"
+                              },
+                              "volumeAttributesClassName": {
+                                "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
+                                "type": "string"
+                              },
+                              "volumeMode": {
+                                "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                "type": "string"
+                              },
+                              "volumeName": {
+                                "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "fc": {
+                    "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                    "type": "object",
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "lun is Optional: FC target lun number",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "readOnly": {
+                        "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "targetWWNs": {
+                        "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "wwids": {
+                        "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    }
+                  },
+                  "flexVolume": {
+                    "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                    "type": "object",
+                    "required": [
+                      "driver"
+                    ],
+                    "properties": {
+                      "driver": {
+                        "description": "driver is the name of the driver to use for this volume.",
+                        "type": "string"
+                      },
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                        "type": "string"
+                      },
+                      "options": {
+                        "description": "options is Optional: this field holds extra command options if any.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      },
+                      "readOnly": {
+                        "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    }
+                  },
+                  "flocker": {
+                    "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                    "type": "object",
+                    "properties": {
+                      "datasetName": {
+                        "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                        "type": "string"
+                      },
+                      "datasetUUID": {
+                        "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "gcePersistentDisk": {
+                    "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                    "type": "object",
+                    "required": [
+                      "pdName"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "partition": {
+                        "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "pdName": {
+                        "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "gitRepo": {
+                    "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                    "type": "object",
+                    "required": [
+                      "repository"
+                    ],
+                    "properties": {
+                      "directory": {
+                        "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                        "type": "string"
+                      },
+                      "repository": {
+                        "description": "repository is the URL",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "revision is the commit hash for the specified revision.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "glusterfs": {
+                    "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                    "type": "object",
+                    "required": [
+                      "endpoints",
+                      "path"
+                    ],
+                    "properties": {
+                      "endpoints": {
+                        "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "path": {
+                        "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "hostPath": {
+                    "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                    "type": "object",
+                    "required": [
+                      "path"
+                    ],
+                    "properties": {
+                      "path": {
+                        "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      },
+                      "type": {
+                        "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "image": {
+                    "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                    "type": "object",
+                    "properties": {
+                      "pullPolicy": {
+                        "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                        "type": "string"
+                      },
+                      "reference": {
+                        "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "iscsi": {
+                    "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+                    "type": "object",
+                    "required": [
+                      "iqn",
+                      "lun",
+                      "targetPortal"
+                    ],
+                    "properties": {
+                      "chapAuthDiscovery": {
+                        "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "chapAuthSession": {
+                        "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                        "type": "boolean"
+                      },
+                      "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                        "type": "string"
+                      },
+                      "initiatorName": {
+                        "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                        "type": "string"
+                      },
+                      "iqn": {
+                        "description": "iqn is the target iSCSI Qualified Name.",
+                        "type": "string"
+                      },
+                      "iscsiInterface": {
+                        "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                        "type": "string"
+                      },
+                      "lun": {
+                        "description": "lun represents iSCSI Target Lun number.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "portals": {
+                        "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "targetPortal": {
+                        "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "name": {
+                    "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "nfs": {
+                    "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                    "type": "object",
+                    "required": [
+                      "path",
+                      "server"
+                    ],
+                    "properties": {
+                      "path": {
+                        "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "boolean"
+                      },
+                      "server": {
+                        "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "persistentVolumeClaim": {
+                    "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                    "type": "object",
+                    "required": [
+                      "claimName"
+                    ],
+                    "properties": {
+                      "claimName": {
+                        "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                        "type": "boolean"
+                      }
+                    }
+                  },
+                  "photonPersistentDisk": {
+                    "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                    "type": "object",
+                    "required": [
+                      "pdID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "pdID": {
+                        "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "portworxVolume": {
+                    "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                    "type": "object",
+                    "required": [
+                      "volumeID"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "volumeID": {
+                        "description": "volumeID uniquely identifies a Portworx volume",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "projected": {
+                    "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "sources": {
+                        "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                        "type": "array",
+                        "items": {
+                          "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                          "type": "object",
+                          "properties": {
+                            "clusterTrustBundle": {
+                              "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "labelSelector": {
+                                  "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                  "type": "object",
+                                  "properties": {
+                                    "matchExpressions": {
+                                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "operator"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the label key that the selector applies to.",
+                                            "type": "string"
+                                          },
+                                          "operator": {
+                                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                            "type": "string"
+                                          },
+                                          "values": {
+                                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "matchLabels": {
+                                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                      "type": "object",
+                                      "additionalProperties": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "name": {
+                                  "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                  "type": "boolean"
+                                },
+                                "path": {
+                                  "description": "Relative path from the volume root to write the bundle.",
+                                  "type": "string"
+                                },
+                                "signerName": {
+                                  "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "configMap": {
+                              "description": "configMap information about the configMap data to project",
+                              "type": "object",
+                              "properties": {
+                                "items": {
+                                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "type": "object",
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "downwardAPI": {
+                              "description": "downwardAPI information about the downwardAPI data to project",
+                              "type": "object",
+                              "properties": {
+                                "items": {
+                                  "description": "Items is a list of DownwardAPIVolume file",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                    "type": "object",
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "fieldRef": {
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                        "type": "object",
+                                        "required": [
+                                          "fieldPath"
+                                        ],
+                                        "properties": {
+                                          "apiVersion": {
+                                            "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                            "type": "string"
+                                          },
+                                          "fieldPath": {
+                                            "description": "Path of the field to select in the specified API version.",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "mode": {
+                                        "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                        "type": "string"
+                                      },
+                                      "resourceFieldRef": {
+                                        "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                        "type": "object",
+                                        "required": [
+                                          "resource"
+                                        ],
+                                        "properties": {
+                                          "containerName": {
+                                            "description": "Container name: required for volumes, optional for env vars",
+                                            "type": "string"
+                                          },
+                                          "divisor": {
+                                            "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                            "x-kubernetes-int-or-string": true
+                                          },
+                                          "resource": {
+                                            "description": "Required: resource to select",
+                                            "type": "string"
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "secret": {
+                              "description": "secret information about the secret data to project",
+                              "type": "object",
+                              "properties": {
+                                "items": {
+                                  "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Maps a string key to a path within a volume.",
+                                    "type": "object",
+                                    "required": [
+                                      "key",
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "key": {
+                                        "description": "key is the key to project.",
+                                        "type": "string"
+                                      },
+                                      "mode": {
+                                        "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "path": {
+                                        "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "name": {
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "description": "optional field specify whether the Secret or its key must be defined",
+                                  "type": "boolean"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            },
+                            "serviceAccountToken": {
+                              "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "audience": {
+                                  "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                  "type": "string"
+                                },
+                                "expirationSeconds": {
+                                  "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "path": {
+                                  "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
+                    }
+                  },
+                  "quobyte": {
+                    "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                    "type": "object",
+                    "required": [
+                      "registry",
+                      "volume"
+                    ],
+                    "properties": {
+                      "group": {
+                        "description": "group to map volume access to\nDefault is no group",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "registry": {
+                        "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                        "type": "string"
+                      },
+                      "tenant": {
+                        "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                        "type": "string"
+                      },
+                      "user": {
+                        "description": "user to map volume access to\nDefaults to serivceaccount user",
+                        "type": "string"
+                      },
+                      "volume": {
+                        "description": "volume is a string that references an already created Quobyte volume by name.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "rbd": {
+                    "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+                    "type": "object",
+                    "required": [
+                      "image",
+                      "monitors"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                        "type": "string"
+                      },
+                      "image": {
+                        "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "keyring": {
+                        "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "monitors": {
+                        "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "pool": {
+                        "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "user": {
+                        "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "scaleIO": {
+                    "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                    "type": "object",
+                    "required": [
+                      "gateway",
+                      "secretRef",
+                      "system"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                        "type": "string"
+                      },
+                      "gateway": {
+                        "description": "gateway is the host address of the ScaleIO API Gateway.",
+                        "type": "string"
+                      },
+                      "protectionDomain": {
+                        "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "sslEnabled": {
+                        "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                        "type": "boolean"
+                      },
+                      "storageMode": {
+                        "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                        "type": "string"
+                      },
+                      "storagePool": {
+                        "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                        "type": "string"
+                      },
+                      "system": {
+                        "description": "system is the name of the storage system as configured in ScaleIO.",
+                        "type": "string"
+                      },
+                      "volumeName": {
+                        "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "secret": {
+                    "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                    "type": "object",
+                    "properties": {
+                      "defaultMode": {
+                        "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "items": {
+                        "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                        "type": "array",
+                        "items": {
+                          "description": "Maps a string key to a path within a volume.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "path"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the key to project.",
+                              "type": "string"
+                            },
+                            "mode": {
+                              "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "path": {
+                              "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "optional": {
+                        "description": "optional field specify whether the Secret or its keys must be defined",
+                        "type": "boolean"
+                      },
+                      "secretName": {
+                        "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "storageos": {
+                    "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                    "type": "object",
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                        "type": "boolean"
+                      },
+                      "secretRef": {
+                        "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "volumeName": {
+                        "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                        "type": "string"
+                      },
+                      "volumeNamespace": {
+                        "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "vsphereVolume": {
+                    "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                    "type": "object",
+                    "required": [
+                      "volumePath"
+                    ],
+                    "properties": {
+                      "fsType": {
+                        "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                        "type": "string"
+                      },
+                      "storagePolicyID": {
+                        "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                        "type": "string"
+                      },
+                      "storagePolicyName": {
+                        "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                        "type": "string"
+                      },
+                      "volumePath": {
+                        "description": "volumePath is the path that identifies vSphere volume vmdk",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "installPlanApproval": {
+          "description": "Approval is the user approval policy for an InstallPlan.\nIt must be one of \"Automatic\" or \"Manual\".",
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "sourceNamespace": {
+          "type": "string"
+        },
+        "startingCSV": {
+          "type": "string"
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "required": [
+        "lastUpdated"
+      ],
+      "properties": {
+        "catalogHealth": {
+          "description": "CatalogHealth contains the Subscription's view of its relevant CatalogSources' status.\nIt is used to determine SubscriptionStatusConditions related to CatalogSources.",
+          "type": "array",
+          "items": {
+            "description": "SubscriptionCatalogHealth describes the health of a CatalogSource the Subscription knows about.",
+            "type": "object",
+            "required": [
+              "catalogSourceRef",
+              "healthy",
+              "lastUpdated"
+            ],
+            "properties": {
+              "catalogSourceRef": {
+                "description": "CatalogSourceRef is a reference to a CatalogSource.",
+                "type": "object",
+                "properties": {
+                  "apiVersion": {
+                    "description": "API version of the referent.",
+                    "type": "string"
+                  },
+                  "fieldPath": {
+                    "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+                    "type": "string"
+                  },
+                  "kind": {
+                    "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+                    "type": "string"
+                  },
+                  "name": {
+                    "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+                    "type": "string"
+                  },
+                  "resourceVersion": {
+                    "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+                    "type": "string"
+                  },
+                  "uid": {
+                    "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
+                    "type": "string"
+                  }
+                },
+                "x-kubernetes-map-type": "atomic"
+              },
+              "healthy": {
+                "description": "Healthy is true if the CatalogSource is healthy; false otherwise.",
+                "type": "boolean"
+              },
+              "lastUpdated": {
+                "description": "LastUpdated represents the last time that the CatalogSourceHealth changed",
+                "type": "string",
+                "format": "date-time"
+              }
+            }
+          }
+        },
+        "conditions": {
+          "description": "Conditions is a list of the latest available observations about a Subscription's current state.",
+          "type": "array",
+          "items": {
+            "description": "SubscriptionCondition represents the latest available observations of a Subscription's state.",
+            "type": "object",
+            "required": [
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastHeartbeatTime": {
+                "description": "LastHeartbeatTime is the last time we got an update on a given condition",
+                "type": "string",
+                "format": "date-time"
+              },
+              "lastTransitionTime": {
+                "description": "LastTransitionTime is the last time the condition transit from one status to another",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Message is a human-readable message indicating details about last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Reason is a one-word CamelCase reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "Status is the status of the condition, one of True, False, Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "Type is the type of Subscription condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "currentCSV": {
+          "description": "CurrentCSV is the CSV the Subscription is progressing to.",
+          "type": "string"
+        },
+        "installPlanGeneration": {
+          "description": "InstallPlanGeneration is the current generation of the installplan",
+          "type": "integer"
+        },
+        "installPlanRef": {
+          "description": "InstallPlanRef is a reference to the latest InstallPlan that contains the Subscription's current CSV.",
+          "type": "object",
+          "properties": {
+            "apiVersion": {
+              "description": "API version of the referent.",
+              "type": "string"
+            },
+            "fieldPath": {
+              "description": "If referring to a piece of an object instead of an entire object, this string\nshould contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].\nFor example, if the object reference is to a container within a pod, this would take on a value like:\n\"spec.containers{name}\" (where \"name\" refers to the name of the container that triggered\nthe event) or if no container name is specified \"spec.containers[2]\" (container with\nindex 2 in this pod). This syntax is chosen only to have some well-defined way of\nreferencing a part of an object.",
+              "type": "string"
+            },
+            "kind": {
+              "description": "Kind of the referent.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+              "type": "string"
+            },
             "name": {
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+              "type": "string"
+            },
+            "namespace": {
+              "description": "Namespace of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/",
+              "type": "string"
+            },
+            "resourceVersion": {
+              "description": "Specific resourceVersion to which this reference is made, if any.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency",
+              "type": "string"
+            },
+            "uid": {
+              "description": "UID of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids",
               "type": "string"
             }
           },
           "x-kubernetes-map-type": "atomic"
         },
-        "dbname": {
-          "description": "The name of the database where the publication will be installed in\nthe \"subscriber\" cluster",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "dbname is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "externalClusterName": {
-          "description": "The name of the external cluster with the publication (\"publisher\")",
+        "installedCSV": {
+          "description": "InstalledCSV is the CSV currently installed by the Subscription.",
           "type": "string"
         },
-        "name": {
-          "description": "The name of the subscription inside PostgreSQL",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "name is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "parameters": {
-          "description": "Subscription parameters part of the `WITH` clause as expected by\nPostgreSQL `CREATE SUBSCRIPTION` command",
+        "installplan": {
+          "description": "Install is a reference to the latest InstallPlan generated for the Subscription.\nDEPRECATED: InstallPlanRef",
           "type": "object",
-          "additionalProperties": {
-            "type": "string"
+          "required": [
+            "apiVersion",
+            "kind",
+            "name",
+            "uuid"
+          ],
+          "properties": {
+            "apiVersion": {
+              "type": "string"
+            },
+            "kind": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "uuid": {
+              "description": "UID is a type that holds unique ID values, including UUIDs.  Because we\ndon't ONLY use UUIDs, this is an alias to string.  Being a type captures\nintent and helps make sure that UIDs and names do not get conflated.",
+              "type": "string"
+            }
           }
         },
-        "publicationDBName": {
-          "description": "The name of the database containing the publication on the external\ncluster. Defaults to the one in the external cluster definition.",
-          "type": "string"
-        },
-        "publicationName": {
-          "description": "The name of the publication inside the PostgreSQL database in the\n\"publisher\"",
-          "type": "string"
-        },
-        "subscriptionReclaimPolicy": {
-          "description": "The policy for end-of-life maintenance of this subscription",
+        "lastUpdated": {
+          "description": "LastUpdated represents the last time that the Subscription status was updated.",
           "type": "string",
-          "enum": [
-            "delete",
-            "retain"
-          ]
-        }
-      }
-    },
-    "status": {
-      "description": "SubscriptionStatus defines the observed state of Subscription",
-      "type": "object",
-      "properties": {
-        "applied": {
-          "description": "Applied is true if the subscription was reconciled correctly",
-          "type": "boolean"
+          "format": "date-time"
         },
-        "message": {
-          "description": "Message is the reconciliation output message",
+        "reason": {
+          "description": "Reason is the reason the Subscription was transitioned to its current state.",
           "type": "string"
         },
-        "observedGeneration": {
-          "description": "A sequence number representing the latest\ndesired state that was synchronized",
-          "type": "integer",
-          "format": "int64"
+        "state": {
+          "description": "State represents the current state of the Subscription",
+          "type": "string"
         }
       }
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "postgresql.cnpg.noobaa.io",
+      "group": "operators.coreos.com",
       "kind": "Subscription",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/subscriptionlist.json
+++ b/class_generator/schema/subscriptionlist.json
@@ -13,7 +13,7 @@
       "description": "List of subscriptions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Subscription"
+        "$ref": "_definitions.json#/definitions/com.coreos.operators.v1alpha1.Subscription"
       }
     },
     "kind": {
@@ -27,9 +27,9 @@
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "postgresql.cnpg.noobaa.io",
+      "group": "operators.coreos.com",
       "kind": "SubscriptionList",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/tfjob.json
+++ b/class_generator/schema/tfjob.json
@@ -43,6 +43,10 @@
               "description": "CleanPodPolicy defines the policy to kill pods after the job completes.\nDefault to None.",
               "type": "string"
             },
+            "managedBy": {
+              "description": "ManagedBy is used to indicate the controller or entity that manages a job.\nThe value must be either an empty, 'kubeflow.org/training-operator' or\n'kueue.x-k8s.io/multikueue'.\nThe training-operator reconciles a job which doesn't have this\nfield at all or the field value is the reserved string\n'kubeflow.org/training-operator', but delegates reconciling the job\nwith 'kueue.x-k8s.",
+              "type": "string"
+            },
             "schedulingPolicy": {
               "description": "SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling",
               "type": "object",
@@ -62,7 +66,13 @@
                   "type": "string"
                 },
                 "queue": {
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "spec.runPolicy.schedulingPolicy.queue is immutable",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
                 },
                 "scheduleTimeoutSeconds": {
                   "type": "integer",
@@ -194,10 +204,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -223,10 +235,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
@@ -237,7 +251,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
@@ -277,10 +292,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -306,14 +323,17 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
@@ -370,10 +390,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -386,7 +408,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -394,7 +416,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -429,10 +451,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -449,7 +473,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -463,7 +488,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -503,10 +529,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -519,7 +547,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -527,7 +555,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -562,10 +590,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -582,14 +612,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -643,10 +675,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -659,7 +693,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -667,7 +701,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -702,10 +736,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -722,7 +758,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -736,7 +773,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -776,10 +814,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -792,7 +832,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -800,7 +840,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -835,10 +875,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -855,14 +897,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           }
@@ -887,14 +931,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -930,7 +976,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -993,7 +1039,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1006,7 +1052,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -1020,7 +1070,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1039,7 +1089,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1050,7 +1100,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -1077,7 +1128,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1112,7 +1164,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1174,7 +1227,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1209,7 +1263,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1273,7 +1328,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1295,7 +1351,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1331,7 +1387,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1448,7 +1505,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1470,7 +1528,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1506,7 +1564,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1594,7 +1653,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -1605,6 +1664,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -1644,6 +1707,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -1654,7 +1734,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -1662,7 +1743,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1671,7 +1753,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -1726,7 +1808,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -1768,7 +1850,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1790,7 +1873,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1826,7 +1909,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1926,7 +2010,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -1944,7 +2032,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -1955,6 +2043,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -1964,14 +2056,22 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "dnsConfig": {
                         "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
@@ -1982,7 +2082,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "options": {
                             "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
@@ -1999,14 +2100,16 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "searches": {
                             "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -2033,14 +2136,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -2076,7 +2181,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2139,7 +2244,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2152,7 +2257,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -2166,7 +2275,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2185,7 +2294,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2196,7 +2305,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
@@ -2223,7 +2333,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2258,7 +2369,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2320,7 +2432,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2355,7 +2468,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2419,7 +2533,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2441,7 +2556,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2477,7 +2592,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2594,7 +2710,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2616,7 +2733,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2652,7 +2769,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2740,7 +2858,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -2751,6 +2869,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -2790,6 +2912,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -2800,7 +2939,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -2808,7 +2948,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2817,7 +2958,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -2872,7 +3013,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -2914,7 +3055,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2936,7 +3078,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2972,7 +3114,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3041,7 +3184,7 @@
                               "type": "boolean"
                             },
                             "targetContainerName": {
-                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\n\nThe container runtime must implement support for this feature.",
+                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature.",
                               "type": "string"
                             },
                             "terminationMessagePath": {
@@ -3076,7 +3219,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.\nCannot be updated.",
@@ -3094,7 +3241,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -3105,6 +3252,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -3114,35 +3265,51 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostAliases": {
-                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified.",
                         "type": "array",
                         "items": {
                           "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                           "type": "object",
+                          "required": [
+                            "ip"
+                          ],
                           "properties": {
                             "hostnames": {
                               "description": "Hostnames for the above IP address.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "ip": {
                               "description": "IP address of the host file entry.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "ip"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostIPC": {
                         "description": "Use the host's ipc namespace.\nOptional: Default to false.",
@@ -3172,12 +3339,16 @@
                           "type": "object",
                           "properties": {
                             "name": {
-                              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             }
                           },
                           "x-kubernetes-map-type": "atomic"
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "initContainers": {
                         "description": "List of initialization containers belonging to the pod.\nInit containers are executed in order prior to containers being started. If any\ninit container fails, the pod is considered to have failed and is handled according\nto its restartPolicy. The name for an init container or normal container must be\nunique among all containers.",
@@ -3194,14 +3365,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -3237,7 +3410,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3300,7 +3473,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3313,7 +3486,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -3327,7 +3504,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3346,7 +3523,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3357,7 +3534,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -3384,7 +3562,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3419,7 +3598,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3481,7 +3661,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3516,7 +3697,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3580,7 +3762,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3602,7 +3785,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3638,7 +3821,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3755,7 +3939,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3777,7 +3962,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3813,7 +3998,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3901,7 +4087,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -3912,6 +4098,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -3951,6 +4141,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -3961,7 +4168,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -3969,7 +4177,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3978,7 +4187,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -4033,7 +4242,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -4075,7 +4284,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4097,7 +4307,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4133,7 +4343,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4233,7 +4444,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -4251,7 +4466,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -4262,6 +4477,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -4271,17 +4490,25 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
-                        "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty,\nthe scheduler simply schedules this pod onto that node, assuming that it fits resource\nrequirements.",
+                        "description": "NodeName indicates in which node this pod is scheduled.\nIf empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.\nOnce this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.\nThis field should not be used to express a desire for the pod to be scheduled on a specific node.\nhttps://kubernetes.",
                         "type": "string"
                       },
                       "nodeSelector": {
@@ -4293,7 +4520,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.",
+                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.appArmorProfile\n- spec.securityContext.",
                         "type": "object",
                         "required": [
                           "name"
@@ -4341,13 +4568,14 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
-                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable.",
+                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
                         "type": "array",
                         "items": {
-                          "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource.\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
+                          "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                           "type": "object",
                           "required": [
                             "name"
@@ -4357,19 +4585,13 @@
                               "description": "Name uniquely identifies this resource claim inside the pod.\nThis must be a DNS_LABEL.",
                               "type": "string"
                             },
-                            "source": {
-                              "description": "Source describes where to find the ResourceClaim.",
-                              "type": "object",
-                              "properties": {
-                                "resourceClaimName": {
-                                  "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.",
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
-                                  "type": "string"
-                                }
-                              }
+                            "resourceClaimName": {
+                              "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
+                              "type": "string"
                             }
                           }
                         },
@@ -4391,7 +4613,7 @@
                         "type": "string"
                       },
                       "schedulingGates": {
-                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.\n\n\nThis is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
                         "type": "array",
                         "items": {
                           "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
@@ -4415,8 +4637,25 @@
                         "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.",
                         "type": "object",
                         "properties": {
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            }
+                          },
                           "fsGroup": {
-                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
+                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
                             "type": "integer",
                             "format": "int64"
                           },
@@ -4472,18 +4711,23 @@
                                 "type": "string"
                               },
                               "type": {
-                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                 "type": "string"
                               }
                             }
                           },
                           "supplementalGroups": {
-                            "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container.",
+                            "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.",
                             "type": "array",
                             "items": {
                               "type": "integer",
                               "format": "int64"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
                           },
                           "sysctls": {
                             "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
@@ -4505,7 +4749,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "windowsOptions": {
                             "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
@@ -4532,7 +4777,7 @@
                         }
                       },
                       "serviceAccount": {
-                        "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
+                        "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
                         "type": "string"
                       },
                       "serviceAccountName": {
@@ -4585,7 +4830,8 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologySpreadConstraints": {
                         "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology\ndomains. Scheduler will schedule pods in a way which abides by the constraints.\nAll topologySpreadConstraints are ANDed.",
@@ -4627,10 +4873,12 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -4661,11 +4909,11 @@
                               "format": "int32"
                             },
                             "nodeAffinityPolicy": {
-                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
                               "type": "string"
                             },
                             "nodeTaintsPolicy": {
-                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
                               "type": "string"
                             },
                             "topologyKey": {
@@ -4702,7 +4950,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -4788,7 +5036,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "path": {
                                   "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
@@ -4807,7 +5056,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4839,7 +5088,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4885,10 +5134,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
-                                  "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -4918,7 +5168,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4957,7 +5207,7 @@
                                     ],
                                     "properties": {
                                       "fieldRef": {
-                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                         "type": "object",
                                         "required": [
                                           "fieldPath"
@@ -5007,7 +5257,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5076,7 +5327,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "dataSource": {
                                           "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.",
@@ -5177,10 +5429,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5219,7 +5473,7 @@
                               "type": "object",
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                   "type": "string"
                                 },
                                 "lun": {
@@ -5236,14 +5490,16 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "wwids": {
                                   "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5278,7 +5534,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5308,7 +5564,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5370,7 +5626,7 @@
                               }
                             },
                             "hostPath": {
-                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.",
+                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                               "type": "object",
                               "required": [
                                 "path"
@@ -5382,6 +5638,20 @@
                                 },
                                 "type": {
                                   "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact.",
+                              "type": "object",
+                              "properties": {
+                                "pullPolicy": {
+                                  "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk.",
+                                  "type": "string"
+                                },
+                                "reference": {
+                                  "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.",
                                   "type": "string"
                                 }
                               }
@@ -5404,7 +5674,7 @@
                                   "type": "boolean"
                                 },
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                                   "type": "string"
                                 },
                                 "initiatorName": {
@@ -5429,7 +5699,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
@@ -5440,7 +5711,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5543,14 +5814,14 @@
                                   "format": "int32"
                                 },
                                 "sources": {
-                                  "description": "sources is the list of volume projections",
+                                  "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                                   "type": "array",
                                   "items": {
-                                    "description": "Projection that may be projected along with other supported volume types",
+                                    "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                                     "type": "object",
                                     "properties": {
                                       "clusterTrustBundle": {
-                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
+                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
                                         "type": "object",
                                         "required": [
                                           "path"
@@ -5584,10 +5855,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5646,10 +5919,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -5674,7 +5948,7 @@
                                               ],
                                               "properties": {
                                                 "fieldRef": {
-                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                                   "type": "object",
                                                   "required": [
                                                     "fieldPath"
@@ -5724,7 +5998,8 @@
                                                   "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -5757,10 +6032,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -5793,7 +6069,8 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5840,7 +6117,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                                   "type": "string"
                                 },
                                 "image": {
@@ -5856,7 +6133,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "pool": {
                                   "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -5871,7 +6149,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5913,7 +6191,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5975,7 +6253,8 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "optional": {
                                   "description": "optional field specify whether the Secret or its keys must be defined",
@@ -6004,7 +6283,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6046,7 +6325,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       }
                     }
                   }
@@ -6156,10 +6439,12 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
-                    }
+                    },
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -6198,5 +6483,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tfjoblist.json
+++ b/class_generator/schema/tfjoblist.json
@@ -32,5 +32,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/topology.json
+++ b/class_generator/schema/topology.json
@@ -68,5 +68,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/topologylist.json
+++ b/class_generator/schema/topologylist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/trainingoperator.json
+++ b/class_generator/schema/trainingoperator.json
@@ -54,38 +54,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,17 +105,40 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -126,6 +150,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "TrainingOperator name must be default-trainingoperator",

--- a/class_generator/schema/trainingoperatorlist.json
+++ b/class_generator/schema/trainingoperatorlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/trustyai.json
+++ b/class_generator/schema/trustyai.json
@@ -54,38 +54,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,17 +105,40 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
           "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -126,6 +150,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "TrustyAI name must be default-trustyai",

--- a/class_generator/schema/trustyailist.json
+++ b/class_generator/schema/trustyailist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/workbenches.json
+++ b/class_generator/schema/workbenches.json
@@ -44,6 +44,12 @@
               }
             }
           }
+        },
+        "workbenchNamespace": {
+          "description": "Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to \"rhods-notebooks\"",
+          "type": "string",
+          "maxLength": 63,
+          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
         }
       }
     },
@@ -54,38 +60,39 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
-              "lastTransitionTime",
-              "message",
-              "reason",
               "status",
               "type"
             ],
             "properties": {
+              "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
+                "type": "string",
+                "format": "date-time"
+              },
               "lastTransitionTime": {
-                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
-                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
-                "type": "string",
-                "maxLength": 32768
+                "description": "message is a human-readable message indicating details about the transition.",
+                "type": "string"
               },
               "observedGeneration": {
-                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
               },
               "reason": {
-                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
-                "type": "string",
-                "maxLength": 1024,
-                "minLength": 1,
-                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
+                "type": "string"
               },
               "status": {
                 "description": "status of the condition, one of True, False, Unknown.",
@@ -104,16 +111,42 @@
               }
             }
           },
-          "x-kubernetes-list-map-keys": [
-            "type"
-          ],
-          "x-kubernetes-list-type": "map"
+          "x-kubernetes-list-type": "atomic"
         },
         "observedGeneration": {
+          "description": "The generation observed by the resource controller.",
           "type": "integer",
           "format": "int64"
         },
         "phase": {
+          "type": "string"
+        },
+        "releases": {
+          "type": "array",
+          "items": {
+            "description": "ComponentRelease represents the detailed status of a component release.",
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "repoUrl": {
+                "type": "string"
+              },
+              "version": {
+                "type": "string"
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
+        },
+        "workbenchNamespace": {
           "type": "string"
         }
       }
@@ -126,6 +159,7 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "x-kubernetes-validations": [
     {
       "message": "Workbenches name must be default-workbenches",

--- a/class_generator/schema/workbencheslist.json
+++ b/class_generator/schema/workbencheslist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/workload.json
+++ b/class_generator/schema/workload.json
@@ -22,8 +22,14 @@
       ],
       "properties": {
         "active": {
-          "description": "Active determines if a workload can be admitted into a queue.\nChanging active from true to false will evict any running workloads.\nPossible values are:\n\n\n  - false: indicates that a workload should never be admitted and evicts running workloads\n  - true: indicates that a workload can be evaluated for admission into it's respective queue.\n\n\nDefaults to true",
+          "description": "Active determines if a workload can be admitted into a queue.\nChanging active from true to false will evict any running workloads.\nPossible values are:\n\n  - false: indicates that a workload should never be admitted and evicts running workloads\n  - true: indicates that a workload can be evaluated for admission into it's respective queue.\n\nDefaults to true",
           "type": "boolean"
+        },
+        "maximumExecutionTimeSeconds": {
+          "description": "maximumExecutionTimeSeconds if provided, determines the maximum time, in seconds,\nthe workload can be admitted before it's automatically deactivated.\n\nIf unspecified, no execution time limit is enforced on the Workload.",
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1
         },
         "podSets": {
           "description": "podSets is a list of sets of homogeneous pods, each described by a Pod spec\nand a count.\nThere must be at least one element and at most 8.\npodSets cannot be changed.",
@@ -44,7 +50,7 @@
                 "minimum": 0
               },
               "minCount": {
-                "description": "minCount is the minimum number of pods for the spec acceptable\nif the workload supports partial admission.\n\n\nIf not provided, partial admission for the current PodSet is not\nenabled.\n\n\nOnly one podSet within the workload can use this.\n\n\nThis is an alpha field and requires enabling PartialAdmission feature gate.",
+                "description": "minCount is the minimum number of pods for the spec acceptable\nif the workload supports partial admission.\n\nIf not provided, partial admission for the current PodSet is not\nenabled.\n\nOnly one podSet within the workload can use this.\n\nThis is an alpha field and requires enabling PartialAdmission feature gate.",
                 "type": "integer",
                 "format": "int32",
                 "minimum": 1
@@ -56,7 +62,7 @@
                 "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
               },
               "template": {
-                "description": "template is the Pod template.\n\n\nThe only allowed fields in template.metadata are labels and annotations.\n\n\nIf requests are omitted for a container or initContainer,\nthey default to the limits if they are explicitly specified for the\ncontainer or initContainer.\n\n\nDuring admission, the rules in nodeSelector and\nnodeAffinity.requiredDuringSchedulingIgnoredDuringExecution that match\nthe keys in the nodeLabels from the ResourceFlavors considered for this\nWorkload are used to filter the ResourceFlavors that can be assigned to\nthis podSet.",
+                "description": "template is the Pod template.\n\nThe only allowed fields in template.metadata are labels and annotations.\n\nIf requests are omitted for a container or initContainer,\nthey default to the limits if they are explicitly specified for the\ncontainer or initContainer.\n\nDuring admission, the rules in nodeSelector and\nnodeAffinity.requiredDuringSchedulingIgnoredDuringExecution that match\nthe keys in the nodeLabels from the ResourceFlavors considered for this\nWorkload are used to filter the ResourceFlavors that can be assigned to\nthis podSet.",
                 "type": "object",
                 "properties": {
                   "metadata": {
@@ -352,7 +358,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -360,7 +366,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -491,7 +497,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -499,7 +505,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -637,7 +643,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -645,7 +651,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -776,7 +782,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -784,7 +790,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -920,7 +926,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -983,7 +989,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -1014,7 +1020,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1033,7 +1039,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1295,7 +1301,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1472,7 +1478,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1597,7 +1603,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -1608,6 +1614,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -1693,7 +1703,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -1748,7 +1758,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -1813,7 +1823,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1984,7 +1994,7 @@
                                     "type": "boolean"
                                   },
                                   "recursiveReadOnly": {
-                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                                     "type": "string"
                                   },
                                   "subPath": {
@@ -2065,7 +2075,7 @@
                         "description": "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing\npod to perform user-initiated actions such as debugging. This list cannot be specified when\ncreating a pod, and it cannot be modified by updating the pod spec. In order to add an\nephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.",
                         "type": "array",
                         "items": {
-                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for\nuser-initiated activities such as debugging. Ephemeral containers have no resource or\nscheduling guarantees, and they will not be restarted when they exit or when a Pod is\nremoved or restarted. The kubelet may evict a Pod if an ephemeral container causes the\nPod to exceed its resource allocation.\n\n\nTo add an ephemeral container, use the ephemeralcontainers subresource of an existing\nPod. Ephemeral containers may not be removed or restarted.",
+                          "description": "An EphemeralContainer is a temporary container that you may add to an existing Pod for\nuser-initiated activities such as debugging. Ephemeral containers have no resource or\nscheduling guarantees, and they will not be restarted when they exit or when a Pod is\nremoved or restarted. The kubelet may evict a Pod if an ephemeral container causes the\nPod to exceed its resource allocation.\n\nTo add an ephemeral container, use the ephemeralcontainers subresource of an existing\nPod. Ephemeral containers may not be removed or restarted.",
                           "type": "object",
                           "required": [
                             "name"
@@ -2121,7 +2131,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2184,7 +2194,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2215,7 +2225,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2234,7 +2244,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2496,7 +2506,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2673,7 +2683,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2798,7 +2808,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -2809,6 +2819,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -2894,7 +2908,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -2949,7 +2963,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -3014,7 +3028,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3120,7 +3134,7 @@
                               "type": "boolean"
                             },
                             "targetContainerName": {
-                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\n\nThe container runtime must implement support for this feature. If the runtime does not\nsupport namespace targeting then the result of setting this field is undefined.",
+                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature. If the runtime does not\nsupport namespace targeting then the result of setting this field is undefined.",
                               "type": "string"
                             },
                             "terminationMessagePath": {
@@ -3189,7 +3203,7 @@
                                     "type": "boolean"
                                   },
                                   "recursiveReadOnly": {
-                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                                     "type": "string"
                                   },
                                   "subPath": {
@@ -3275,7 +3289,7 @@
                           "type": "object",
                           "properties": {
                             "name": {
-                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             }
                           },
@@ -3346,7 +3360,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3409,7 +3423,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3440,7 +3454,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3459,7 +3473,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3721,7 +3735,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3898,7 +3912,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4023,7 +4037,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -4034,6 +4048,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -4119,7 +4137,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -4174,7 +4192,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -4239,7 +4257,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4410,7 +4428,7 @@
                                     "type": "boolean"
                                   },
                                   "recursiveReadOnly": {
-                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
                                     "type": "string"
                                   },
                                   "subPath": {
@@ -4440,7 +4458,7 @@
                         "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
-                        "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty,\nthe scheduler simply schedules this pod onto that node, assuming that it fits resource\nrequirements.",
+                        "description": "NodeName indicates in which node this pod is scheduled.\nIf empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.\nOnce this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.\nThis field should not be used to express a desire for the pod to be scheduled on a specific node.\nhttps://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodename",
                         "type": "string"
                       },
                       "nodeSelector": {
@@ -4452,7 +4470,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.appArmorProfile\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.seccompProfile\n- spec.securityContext.fsGroup\n- spec.securityContext.fsGroupChangePolicy\n- spec.securityContext.sysctls\n- spec.shareProcessNamespace\n- spec.securityContext.runAsUser\n- spec.securityContext.runAsGroup\n- spec.securityContext.supplementalGroups\n- spec.containers[*].securityContext.appArmorProfile\n- spec.containers[*].securityContext.seLinuxOptions\n- spec.containers[*].securityContext.seccompProfile\n- spec.containers[*].securityContext.capabilities\n- spec.containers[*].securityContext.readOnlyRootFilesystem\n- spec.containers[*].securityContext.privileged\n- spec.containers[*].securityContext.allowPrivilegeEscalation\n- spec.containers[*].securityContext.procMount\n- spec.containers[*].securityContext.runAsUser\n- spec.containers[*].securityContext.runAsGroup",
+                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.appArmorProfile\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.seccompProfile\n- spec.securityContext.fsGroup\n- spec.securityContext.fsGroupChangePolicy\n- spec.securityContext.sysctls\n- spec.shareProcessNamespace\n- spec.securityContext.runAsUser\n- spec.securityContext.runAsGroup\n- spec.securityContext.supplementalGroups\n- spec.securityContext.supplementalGroupsPolicy\n- spec.containers[*].securityContext.appArmorProfile\n- spec.containers[*].securityContext.seLinuxOptions\n- spec.containers[*].securityContext.seccompProfile\n- spec.containers[*].securityContext.capabilities\n- spec.containers[*].securityContext.readOnlyRootFilesystem\n- spec.containers[*].securityContext.privileged\n- spec.containers[*].securityContext.allowPrivilegeEscalation\n- spec.containers[*].securityContext.procMount\n- spec.containers[*].securityContext.runAsUser\n- spec.containers[*].securityContext.runAsGroup",
                         "type": "object",
                         "required": [
                           "name"
@@ -4504,10 +4522,10 @@
                         "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
-                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable.",
+                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
                         "type": "array",
                         "items": {
-                          "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource.\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
+                          "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                           "type": "object",
                           "required": [
                             "name"
@@ -4517,19 +4535,13 @@
                               "description": "Name uniquely identifies this resource claim inside the pod.\nThis must be a DNS_LABEL.",
                               "type": "string"
                             },
-                            "source": {
-                              "description": "Source describes where to find the ResourceClaim.",
-                              "type": "object",
-                              "properties": {
-                                "resourceClaimName": {
-                                  "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.",
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted. The pod name and resource name, along with a\ngenerated component, will be used to form a unique name for the\nResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\n\nThis field is immutable and no changes will be made to the\ncorresponding ResourceClaim by the control plane after creating the\nResourceClaim.",
-                                  "type": "string"
-                                }
-                              }
+                            "resourceClaimName": {
+                              "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted. The pod name and resource name, along with a\ngenerated component, will be used to form a unique name for the\nResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.\n\nThis field is immutable and no changes will be made to the\ncorresponding ResourceClaim by the control plane after creating the\nResourceClaim.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                              "type": "string"
                             }
                           }
                         },
@@ -4551,7 +4563,7 @@
                         "type": "string"
                       },
                       "schedulingGates": {
-                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
+                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
                         "type": "array",
                         "items": {
                           "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
@@ -4593,7 +4605,7 @@
                             }
                           },
                           "fsGroup": {
-                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "integer",
                             "format": "int64"
                           },
@@ -4649,19 +4661,23 @@
                                 "type": "string"
                               },
                               "type": {
-                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                 "type": "string"
                               }
                             }
                           },
                           "supplementalGroups": {
-                            "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container. Note that group memberships\ndefined in the container image for the uid of the container process are still effective,\neven if they are not included in this list.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.\nIf unspecified, no additional groups are added, though group memberships\ndefined in the container image may still be used, depending on the\nsupplementalGroupsPolicy field.\nNote that this field cannot be set when spec.os.name is windows.",
                             "type": "array",
                             "items": {
                               "type": "integer",
                               "format": "int64"
                             },
                             "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
                           },
                           "sysctls": {
                             "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
@@ -4825,7 +4841,7 @@
                               "x-kubernetes-map-type": "atomic"
                             },
                             "matchLabelKeys": {
-                              "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                              "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
                               "type": "array",
                               "items": {
                                 "type": "string"
@@ -4838,16 +4854,16 @@
                               "format": "int32"
                             },
                             "minDomains": {
-                              "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                              "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
                               "type": "integer",
                               "format": "int32"
                             },
                             "nodeAffinityPolicy": {
-                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
                               "type": "string"
                             },
                             "nodeTaintsPolicy": {
-                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
                               "type": "string"
                             },
                             "topologyKey": {
@@ -4884,7 +4900,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -4990,7 +5006,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5022,7 +5038,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5072,7 +5088,7 @@
                                   "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
-                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -5102,7 +5118,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5212,11 +5228,11 @@
                               }
                             },
                             "ephemeral": {
-                              "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                              "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
                               "type": "object",
                               "properties": {
                                 "volumeClaimTemplate": {
-                                  "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\n\nRequired, must not be nil.",
+                                  "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
                                   "type": "object",
                                   "required": [
                                     "spec"
@@ -5385,7 +5401,7 @@
                                           "type": "string"
                                         },
                                         "volumeAttributesClassName": {
-                                          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.",
+                                          "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
                                           "type": "string"
                                         },
                                         "volumeMode": {
@@ -5407,7 +5423,7 @@
                               "type": "object",
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                   "type": "string"
                                 },
                                 "lun": {
@@ -5468,7 +5484,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5498,7 +5514,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5560,7 +5576,7 @@
                               }
                             },
                             "hostPath": {
-                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath\n---\nTODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not\nmount host directories as read/write.",
+                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                               "type": "object",
                               "required": [
                                 "path"
@@ -5572,6 +5588,20 @@
                                 },
                                 "type": {
                                   "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                              "type": "object",
+                              "properties": {
+                                "pullPolicy": {
+                                  "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                                  "type": "string"
+                                },
+                                "reference": {
+                                  "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
                                   "type": "string"
                                 }
                               }
@@ -5594,7 +5624,7 @@
                                   "type": "boolean"
                                 },
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                                   "type": "string"
                                 },
                                 "initiatorName": {
@@ -5631,7 +5661,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5734,14 +5764,14 @@
                                   "format": "int32"
                                 },
                                 "sources": {
-                                  "description": "sources is the list of volume projections",
+                                  "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                                   "type": "array",
                                   "items": {
-                                    "description": "Projection that may be projected along with other supported volume types",
+                                    "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                                     "type": "object",
                                     "properties": {
                                       "clusterTrustBundle": {
-                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
                                         "type": "object",
                                         "required": [
                                           "path"
@@ -5843,7 +5873,7 @@
                                             "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -5956,7 +5986,7 @@
                                             "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -6037,7 +6067,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                                   "type": "string"
                                 },
                                 "image": {
@@ -6069,7 +6099,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6111,7 +6141,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6203,7 +6233,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nTODO: Add other useful fields. apiVersion, kind, uid?\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6252,6 +6282,33 @@
                         "x-kubernetes-list-type": "map"
                       }
                     }
+                  }
+                }
+              },
+              "topologyRequest": {
+                "description": "topologyRequest defines the topology request for the PodSet.",
+                "type": "object",
+                "properties": {
+                  "podIndexLabel": {
+                    "description": "PodIndexLabel indicates the name of the label indexing the pods.\nFor example, in the context of\n- kubernetes job this is: kubernetes.io/job-completion-index\n- JobSet: kubernetes.io/job-completion-index (inherited from Job)\n- Kubeflow: training.kubeflow.org/replica-index",
+                    "type": "string"
+                  },
+                  "preferred": {
+                    "description": "preferred indicates the topology level preferred by the PodSet, as\nindicated by the `kueue.x-k8s.io/podset-preferred-topology` PodSet\nannotation.",
+                    "type": "string"
+                  },
+                  "required": {
+                    "description": "required indicates the topology level required by the PodSet, as\nindicated by the `kueue.x-k8s.io/podset-required-topology` PodSet\nannotation.",
+                    "type": "string"
+                  },
+                  "subGroupCount": {
+                    "description": "SubGroupIndexLabel indicates the count of replicated Jobs (groups) within a PodSet.\nFor example, in the context of JobSet this value is read from jobset.sigs.k8s.io/replicatedjob-replicas.",
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "subGroupIndexLabel": {
+                    "description": "SubGroupIndexLabel indicates the name of the label indexing the instances of replicated Jobs (groups)\nwithin a PodSet. For example, in the context of JobSet this is jobset.sigs.k8s.io/job-index.",
+                    "type": "string"
                   }
                 }
               }
@@ -6306,6 +6363,11 @@
       "description": "WorkloadStatus defines the observed state of Workload",
       "type": "object",
       "properties": {
+        "accumulatedPastExexcutionTimeSeconds": {
+          "description": "accumulatedPastExexcutionTimeSeconds holds the total time, in seconds, the workload spent\nin Admitted state, in the previous `Admit` - `Evict` cycles.",
+          "type": "integer",
+          "format": "int32"
+        },
         "admission": {
           "description": "admission holds the parameters of the admission of the workload by a\nClusterQueue. admission can be set back to null, but its fields cannot be\nchanged once set.",
           "type": "object",
@@ -6353,11 +6415,60 @@
                     "pattern": "^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
                   },
                   "resourceUsage": {
-                    "description": "resourceUsage keeps track of the total resources all the pods in the podset need to run.\n\n\nBeside what is provided in podSet's specs, this calculation takes into account\nthe LimitRange defaults and RuntimeClass overheads at the moment of admission.\nThis field will not change in case of quota reclaim.",
+                    "description": "resourceUsage keeps track of the total resources all the pods in the podset need to run.\n\nBeside what is provided in podSet's specs, this calculation takes into account\nthe LimitRange defaults and RuntimeClass overheads at the moment of admission.\nThis field will not change in case of quota reclaim.",
                     "type": "object",
                     "additionalProperties": {
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
+                    }
+                  },
+                  "topologyAssignment": {
+                    "description": "topologyAssignment indicates the topology assignment divided into\ntopology domains corresponding to the lowest level of the topology.\nThe assignment specifies the number of Pods to be scheduled per topology\ndomain and specifies the node selectors for each topology domain, in the\nfollowing way: the node selector keys are specified by the levels field\n(same for all domains), and the corresponding node selector value is\nspecified by the domains.values subfield. If the TopologySpec.Levels field contains\n\"kubernetes.io/hostname\" label, topologyAssignment will contain data only for\nthis label, and omit higher levels in the topology\n\nExample:\n\ntopologyAssignment:\n  levels:\n  - cloud.provider.com/topology-block\n  - cloud.provider.com/topology-rack\n  domains:\n  - values: [block-1, rack-1]\n    count: 4\n  - values: [block-1, rack-2]\n    count: 2\n\nHere:\n- 4 Pods are to be scheduled on nodes matching the node selector:\n  cloud.provider.com/topology-block: block-1\n  cloud.provider.com/topology-rack: rack-1\n- 2 Pods are to be scheduled on nodes matching the node selector:\n  cloud.provider.com/topology-block: block-1\n  cloud.provider.com/topology-rack: rack-2\n\nExample:\nBelow there is an equivalent of the above example assuming, Topology\nobject defines kubernetes.io/hostname as the lowest level in topology.\nHence we omit higher level of topologies, since the hostname label\nis sufficient to explicitly identify a proper node.\n\ntopologyAssignment:\n  levels:\n  - kubernetes.io/hostname\n  domains:\n  - values: [hostname-1]\n    count: 4\n  - values: [hostname-2]\n    count: 2",
+                    "type": "object",
+                    "required": [
+                      "domains",
+                      "levels"
+                    ],
+                    "properties": {
+                      "domains": {
+                        "description": "domains is a list of topology assignments split by topology domains at\nthe lowest level of the topology.",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "required": [
+                            "count",
+                            "values"
+                          ],
+                          "properties": {
+                            "count": {
+                              "description": "count indicates the number of Pods to be scheduled in the topology\ndomain indicated by the values field.",
+                              "type": "integer",
+                              "format": "int32",
+                              "minimum": 1
+                            },
+                            "values": {
+                              "description": "values is an ordered list of node selector values describing a topology\ndomain. The values correspond to the consecutive topology levels, from\nthe highest to the lowest.",
+                              "type": "array",
+                              "maxItems": 8,
+                              "minItems": 1,
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        }
+                      },
+                      "levels": {
+                        "description": "levels is an ordered list of keys denoting the levels of the assigned\ntopology (i.e. node label keys), from the highest to the lowest level of\nthe topology.",
+                        "type": "array",
+                        "maxItems": 8,
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      }
                     }
                   }
                 }
@@ -6504,10 +6615,10 @@
           "x-kubernetes-list-type": "map"
         },
         "conditions": {
-          "description": "conditions hold the latest available observations of the Workload\ncurrent state.\n\n\nThe type of the condition could be:\n\n\n- Admitted: the Workload was admitted through a ClusterQueue.\n- Finished: the associated workload finished running (failed or succeeded).\n- PodsReady: at least `.spec.podSets[*].count` Pods are ready or have\nsucceeded.",
+          "description": "conditions hold the latest available observations of the Workload\ncurrent state.\n\nThe type of the condition could be:\n\n- Admitted: the Workload was admitted through a ClusterQueue.\n- Finished: the associated workload finished running (failed or succeeded).\n- PodsReady: at least `.spec.podSets[*].count` Pods are ready or have\nsucceeded.",
           "type": "array",
           "items": {
-            "description": "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}",
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
             "type": "object",
             "required": [
               "lastTransitionTime",
@@ -6550,7 +6661,7 @@
                 ]
               },
               "type": {
-                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.\n---\nMany .condition.type values are consistent across resources like Available, but because arbitrary conditions can be\nuseful (see .node.status.conditions), the ability to deconflict is important.\nThe regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)",
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
                 "type": "string",
                 "maxLength": 316,
                 "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
@@ -6606,6 +6717,37 @@
               "format": "date-time"
             }
           }
+        },
+        "resourceRequests": {
+          "description": "resourceRequests provides a detailed view of the resources that were\nrequested by a non-admitted workload when it was considered for admission.\nIf admission is non-null, resourceRequests will be empty because\nadmission.resourceUsage contains the detailed information.",
+          "type": "array",
+          "maxItems": 8,
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "description": "name is the name of the podSet. It should match one of the names in .spec.podSets.",
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "resources": {
+                "description": "resources is the total resources all the pods in the podset need to run.\n\nBeside what is provided in podSet's specs, this value also takes into account\nthe LimitRange defaults and RuntimeClass overheads at the moment of consideration\nand the application of resource.excludeResourcePrefixes and resource.transformations.",
+                "type": "object",
+                "additionalProperties": {
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map"
         }
       }
     }
@@ -6634,6 +6776,10 @@
     {
       "message": "field is immutable",
       "rule": "(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c, c.type == 'QuotaReserved' && c.status == 'True')) && (has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c, c.type == 'QuotaReserved' && c.status == 'True')) && has(oldSelf.spec.queueName) && has(self.spec.queueName) ? oldSelf.spec.queueName == self.spec.queueName : true"
+    },
+    {
+      "message": "maximumExecutionTimeSeconds is immutable while admitted",
+      "rule": "((has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c, c.type == 'Admitted' && c.status == 'True')) && (has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c, c.type == 'Admitted' && c.status == 'True')))?((has(oldSelf.spec.maximumExecutionTimeSeconds)?oldSelf.spec.maximumExecutionTimeSeconds:0) ==  (has(self.spec.maximumExecutionTimeSeconds)?self.spec.maximumExecutionTimeSeconds:0)):true"
     }
   ],
   "$schema": "http://json-schema.org/schema#"

--- a/class_generator/schema/xgboostjob.json
+++ b/class_generator/schema/xgboostjob.json
@@ -39,6 +39,10 @@
               "description": "CleanPodPolicy defines the policy to kill pods after the job completes.\nDefault to None.",
               "type": "string"
             },
+            "managedBy": {
+              "description": "ManagedBy is used to indicate the controller or entity that manages a job.\nThe value must be either an empty, 'kubeflow.org/training-operator' or\n'kueue.x-k8s.io/multikueue'.\nThe training-operator reconciles a job which doesn't have this\nfield at all or the field value is the reserved string\n'kubeflow.org/training-operator', but delegates reconciling the job\nwith 'kueue.x-k8s.",
+              "type": "string"
+            },
             "schedulingPolicy": {
               "description": "SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling",
               "type": "object",
@@ -58,7 +62,13 @@
                   "type": "string"
                 },
                 "queue": {
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "spec.runPolicy.schedulingPolicy.queue is immutable",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
                 },
                 "scheduleTimeoutSeconds": {
                   "type": "integer",
@@ -185,10 +195,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -214,10 +226,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
@@ -228,7 +242,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
@@ -268,10 +283,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchFields": {
                                           "description": "A list of node selector requirements by node's fields.",
@@ -297,14 +314,17 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       },
                                       "x-kubernetes-map-type": "atomic"
-                                    }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
                                   }
                                 },
                                 "x-kubernetes-map-type": "atomic"
@@ -361,10 +381,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -377,7 +399,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -385,7 +407,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -420,10 +442,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -440,7 +464,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -454,7 +479,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -494,10 +520,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -510,7 +538,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -518,7 +546,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -553,10 +581,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -573,14 +603,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           },
@@ -634,10 +666,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -650,7 +684,7 @@
                                           "x-kubernetes-map-type": "atomic"
                                         },
                                         "matchLabelKeys": {
-                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -658,7 +692,7 @@
                                           "x-kubernetes-list-type": "atomic"
                                         },
                                         "mismatchLabelKeys": {
-                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                          "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -693,10 +727,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -713,7 +749,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "topologyKey": {
                                           "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
@@ -727,7 +764,8 @@
                                       "format": "int32"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               },
                               "requiredDuringSchedulingIgnoredDuringExecution": {
                                 "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.",
@@ -767,10 +805,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -783,7 +823,7 @@
                                       "x-kubernetes-map-type": "atomic"
                                     },
                                     "matchLabelKeys": {
-                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -791,7 +831,7 @@
                                       "x-kubernetes-list-type": "atomic"
                                     },
                                     "mismatchLabelKeys": {
-                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
+                                      "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -826,10 +866,12 @@
                                                 "type": "array",
                                                 "items": {
                                                   "type": "string"
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "matchLabels": {
                                           "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -846,14 +888,16 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "topologyKey": {
                                       "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
                                       "type": "string"
                                     }
                                   }
-                                }
+                                },
+                                "x-kubernetes-list-type": "atomic"
                               }
                             }
                           }
@@ -878,14 +922,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -921,7 +967,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -984,7 +1030,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -997,7 +1043,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -1011,7 +1061,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1030,7 +1080,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -1041,7 +1091,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -1068,7 +1119,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1103,7 +1155,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1165,7 +1218,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -1200,7 +1254,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -1264,7 +1319,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1286,7 +1342,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1322,7 +1378,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1439,7 +1496,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1461,7 +1519,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1497,7 +1555,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1585,7 +1644,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -1596,6 +1655,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -1635,6 +1698,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -1645,7 +1725,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -1653,7 +1734,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1662,7 +1744,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -1717,7 +1799,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -1759,7 +1841,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -1781,7 +1864,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -1817,7 +1900,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -1917,7 +2001,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -1935,7 +2023,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -1946,6 +2034,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -1955,14 +2047,22 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "dnsConfig": {
                         "description": "Specifies the DNS parameters of a pod.\nParameters specified here will be merged to the generated DNS\nconfiguration based on DNSPolicy.",
@@ -1973,7 +2073,8 @@
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "options": {
                             "description": "A list of DNS resolver options.\nThis will be merged with the base options generated from DNSPolicy.\nDuplicated entries will be removed. Resolution options given in Options\nwill override those that appear in the base DNSPolicy.",
@@ -1990,14 +2091,16 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "searches": {
                             "description": "A list of DNS search domains for host-name lookup.\nThis will be appended to the base search paths generated from DNSPolicy.\nDuplicated search paths will be removed.",
                             "type": "array",
                             "items": {
                               "type": "string"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           }
                         }
                       },
@@ -2024,14 +2127,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -2067,7 +2172,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2130,7 +2235,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -2143,7 +2248,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -2157,7 +2266,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2176,7 +2285,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -2187,7 +2296,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images",
@@ -2214,7 +2324,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2249,7 +2360,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2311,7 +2423,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -2346,7 +2459,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -2410,7 +2524,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2432,7 +2547,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2468,7 +2583,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2585,7 +2701,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2607,7 +2724,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2643,7 +2760,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -2731,7 +2849,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -2742,6 +2860,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -2781,6 +2903,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -2791,7 +2930,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -2799,7 +2939,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2808,7 +2949,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -2863,7 +3004,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -2905,7 +3046,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -2927,7 +3069,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -2963,7 +3105,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3032,7 +3175,7 @@
                               "type": "boolean"
                             },
                             "targetContainerName": {
-                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\n\nThe container runtime must implement support for this feature.",
+                              "description": "If set, the name of the container from PodSpec that this ephemeral container targets.\nThe ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.\nIf not set then the ephemeral container uses the namespaces configured in the Pod spec.\n\nThe container runtime must implement support for this feature.",
                               "type": "string"
                             },
                             "terminationMessagePath": {
@@ -3067,7 +3210,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.\nCannot be updated.",
@@ -3085,7 +3232,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -3096,6 +3243,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -3105,35 +3256,51 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostAliases": {
-                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified. This is only valid for non-hostNetwork pods.",
+                        "description": "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts\nfile if specified.",
                         "type": "array",
                         "items": {
                           "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the\npod's hosts file.",
                           "type": "object",
+                          "required": [
+                            "ip"
+                          ],
                           "properties": {
                             "hostnames": {
                               "description": "Hostnames for the above IP address.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "ip": {
                               "description": "IP address of the host file entry.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "ip"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "hostIPC": {
                         "description": "Use the host's ipc namespace.\nOptional: Default to false.",
@@ -3163,12 +3330,16 @@
                           "type": "object",
                           "properties": {
                             "name": {
-                              "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                               "type": "string"
                             }
                           },
                           "x-kubernetes-map-type": "atomic"
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "initContainers": {
                         "description": "List of initialization containers belonging to the pod.\nInit containers are executed in order prior to containers being started. If any\ninit container fails, the pod is considered to have failed and is handled according\nto its restartPolicy. The name for an init container or normal container must be\nunique among all containers.",
@@ -3185,14 +3356,16 @@
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "command": {
                               "description": "Entrypoint array. Not executed within a shell.\nThe container image's ENTRYPOINT is used if this is not provided.\nVariable references $(VAR_NAME) are expanded using the container's environment. If a variable\ncannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced\nto a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.",
                               "type": "array",
                               "items": {
                                 "type": "string"
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "env": {
                               "description": "List of environment variables to set in the container.\nCannot be updated.",
@@ -3228,7 +3401,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3291,7 +3464,7 @@
                                             "type": "string"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -3304,7 +3477,11 @@
                                     }
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "envFrom": {
                               "description": "List of sources to populate environment variables in the container.\nThe keys defined within a source must be a C_IDENTIFIER. All invalid keys\nwill be reported as an event when the container is starting. When a key exists in multiple\nsources, the value associated with the last source will take precedence.\nValues defined by an Env with a duplicate key will take precedence.\nCannot be updated.",
@@ -3318,7 +3495,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3337,7 +3514,7 @@
                                     "type": "object",
                                     "properties": {
                                       "name": {
-                                        "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                         "type": "string"
                                       },
                                       "optional": {
@@ -3348,7 +3525,8 @@
                                     "x-kubernetes-map-type": "atomic"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-type": "atomic"
                             },
                             "image": {
                               "description": "Container image name.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
@@ -3375,7 +3553,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3410,7 +3589,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3472,7 +3652,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         }
                                       }
                                     },
@@ -3507,7 +3688,8 @@
                                                 "type": "string"
                                               }
                                             }
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "path": {
                                           "description": "Path to access on the HTTP server.",
@@ -3571,7 +3753,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3593,7 +3776,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3629,7 +3812,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3746,7 +3930,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3768,7 +3953,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -3804,7 +3989,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -3892,7 +4078,7 @@
                               "type": "object",
                               "properties": {
                                 "claims": {
-                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable. It can only be set for containers.",
+                                  "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
                                   "type": "array",
                                   "items": {
                                     "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
@@ -3903,6 +4089,10 @@
                                     "properties": {
                                       "name": {
                                         "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                        "type": "string"
+                                      },
+                                      "request": {
+                                        "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
                                         "type": "string"
                                       }
                                     }
@@ -3942,6 +4132,23 @@
                                   "description": "AllowPrivilegeEscalation controls whether a process can gain more\nprivileges than its parent process. This bool directly controls if\nthe no_new_privs flag will be set on the container process.\nAllowPrivilegeEscalation is true always when the container is:\n1) run as Privileged\n2) has CAP_SYS_ADMIN\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "boolean"
                                 },
+                                "appArmorProfile": {
+                                  "description": "appArmorProfile is the AppArmor options to use by this container. If set, this profile\noverrides the pod's appArmorProfile.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "type": "object",
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "properties": {
+                                    "localhostProfile": {
+                                      "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
                                 "capabilities": {
                                   "description": "The capabilities to add/drop when running containers.\nDefaults to the default set of capabilities granted by the container runtime.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "object",
@@ -3952,7 +4159,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "drop": {
                                       "description": "Removed capabilities",
@@ -3960,7 +4168,8 @@
                                       "items": {
                                         "description": "Capability represent POSIX capabilities type",
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -3969,7 +4178,7 @@
                                   "type": "boolean"
                                 },
                                 "procMount": {
-                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default is DefaultProcMount which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
+                                  "description": "procMount denotes the type of proc mount to use for the containers.\nThe default value is Default which uses the container runtime defaults for\nreadonly paths and masked paths.\nThis requires the ProcMountType feature flag to be enabled.\nNote that this field cannot be set when spec.os.name is windows.",
                                   "type": "string"
                                 },
                                 "readOnlyRootFilesystem": {
@@ -4024,7 +4233,7 @@
                                       "type": "string"
                                     },
                                     "type": {
-                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                       "type": "string"
                                     }
                                   }
@@ -4066,7 +4275,8 @@
                                       "type": "array",
                                       "items": {
                                         "type": "string"
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     }
                                   }
                                 },
@@ -4088,7 +4298,7 @@
                                       "format": "int32"
                                     },
                                     "service": {
-                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                      "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
                                       "type": "string"
                                     }
                                   }
@@ -4124,7 +4334,8 @@
                                             "type": "string"
                                           }
                                         }
-                                      }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
                                     },
                                     "path": {
                                       "description": "Path to access on the HTTP server.",
@@ -4224,7 +4435,11 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "devicePath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "volumeMounts": {
                               "description": "Pod volumes to mount into the container's filesystem.\nCannot be updated.",
@@ -4242,7 +4457,7 @@
                                     "type": "string"
                                   },
                                   "mountPropagation": {
-                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.",
+                                    "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
                                     "type": "string"
                                   },
                                   "name": {
@@ -4253,6 +4468,10 @@
                                     "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
                                     "type": "boolean"
                                   },
+                                  "recursiveReadOnly": {
+                                    "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.",
+                                    "type": "string"
+                                  },
                                   "subPath": {
                                     "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
                                     "type": "string"
@@ -4262,17 +4481,25 @@
                                     "type": "string"
                                   }
                                 }
-                              }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "mountPath"
+                              ],
+                              "x-kubernetes-list-type": "map"
                             },
                             "workingDir": {
                               "description": "Container's working directory.\nIf not specified, the container runtime's default will be used, which\nmight be configured in the container image.\nCannot be updated.",
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       },
                       "nodeName": {
-                        "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty,\nthe scheduler simply schedules this pod onto that node, assuming that it fits resource\nrequirements.",
+                        "description": "NodeName indicates in which node this pod is scheduled.\nIf empty, this pod is a candidate for scheduling by the scheduler defined in schedulerName.\nOnce this field is set, the kubelet for this node becomes responsible for the lifecycle of this pod.\nThis field should not be used to express a desire for the pod to be scheduled on a specific node.\nhttps://kubernetes.",
                         "type": "string"
                       },
                       "nodeSelector": {
@@ -4284,7 +4511,7 @@
                         "x-kubernetes-map-type": "atomic"
                       },
                       "os": {
-                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.seLinuxOptions\n- spec.securityContext.",
+                        "description": "Specifies the OS of the containers in the pod.\nSome pod and container fields are restricted if this is set.\n\nIf the OS field is set to linux, the following fields must be unset:\n-securityContext.windowsOptions\n\nIf the OS field is set to windows, following fields must be unset:\n- spec.hostPID\n- spec.hostIPC\n- spec.hostUsers\n- spec.securityContext.appArmorProfile\n- spec.securityContext.",
                         "type": "object",
                         "required": [
                           "name"
@@ -4332,13 +4559,14 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "resourceClaims": {
-                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\n\nThis field is immutable.",
+                        "description": "ResourceClaims defines which ResourceClaims must be allocated\nand reserved before the Pod is allowed to start. The resources\nwill be made available to those containers which consume them\nby name.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable.",
                         "type": "array",
                         "items": {
-                          "description": "PodResourceClaim references exactly one ResourceClaim through a ClaimSource.\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
+                          "description": "PodResourceClaim references exactly one ResourceClaim, either directly\nor by naming a ResourceClaimTemplate which is then turned into a ResourceClaim\nfor the pod.\n\nIt adds a name to it that uniquely identifies the ResourceClaim inside the Pod.\nContainers that need access to the ResourceClaim reference it with this name.",
                           "type": "object",
                           "required": [
                             "name"
@@ -4348,19 +4576,13 @@
                               "description": "Name uniquely identifies this resource claim inside the pod.\nThis must be a DNS_LABEL.",
                               "type": "string"
                             },
-                            "source": {
-                              "description": "Source describes where to find the ResourceClaim.",
-                              "type": "object",
-                              "properties": {
-                                "resourceClaimName": {
-                                  "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.",
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
-                                  "type": "string"
-                                }
-                              }
+                            "resourceClaimName": {
+                              "description": "ResourceClaimName is the name of a ResourceClaim object in the same\nnamespace as this pod.\n\nExactly one of ResourceClaimName and ResourceClaimTemplateName must\nbe set.",
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "description": "ResourceClaimTemplateName is the name of a ResourceClaimTemplate\nobject in the same namespace as this pod.\n\nThe template will be used to create a new ResourceClaim, which will\nbe bound to this pod. When this pod is deleted, the ResourceClaim\nwill also be deleted.",
+                              "type": "string"
                             }
                           }
                         },
@@ -4382,7 +4604,7 @@
                         "type": "string"
                       },
                       "schedulingGates": {
-                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.\n\n\nThis is a beta feature enabled by the PodSchedulingReadiness feature gate.",
+                        "description": "SchedulingGates is an opaque list of values that if specified will block scheduling the pod.\nIf schedulingGates is not empty, the pod will stay in the SchedulingGated state and the\nscheduler will not attempt to schedule the pod.\n\nSchedulingGates can only be set at pod creation time, and be removed only afterwards.",
                         "type": "array",
                         "items": {
                           "description": "PodSchedulingGate is associated to a Pod to guard its scheduling.",
@@ -4406,8 +4628,25 @@
                         "description": "SecurityContext holds pod-level security attributes and common container settings.\nOptional: Defaults to empty.  See type description for default values of each field.",
                         "type": "object",
                         "properties": {
+                          "appArmorProfile": {
+                            "description": "appArmorProfile is the AppArmor options to use by the containers in this pod.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "object",
+                            "required": [
+                              "type"
+                            ],
+                            "properties": {
+                              "localhostProfile": {
+                                "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                                "type": "string"
+                              },
+                              "type": {
+                                "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                                "type": "string"
+                              }
+                            }
+                          },
                           "fsGroup": {
-                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
+                            "description": "A special supplemental group that applies to all containers in a pod.\nSome volume types allow the Kubelet to change the ownership of that volume\nto be owned by the pod:\n\n1. The owning GID will be the FSGroup\n2. The setgid bit is set (new files created in the volume will be owned by FSGroup)\n3.",
                             "type": "integer",
                             "format": "int64"
                           },
@@ -4463,18 +4702,23 @@
                                 "type": "string"
                               },
                               "type": {
-                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                                "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
                                 "type": "string"
                               }
                             }
                           },
                           "supplementalGroups": {
-                            "description": "A list of groups applied to the first process run in each container, in addition\nto the container's primary GID, the fsGroup (if specified), and group memberships\ndefined in the container image for the uid of the container process. If unspecified,\nno additional groups are added to any container.",
+                            "description": "A list of groups applied to the first process run in each container, in\naddition to the container's primary GID and fsGroup (if specified).  If\nthe SupplementalGroupsPolicy feature is enabled, the\nsupplementalGroupsPolicy field determines whether these are in addition\nto or instead of any group memberships defined in the container image.",
                             "type": "array",
                             "items": {
                               "type": "integer",
                               "format": "int64"
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "description": "Defines how supplemental groups of the first container processes are calculated.\nValid values are \"Merge\" and \"Strict\". If not specified, \"Merge\" is used.\n(Alpha) Using the field requires the SupplementalGroupsPolicy feature gate to be enabled\nand the container runtime must implement support for this feature.\nNote that this field cannot be set when spec.os.name is windows.",
+                            "type": "string"
                           },
                           "sysctls": {
                             "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported\nsysctls (by the container runtime) might fail to launch.\nNote that this field cannot be set when spec.os.name is windows.",
@@ -4496,7 +4740,8 @@
                                   "type": "string"
                                 }
                               }
-                            }
+                            },
+                            "x-kubernetes-list-type": "atomic"
                           },
                           "windowsOptions": {
                             "description": "The Windows specific settings applied to all containers.\nIf unspecified, the options within a container's SecurityContext will be used.\nIf set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.\nNote that this field cannot be set when spec.os.name is linux.",
@@ -4523,7 +4768,7 @@
                         }
                       },
                       "serviceAccount": {
-                        "description": "DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
+                        "description": "DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.\nDeprecated: Use serviceAccountName instead.",
                         "type": "string"
                       },
                       "serviceAccountName": {
@@ -4576,7 +4821,8 @@
                               "type": "string"
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-type": "atomic"
                       },
                       "topologySpreadConstraints": {
                         "description": "TopologySpreadConstraints describes how a group of pods ought to spread across topology\ndomains. Scheduler will schedule pods in a way which abides by the constraints.\nAll topologySpreadConstraints are ANDed.",
@@ -4618,10 +4864,12 @@
                                         "type": "array",
                                         "items": {
                                           "type": "string"
-                                        }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "matchLabels": {
                                   "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -4652,11 +4900,11 @@
                               "format": "int32"
                             },
                             "nodeAffinityPolicy": {
-                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
+                              "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.",
                               "type": "string"
                             },
                             "nodeTaintsPolicy": {
-                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
+                              "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.",
                               "type": "string"
                             },
                             "topologyKey": {
@@ -4693,7 +4941,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -4779,7 +5027,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "path": {
                                   "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
@@ -4798,7 +5047,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4830,7 +5079,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4876,10 +5125,11 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "name": {
-                                  "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                  "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                   "type": "string"
                                 },
                                 "optional": {
@@ -4909,7 +5159,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -4948,7 +5198,7 @@
                                     ],
                                     "properties": {
                                       "fieldRef": {
-                                        "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                        "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                         "type": "object",
                                         "required": [
                                           "fieldPath"
@@ -4998,7 +5248,8 @@
                                         "x-kubernetes-map-type": "atomic"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5067,7 +5318,8 @@
                                           "type": "array",
                                           "items": {
                                             "type": "string"
-                                          }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
                                         },
                                         "dataSource": {
                                           "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.",
@@ -5168,10 +5420,12 @@
                                                     "type": "array",
                                                     "items": {
                                                       "type": "string"
-                                                    }
+                                                    },
+                                                    "x-kubernetes-list-type": "atomic"
                                                   }
                                                 }
-                                              }
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
                                             },
                                             "matchLabels": {
                                               "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5210,7 +5464,7 @@
                               "type": "object",
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
                                   "type": "string"
                                 },
                                 "lun": {
@@ -5227,14 +5481,16 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "wwids": {
                                   "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5269,7 +5525,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5299,7 +5555,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
                                   "type": "string"
                                 },
                                 "partition": {
@@ -5361,7 +5617,7 @@
                               }
                             },
                             "hostPath": {
-                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.",
+                              "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
                               "type": "object",
                               "required": [
                                 "path"
@@ -5373,6 +5629,20 @@
                                 },
                                 "type": {
                                   "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "image": {
+                              "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact.",
+                              "type": "object",
+                              "properties": {
+                                "pullPolicy": {
+                                  "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk.",
+                                  "type": "string"
+                                },
+                                "reference": {
+                                  "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.",
                                   "type": "string"
                                 }
                               }
@@ -5395,7 +5665,7 @@
                                   "type": "boolean"
                                 },
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
                                   "type": "string"
                                 },
                                 "initiatorName": {
@@ -5420,7 +5690,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "readOnly": {
                                   "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
@@ -5431,7 +5702,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5534,14 +5805,14 @@
                                   "format": "int32"
                                 },
                                 "sources": {
-                                  "description": "sources is the list of volume projections",
+                                  "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
                                   "type": "array",
                                   "items": {
-                                    "description": "Projection that may be projected along with other supported volume types",
+                                    "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
                                     "type": "object",
                                     "properties": {
                                       "clusterTrustBundle": {
-                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
+                                        "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.",
                                         "type": "object",
                                         "required": [
                                           "path"
@@ -5575,10 +5846,12 @@
                                                       "type": "array",
                                                       "items": {
                                                         "type": "string"
-                                                      }
+                                                      },
+                                                      "x-kubernetes-list-type": "atomic"
                                                     }
                                                   }
-                                                }
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
                                               },
                                               "matchLabels": {
                                                 "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -5637,10 +5910,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -5665,7 +5939,7 @@
                                               ],
                                               "properties": {
                                                 "fieldRef": {
-                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+                                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
                                                   "type": "object",
                                                   "required": [
                                                     "fieldPath"
@@ -5715,7 +5989,8 @@
                                                   "x-kubernetes-map-type": "atomic"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           }
                                         }
                                       },
@@ -5748,10 +6023,11 @@
                                                   "type": "string"
                                                 }
                                               }
-                                            }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
                                           },
                                           "name": {
-                                            "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                             "type": "string"
                                           },
                                           "optional": {
@@ -5784,7 +6060,8 @@
                                         }
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 }
                               }
                             },
@@ -5831,7 +6108,7 @@
                               ],
                               "properties": {
                                 "fsType": {
-                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd\nTODO: how do we prevent errors in the filesystem from compromising the machine",
+                                  "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
                                   "type": "string"
                                 },
                                 "image": {
@@ -5847,7 +6124,8 @@
                                   "type": "array",
                                   "items": {
                                     "type": "string"
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "pool": {
                                   "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
@@ -5862,7 +6140,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5904,7 +6182,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -5966,7 +6244,8 @@
                                         "type": "string"
                                       }
                                     }
-                                  }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
                                 },
                                 "optional": {
                                   "description": "optional field specify whether the Secret or its keys must be defined",
@@ -5995,7 +6274,7 @@
                                   "type": "object",
                                   "properties": {
                                     "name": {
-                                      "description": "Name of the referent.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names\nTODO: Add other useful fields. apiVersion, kind, uid?",
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                                       "type": "string"
                                     }
                                   },
@@ -6037,7 +6316,11 @@
                               }
                             }
                           }
-                        }
+                        },
+                        "x-kubernetes-list-map-keys": [
+                          "name"
+                        ],
+                        "x-kubernetes-list-type": "map"
                       }
                     }
                   }
@@ -6147,10 +6430,12 @@
                           "type": "array",
                           "items": {
                             "type": "string"
-                          }
+                          },
+                          "x-kubernetes-list-type": "atomic"
                         }
                       }
-                    }
+                    },
+                    "x-kubernetes-list-type": "atomic"
                   },
                   "matchLabels": {
                     "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
@@ -6189,5 +6474,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/xgboostjoblist.json
+++ b/class_generator/schema/xgboostjoblist.json
@@ -32,5 +32,6 @@
       "version": "v1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/ocp_resources/guardrails_orchestrator.py
+++ b/ocp_resources/guardrails_orchestrator.py
@@ -1,6 +1,7 @@
 # Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
 
 from __future__ import annotations
+from __future__ import annotations
 from typing import Any
 from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentError
 
@@ -14,14 +15,22 @@ class GuardrailsOrchestrator(NamespacedResource):
 
     def __init__(
         self,
+        enable_built_in_detectors: bool | None = None,
+        enable_guardrails_gateway: bool | None = None,
+        guardrails_gateway_config: str | None = None,
         orchestrator_config: str | None = None,
         otel_exporter: dict[str, Any] | None = None,
         replicas: int | None = None,
-        vllm_gateway_config: str | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
+            enable_built_in_detectors (bool): Boolean flag to enable/disable built-in detectors
+
+            enable_guardrails_gateway (bool): Boolean flag to enable/disable the guardrails sidecar gateway
+
+            guardrails_gateway_config (str):  Name of the configmap containing guadrails sidecar gateway arguments
+
             orchestrator_config (str): Name of configmap containing generator,detector,and chunker arguments
 
             otel_exporter (dict[str, Any]): List of orchestrator enviroment variables for configuring the OTLP
@@ -29,15 +38,15 @@ class GuardrailsOrchestrator(NamespacedResource):
 
             replicas (int): Number of replicas
 
-            vllm_gateway_config (str):  Name of the configmap containg vLLM gateway arguments
-
         """
         super().__init__(**kwargs)
 
+        self.enable_built_in_detectors = enable_built_in_detectors
+        self.enable_guardrails_gateway = enable_guardrails_gateway
+        self.guardrails_gateway_config = guardrails_gateway_config
         self.orchestrator_config = orchestrator_config
         self.otel_exporter = otel_exporter
         self.replicas = replicas
-        self.vllm_gateway_config = vllm_gateway_config
 
     def to_dict(self) -> None:
         super().to_dict()
@@ -55,10 +64,16 @@ class GuardrailsOrchestrator(NamespacedResource):
             _spec["orchestratorConfig"] = self.orchestrator_config
             _spec["replicas"] = self.replicas
 
+            if self.enable_built_in_detectors is not None:
+                _spec["enableBuiltInDetectors"] = self.enable_built_in_detectors
+
+            if self.enable_guardrails_gateway is not None:
+                _spec["enableGuardrailsGateway"] = self.enable_guardrails_gateway
+
+            if self.guardrails_gateway_config is not None:
+                _spec["guardrailsGatewayConfig"] = self.guardrails_gateway_config
+
             if self.otel_exporter is not None:
                 _spec["otelExporter"] = self.otel_exporter
-
-            if self.vllm_gateway_config is not None:
-                _spec["vllmGatewayConfig"] = self.vllm_gateway_config
 
     # End of generated code


### PR DESCRIPTION
##### Short description:
Update GuardrailsOrchestrator resource.

##### More details:
The GuardrailsOrchestrator CRD has been updated with 3 new parameters: enable_built_in_detectors, enable_guardrails_gateway, and guardrails_gateway_config. Also, enable updating resources when cluster has the same Kubernetes version as the last generated version.  

##### What this PR does / why we need it:
To be able to use GuardrailsOrchestrator resource.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring built-in detectors and guardrails gateway in Guardrails Orchestrator resources.
  - New options allow enabling/disabling built-in detectors and guardrails gateway, as well as specifying gateway configuration.

- **Refactor**
  - Improved version comparison logic for schema generation to include equal versions, ensuring more consistent handling of cluster versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->