### PR TITLE
feat: Update LMEvalJob resource

### DIFF
--- a/class_generator/schema/__not-kind.txt
+++ b/class_generator/schema/__not-kind.txt
@@ -794,3 +794,17 @@ io.openshift.nfd.v1alpha1.NodeFeatureGroupList
 io.opendatahub.platform.components.v1alpha1.FeastOperatorList
 io.kuadrant.authorino.v1beta3.AuthConfigList
 dev.feast.v1alpha1.FeatureStoreList
+io.sailoperator.v1alpha1.ZTunnelList
+io.sailoperator.v1.IstioRevisionTagList
+io.sailoperator.v1.IstioRevisionList
+io.sailoperator.v1.IstioList
+io.sailoperator.v1.IstioCNIList
+io.istio.telemetry.v1.TelemetryList
+io.istio.security.v1.PeerAuthenticationList
+io.istio.networking.v1.WorkloadGroupList
+io.istio.networking.v1.WorkloadEntryList
+io.istio.networking.v1.VirtualServiceList
+io.istio.networking.v1.SidecarList
+io.istio.networking.v1.ServiceEntryList
+io.istio.networking.v1.GatewayList
+io.istio.networking.v1.DestinationRuleList

--- a/class_generator/schema/account.json
+++ b/class_generator/schema/account.json
@@ -90,6 +90,16 @@
             }
           },
           "x-kubernetes-map-type": "atomic"
+        },
+        "nimConfigRefreshRate": {
+          "description": "Refresh rate for models data, defaults to 24h",
+          "type": "string",
+          "format": "duration"
+        },
+        "validationRefreshRate": {
+          "description": "Refresh Rate for validation, defaults to 24h",
+          "type": "string",
+          "format": "duration"
         }
       }
     },
@@ -150,6 +160,21 @@
               }
             }
           }
+        },
+        "lastAccountCheck": {
+          "description": "The last time we checked the Account, failed or successful.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastSuccessfulConfigRefresh": {
+          "description": "The last time we refresh the integration config successfully.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "lastSuccessfulValidation": {
+          "description": "The last time we validated successfully.",
+          "type": "string",
+          "format": "date-time"
         },
         "nimConfig": {
           "description": "A reference to the ConfigMap with data for NIM deployment.",

--- a/class_generator/schema/all.json
+++ b/class_generator/schema/all.json
@@ -763,6 +763,60 @@
       "$ref": "_definitions.json#/definitions/com.github.operator-framework.operator-lifecycle-manager.pkg.package-server.apis.operators.v1.PackageManifestStatus"
     },
     {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Backup"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.BackupList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Connection"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.ConnectionList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Database"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.DatabaseList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Grant"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.GrantList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.MariaDB"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.MariaDBList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.MaxScale"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.MaxScaleList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Restore"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.RestoreList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.SqlJob"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.SqlJobList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.User"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.UserList"
+    },
+    {
       "$ref": "_definitions.json#/definitions/dev.codeflare.workload.v1beta2.AppWrapper"
     },
     {
@@ -853,6 +907,234 @@
       "$ref": "_definitions.json#/definitions/dev.knative.serving.v1beta1.DomainMappingList"
     },
     {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.ManualApprovalGate"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.ManualApprovalGateList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.OpenShiftPipelinesAsCode"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.OpenShiftPipelinesAsCodeList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonAddon"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonAddonList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonChain"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonChainList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonConfig"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonConfigList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonHub"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonHubList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonInstallerSet"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonInstallerSetList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonPipeline"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonPipelineList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonResult"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonResultList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonTrigger"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.operator.v1alpha1.TektonTriggerList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.pipelinesascode.v1alpha1.Repository"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.pipelinesascode.v1alpha1.RepositoryList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.resolution.v1alpha1.ResolutionRequest"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.resolution.v1alpha1.ResolutionRequestList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.resolution.v1beta1.ResolutionRequest"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.resolution.v1beta1.ResolutionRequestList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.ClusterInterceptor"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.ClusterInterceptorList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.ClusterTriggerBinding"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.ClusterTriggerBindingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.EventListener"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.EventListenerList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.Interceptor"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.InterceptorList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.Trigger"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.TriggerBinding"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.TriggerBindingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.TriggerList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.TriggerTemplate"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1alpha1.TriggerTemplateList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.ClusterTriggerBinding"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.ClusterTriggerBindingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.EventListener"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.EventListenerList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.Trigger"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.TriggerBinding"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.TriggerBindingList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.TriggerList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.TriggerTemplate"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.triggers.v1beta1.TriggerTemplateList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.Pipeline"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.PipelineList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.PipelineRun"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.PipelineRunList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.Task"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.TaskList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.TaskRun"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1.TaskRunList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1alpha1.StepAction"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1alpha1.StepActionList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1alpha1.VerificationPolicy"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1alpha1.VerificationPolicyList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.ClusterTask"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.ClusterTaskList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.CustomRun"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.CustomRunList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.Pipeline"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.PipelineList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.PipelineRun"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.PipelineRunList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.StepAction"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.StepActionList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.Task"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.TaskList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.TaskRun"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/dev.tekton.v1beta1.TaskRunList"
+    },
+    {
       "$ref": "_definitions.json#/definitions/io.argoproj.v1alpha1.ClusterWorkflowTemplate"
     },
     {
@@ -935,6 +1217,48 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.istio.extensions.v1alpha1.WasmPluginList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.DestinationRule"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.DestinationRuleList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.Gateway"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.GatewayList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.ServiceEntry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.ServiceEntryList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.Sidecar"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.SidecarList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.VirtualService"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.VirtualServiceList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.WorkloadEntry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.WorkloadEntryList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.WorkloadGroup"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.networking.v1.WorkloadGroupList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.istio.networking.v1alpha3.DestinationRule"
@@ -1039,6 +1363,12 @@
       "$ref": "_definitions.json#/definitions/io.istio.security.v1.AuthorizationPolicyList"
     },
     {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1.PeerAuthentication"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.security.v1.PeerAuthenticationList"
+    },
+    {
       "$ref": "_definitions.json#/definitions/io.istio.security.v1.RequestAuthentication"
     },
     {
@@ -1061,6 +1391,12 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.istio.security.v1beta1.RequestAuthenticationList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.telemetry.v1.Telemetry"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.istio.telemetry.v1.TelemetryList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.istio.telemetry.v1alpha1.Telemetry"
@@ -3085,16 +3421,16 @@
       "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.operator.v1beta1.AuthorinoList"
     },
     {
-      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta1.AuthConfig"
-    },
-    {
-      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta1.AuthConfigList"
-    },
-    {
       "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta2.AuthConfig"
     },
     {
       "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta2.AuthConfigList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta3.AuthConfig"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta3.AuthConfigList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.maistra.authentication.v1.ServiceMeshPolicy"
@@ -3209,6 +3545,12 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.metal3.v1alpha1.ProvisioningList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.mmontes.mariadb.helm.v1alpha1.MariadbOperator"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.mmontes.mariadb.helm.v1alpha1.MariadbOperatorList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.opendatahub.dashboard.v1.AcceleratorProfile"
@@ -3965,6 +4307,36 @@
     },
     {
       "$ref": "_definitions.json#/definitions/io.ray.v1alpha1.RayServiceList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.Istio"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioCNI"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioCNIList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioRevision"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioRevisionList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioRevisionTag"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioRevisionTagList"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1alpha1.ZTunnel"
+    },
+    {
+      "$ref": "_definitions.json#/definitions/io.sailoperator.v1alpha1.ZTunnelList"
     },
     {
       "$ref": "_definitions.json#/definitions/io.x-k8s.cluster.infrastructure.v1alpha5.Metal3Remediation"

--- a/class_generator/schema/authconfig.json
+++ b/class_generator/schema/authconfig.json
@@ -15,7 +15,7 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "Specifies the desired state of the AuthConfig resource, i.e. the authencation/authorization scheme to be applied to protect the matching service hosts.",
+      "description": "Specifies the desired state of the AuthConfig resource, i.e. the authentication/authorization scheme to be applied to protect the matching service hosts.",
       "type": "object",
       "required": [
         "hosts"
@@ -98,6 +98,10 @@
                     "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -167,6 +171,10 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "expression": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
@@ -244,6 +252,10 @@
                 "additionalProperties": {
                   "type": "object",
                   "properties": {
+                    "expression": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
@@ -258,10 +270,11 @@
               "plain": {
                 "description": "Identity object extracted from the context.\nUse this method when authentication is performed beforehand by a proxy and the resulting object passed to Authorino as JSON in the auth request.",
                 "type": "object",
-                "required": [
-                  "selector"
-                ],
                 "properties": {
+                  "expression": {
+                    "description": "A Common Expression Language (CEL) expression that evaluates to a value that represents an identity.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                    "type": "string"
+                  },
                   "selector": {
                     "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                     "type": "string"
@@ -305,6 +318,10 @@
                     },
                     "patternRef": {
                       "description": "Reference to a named set of pattern expressions",
+                      "type": "string"
+                    },
+                    "predicate": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
                       "type": "string"
                     },
                     "selector": {
@@ -394,6 +411,10 @@
                     "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -414,8 +435,26 @@
                 "description": "Authorization by Kubernetes SubjectAccessReview",
                 "type": "object",
                 "properties": {
+                  "authorizationGroups": {
+                    "description": "Groups to check for existing permission in the Kubernetes RBAC alternatively to a specific user. This is typically obtained from a list of groups the user is a member of. Must be a static list of group names or dynamically resolve to one from the Authorization JSON.",
+                    "type": "object",
+                    "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
+                      "selector": {
+                        "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Static value",
+                        "x-kubernetes-preserve-unknown-fields": true
+                      }
+                    }
+                  },
                   "groups": {
-                    "description": "Groups the user must be a member of or, if `user` is omitted, the groups to check for authorization in the Kubernetes RBAC.",
+                    "description": "Groups the user must be a member of or, if `user` is omitted, the groups to check for authorization in the Kubernetes RBAC.\nDeprecated: Use authorizationGroups instead.",
                     "type": "array",
                     "items": {
                       "type": "string"
@@ -429,6 +468,10 @@
                         "description": "API group of the resource.\nUse '*' for all API groups.",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -443,6 +486,10 @@
                         "description": "Resource name\nOmit it to check for authorization on all resources of the specified kind.",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -457,6 +504,10 @@
                         "description": "Namespace where the user must have permissions on the resource.",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -471,6 +522,10 @@
                         "description": "Resource kind\nUse '*' for all resource kinds.",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -485,6 +540,10 @@
                         "description": "Subresource kind",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -499,6 +558,10 @@
                         "description": "Verb to check for authorization on the resource.\nUse '*' for all verbs.",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -515,6 +578,10 @@
                     "description": "User to check for authorization in the Kubernetes RBAC.\nOmit it to check for group authorization only.",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -542,14 +609,15 @@
                   "externalPolicy": {
                     "description": "Settings for fetching the OPA policy from an external registry.\nUse it alternatively to 'rego'.\nFor the configurations of the HTTP request, the following options are not implemented: 'method', 'body', 'bodyParameters',\n'contentType', 'headers', 'oauth2'. Use it only with: 'url', 'sharedSecret', 'credentials'.",
                     "type": "object",
-                    "required": [
-                      "url"
-                    ],
                     "properties": {
                       "body": {
                         "description": "Raw body of the HTTP request.\nSupersedes 'bodyParameters'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -566,6 +634,10 @@
                         "additionalProperties": {
                           "type": "object",
                           "properties": {
+                            "expression": {
+                              "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                              "type": "string"
+                            },
                             "selector": {
                               "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                               "type": "string"
@@ -638,6 +710,10 @@
                         "additionalProperties": {
                           "type": "object",
                           "properties": {
+                            "expression": {
+                              "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                              "type": "string"
+                            },
                             "selector": {
                               "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                               "type": "string"
@@ -744,6 +820,10 @@
                       "url": {
                         "description": "Endpoint URL of the HTTP service.\nThe value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported\nby https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.\nE.g. https://ext-auth-server.io/metadata?p={request.path}",
                         "type": "string"
+                      },
+                      "urlExpression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a string endpoint URL of the HTTP service to call.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
                       }
                     }
                   },
@@ -794,6 +874,10 @@
                           "description": "Reference to a named set of pattern expressions",
                           "type": "string"
                         },
+                        "predicate": {
+                          "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                          "type": "string"
+                        },
                         "selector": {
                           "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                           "type": "string"
@@ -830,6 +914,10 @@
                     "description": "The name of the permission (or relation) on which to execute the check.",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -847,6 +935,10 @@
                       "kind": {
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -860,6 +952,10 @@
                       "name": {
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -897,6 +993,10 @@
                       "kind": {
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -910,6 +1010,10 @@
                       "name": {
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -959,6 +1063,10 @@
                       "description": "Reference to a named set of pattern expressions",
                       "type": "string"
                     },
+                    "predicate": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                       "type": "string"
@@ -993,6 +1101,10 @@
                     "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -1012,14 +1124,15 @@
               "http": {
                 "description": "Settings of the external HTTP request",
                 "type": "object",
-                "required": [
-                  "url"
-                ],
                 "properties": {
                   "body": {
                     "description": "Raw body of the HTTP request.\nSupersedes 'bodyParameters'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -1036,6 +1149,10 @@
                     "additionalProperties": {
                       "type": "object",
                       "properties": {
+                        "expression": {
+                          "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                          "type": "string"
+                        },
                         "selector": {
                           "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
@@ -1108,6 +1225,10 @@
                     "additionalProperties": {
                       "type": "object",
                       "properties": {
+                        "expression": {
+                          "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                          "type": "string"
+                        },
                         "selector": {
                           "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
@@ -1209,6 +1330,10 @@
                   },
                   "url": {
                     "description": "Endpoint URL of the HTTP service.\nThe value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported\nby https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.\nE.g. https://ext-auth-server.io/metadata?p={request.path}",
+                    "type": "string"
+                  },
+                  "urlExpression": {
+                    "description": "A Common Expression Language (CEL) expression that evaluates to a string endpoint URL of the HTTP service to call.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
                     "type": "string"
                   }
                 }
@@ -1256,6 +1381,10 @@
                       "description": "Reference to a named set of pattern expressions",
                       "type": "string"
                     },
+                    "predicate": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                       "type": "string"
@@ -1294,6 +1423,10 @@
                     "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -1313,14 +1446,15 @@
               "http": {
                 "description": "External source of auth metadata via HTTP request",
                 "type": "object",
-                "required": [
-                  "url"
-                ],
                 "properties": {
                   "body": {
                     "description": "Raw body of the HTTP request.\nSupersedes 'bodyParameters'; use either one or the other.\nUse it with method=POST; for GET requests, set parameters as query string in the 'endpoint' (placeholders can be used).",
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -1337,6 +1471,10 @@
                     "additionalProperties": {
                       "type": "object",
                       "properties": {
+                        "expression": {
+                          "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                          "type": "string"
+                        },
                         "selector": {
                           "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
@@ -1409,6 +1547,10 @@
                     "additionalProperties": {
                       "type": "object",
                       "properties": {
+                        "expression": {
+                          "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                          "type": "string"
+                        },
                         "selector": {
                           "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                           "type": "string"
@@ -1510,6 +1652,10 @@
                   },
                   "url": {
                     "description": "Endpoint URL of the HTTP service.\nThe value can include variable placeholders in the format \"{selector}\", where \"selector\" is any pattern supported\nby https://pkg.go.dev/github.com/tidwall/gjson and selects value from the authorization JSON.\nE.g. https://ext-auth-server.io/metadata?p={request.path}",
+                    "type": "string"
+                  },
+                  "urlExpression": {
+                    "description": "A Common Expression Language (CEL) expression that evaluates to a string endpoint URL of the HTTP service to call.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
                     "type": "string"
                   }
                 }
@@ -1595,6 +1741,10 @@
                       "description": "Reference to a named set of pattern expressions",
                       "type": "string"
                     },
+                    "predicate": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                       "type": "string"
@@ -1666,6 +1816,10 @@
                             "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                             "type": "object",
                             "properties": {
+                              "expression": {
+                                "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                                "type": "string"
+                              },
                               "selector": {
                                 "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                 "type": "string"
@@ -1694,6 +1848,10 @@
                             "additionalProperties": {
                               "type": "object",
                               "properties": {
+                                "expression": {
+                                  "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                                  "type": "string"
+                                },
                                 "selector": {
                                   "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
@@ -1719,6 +1877,10 @@
                         "description": "Plain text content",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -1768,6 +1930,10 @@
                               "description": "Reference to a named set of pattern expressions",
                               "type": "string"
                             },
+                            "predicate": {
+                              "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                              "type": "string"
+                            },
                             "selector": {
                               "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                               "type": "string"
@@ -1793,6 +1959,10 @@
                             "additionalProperties": {
                               "type": "object",
                               "properties": {
+                                "expression": {
+                                  "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                                  "type": "string"
+                                },
                                 "selector": {
                                   "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
@@ -1864,6 +2034,10 @@
                             "description": "Key used to store the entry in the cache.\nThe resolved key must be unique within the scope of this particular config.",
                             "type": "object",
                             "properties": {
+                              "expression": {
+                                "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                                "type": "string"
+                              },
                               "selector": {
                                 "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                 "type": "string"
@@ -1892,6 +2066,10 @@
                             "additionalProperties": {
                               "type": "object",
                               "properties": {
+                                "expression": {
+                                  "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                                  "type": "string"
+                                },
                                 "selector": {
                                   "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
@@ -1917,6 +2095,10 @@
                         "description": "Plain text content",
                         "type": "object",
                         "properties": {
+                          "expression": {
+                            "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                            "type": "string"
+                          },
                           "selector": {
                             "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                             "type": "string"
@@ -1966,6 +2148,10 @@
                               "description": "Reference to a named set of pattern expressions",
                               "type": "string"
                             },
+                            "predicate": {
+                              "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                              "type": "string"
+                            },
                             "selector": {
                               "description": "Path selector to fetch content from the authorization JSON (e.g. 'request.method').\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nAuthorino custom JSON path modifiers are also supported.",
                               "type": "string"
@@ -1991,6 +2177,10 @@
                             "additionalProperties": {
                               "type": "object",
                               "properties": {
+                                "expression": {
+                                  "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                                  "type": "string"
+                                },
                                 "selector": {
                                   "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                                   "type": "string"
@@ -2055,6 +2245,10 @@
                   "description": "HTTP response body to override the default denial body.",
                   "type": "object",
                   "properties": {
+                    "expression": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
@@ -2078,6 +2272,10 @@
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -2093,6 +2291,10 @@
                   "description": "HTTP message to override the default denial message.",
                   "type": "object",
                   "properties": {
+                    "expression": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
@@ -2113,6 +2315,10 @@
                   "description": "HTTP response body to override the default denial body.",
                   "type": "object",
                   "properties": {
+                    "expression": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
@@ -2136,6 +2342,10 @@
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
+                      "expression": {
+                        "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                        "type": "string"
+                      },
                       "selector": {
                         "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                         "type": "string"
@@ -2151,6 +2361,10 @@
                   "description": "HTTP message to override the default denial message.",
                   "type": "object",
                   "properties": {
+                    "expression": {
+                      "description": "A Common Expression Language (CEL) expression that evaluates to a value.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
+                      "type": "string"
+                    },
                     "selector": {
                       "description": "Simple path selector to fetch content from the authorization JSON (e.g. 'request.method') or a string template with variables that resolve to patterns (e.g. \"Hello, {auth.identity.name}!\").\nAny pattern supported by https://pkg.go.dev/github.com/tidwall/gjson can be used.\nThe following Authorino custom modifiers are supported: @extract:{sep:\" \",pos:0}, @replace{old:\"\",new:\"\"}, @case:upper|lower, @base64:encode|decode and @strip.",
                       "type": "string"
@@ -2198,6 +2412,10 @@
               },
               "patternRef": {
                 "description": "Reference to a named set of pattern expressions",
+                "type": "string"
+              },
+              "predicate": {
+                "description": "A Common Expression Language (CEL) expression that evaluates to a boolean.\nString expressions are supported (https://pkg.go.dev/github.com/google/cel-go/ext#Strings).",
                 "type": "string"
               },
               "selector": {
@@ -2316,7 +2534,7 @@
     {
       "group": "authorino.kuadrant.io",
       "kind": "AuthConfig",
-      "version": "v1beta2"
+      "version": "v1beta3"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/authconfiglist.json
+++ b/class_generator/schema/authconfiglist.json
@@ -13,7 +13,7 @@
       "description": "List of authconfigs. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta2.AuthConfig"
+        "$ref": "_definitions.json#/definitions/io.kuadrant.authorino.v1beta3.AuthConfig"
       }
     },
     "kind": {
@@ -29,7 +29,7 @@
     {
       "group": "authorino.kuadrant.io",
       "kind": "AuthConfigList",
-      "version": "v1beta2"
+      "version": "v1beta3"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/authorizationpolicy.json
+++ b/class_generator/schema/authorizationpolicy.json
@@ -18,7 +18,7 @@
       "type": "object",
       "properties": {
         "action": {
-          "description": "Optional.",
+          "description": "Optional.\n\nValid Options: ALLOW, DENY, AUDIT, CUSTOM",
           "type": "string",
           "enum": [
             "ALLOW",
@@ -239,35 +239,130 @@
             "matchLabels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.",
               "type": "object",
+              "maxProperties": 4096,
               "additionalProperties": {
-                "type": "string"
-              }
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard not allowed in label value match",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "wildcard not allowed in label key match",
+                  "rule": "self.all(key, !key.contains('*'))"
+                },
+                {
+                  "message": "key must not be empty",
+                  "rule": "self.all(key, key.size() != 0)"
+                }
+              ]
             }
           }
         },
         "targetRef": {
-          "description": "Optional.",
           "type": "object",
+          "required": [
+            "kind",
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "group is the group of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
             },
             "kind": {
               "description": "kind is kind of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
             },
             "name": {
               "description": "name is the name of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "minLength": 1
             },
             "namespace": {
               "description": "namespace is the namespace of the referent.",
-              "type": "string"
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "cross namespace referencing is not currently supported",
+                  "rule": "self.size() == 0"
+                }
+              ]
             }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+              "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+            }
+          ]
+        },
+        "targetRefs": {
+          "description": "Optional.",
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "name"
+            ],
+            "properties": {
+              "group": {
+                "description": "group is the group of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+              },
+              "kind": {
+                "description": "kind is kind of the target resource.",
+                "type": "string",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+              },
+              "name": {
+                "description": "name is the name of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "minLength": 1
+              },
+              "namespace": {
+                "description": "namespace is the namespace of the referent.",
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "cross namespace referencing is not currently supported",
+                    "rule": "self.size() == 0"
+                  }
+                ]
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+                "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+              }
+            ]
           }
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "only one of targetRefs or selector can be set",
+          "rule": "(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/backup.json
+++ b/class_generator/schema/backup.json
@@ -1,5 +1,5 @@
 {
-  "description": "Backup is a Velero resource that represents the capture of Kubernetes\ncluster state at a point in time (API objects and associated volume state).",
+  "description": "Backup is the Schema for the backups API. It is used to define backup jobs and its storage.",
   "type": "object",
   "properties": {
     "apiVersion": {
@@ -15,71 +15,380 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "BackupSpec defines the specification for a Velero backup.",
+      "description": "BackupSpec defines the desired state of Backup",
       "type": "object",
+      "required": [
+        "mariaDbRef",
+        "storage"
+      ],
       "properties": {
-        "csiSnapshotTimeout": {
-          "description": "CSISnapshotTimeout specifies the time used to wait for CSI VolumeSnapshot status turns to\nReadyToUse during creation, before returning error as timeout.\nThe default value is 10 minute.",
-          "type": "string"
-        },
-        "datamover": {
-          "description": "DataMover specifies the data mover to be used by the backup.\nIf DataMover is \"\" or \"velero\", the built-in data mover will be used.",
-          "type": "string"
-        },
-        "defaultVolumesToFsBackup": {
-          "description": "DefaultVolumesToFsBackup specifies whether pod volume file system backup should be used\nfor all volumes by default."
-        },
-        "defaultVolumesToRestic": {
-          "description": "DefaultVolumesToRestic specifies whether restic should be used to take a\nbackup of all pod volumes by default.\n\n\nDeprecated: this field is no longer used and will be removed entirely in future. Use DefaultVolumesToFsBackup instead."
-        },
-        "excludedClusterScopedResources": {
-          "description": "ExcludedClusterScopedResources is a slice of cluster-scoped\nresource type names to exclude from the backup.\nIf set to \"*\", all cluster-scoped resource types are excluded.\nThe default value is empty."
-        },
-        "excludedNamespaceScopedResources": {
-          "description": "ExcludedNamespaceScopedResources is a slice of namespace-scoped\nresource type names to exclude from the backup.\nIf set to \"*\", all namespace-scoped resource types are excluded.\nThe default value is empty."
-        },
-        "excludedNamespaces": {
-          "description": "ExcludedNamespaces contains a list of namespaces that are not\nincluded in the backup."
-        },
-        "excludedResources": {
-          "description": "ExcludedResources is a slice of resource names that are not\nincluded in the backup."
-        },
-        "hooks": {
-          "description": "Hooks represent custom behaviors that should be executed at different phases of the backup.",
+        "affinity": {
+          "description": "Affinity to be used in the Pod.",
           "type": "object",
           "properties": {
-            "resources": {
-              "description": "Resources are hooks that should be executed when backing up individual instances of a resource."
+            "antiAffinityEnabled": {
+              "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
+              "type": "boolean"
+            },
+            "nodeAffinity": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+              "type": "object",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                    "type": "object",
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "properties": {
+                      "preference": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "weight": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                  "type": "object",
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "type": "array",
+                      "items": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                }
+              }
+            },
+            "podAntiAffinity": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
+              "type": "object",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#weightedpodaffinityterm-v1-core.",
+                    "type": "object",
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podaffinityterm-v1-core.",
+                        "type": "object",
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "type": "array",
+                                "items": {
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "weight": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podaffinityterm-v1-core.",
+                    "type": "object",
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "topologyKey": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                }
+              }
             }
           }
         },
-        "includeClusterResources": {
-          "description": "IncludeClusterResources specifies whether cluster-scoped resources\nshould be included for consideration in the backup."
+        "args": {
+          "description": "Args to be used in the Container.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
-        "includedClusterScopedResources": {
-          "description": "IncludedClusterScopedResources is a slice of cluster-scoped\nresource type names to include in the backup.\nIf set to \"*\", all cluster-scoped resource types are included.\nThe default value is empty, which means only related\ncluster-scoped resources are included."
+        "backoffLimit": {
+          "description": "BackoffLimit defines the maximum number of attempts to successfully take a Backup.",
+          "type": "integer",
+          "format": "int32"
         },
-        "includedNamespaceScopedResources": {
-          "description": "IncludedNamespaceScopedResources is a slice of namespace-scoped\nresource type names to include in the backup.\nThe default value is \"*\"."
+        "compression": {
+          "description": "Compression algorithm to be used in the Backup.",
+          "type": "string",
+          "enum": [
+            "none",
+            "bzip2",
+            "gzip"
+          ]
         },
-        "includedNamespaces": {
-          "description": "IncludedNamespaces is a slice of namespace names to include objects\nfrom. If empty, all namespaces are included."
+        "databases": {
+          "description": "Databases defines the logical databases to be backed up. If not provided, all databases are backed up.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
-        "includedResources": {
-          "description": "IncludedResources is a slice of resource names to include\nin the backup. If empty, all resources are included."
+        "failedJobsHistoryLimit": {
+          "description": "FailedJobsHistoryLimit defines the maximum number of failed Jobs to be displayed.",
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0
         },
-        "itemOperationTimeout": {
-          "description": "ItemOperationTimeout specifies the time used to wait for asynchronous BackupItemAction operations\nThe default value is 4 hour.",
-          "type": "string"
+        "ignoreGlobalPriv": {
+          "description": "IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.\nIf not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false.\nSee: https://github.com/mariadb-operator/mariadb-operator/issues/556",
+          "type": "boolean"
         },
-        "labelSelector": {
-          "description": "LabelSelector is a metav1.LabelSelector to filter with\nwhen adding individual objects to the backup. If empty\nor nil, all objects are included. Optional.",
-          "x-kubernetes-map-type": "atomic"
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
+          "type": "array",
+          "items": {
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
         },
-        "metadata": {
+        "inheritMetadata": {
+          "description": "InheritMetadata defines the metadata to be inherited by children resources.",
           "type": "object",
           "properties": {
+            "annotations": {
+              "description": "Annotations to be added to children resources.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
             "labels": {
+              "description": "Labels to be added to children resources.",
               "type": "object",
               "additionalProperties": {
                 "type": "string"
@@ -87,162 +396,814 @@
             }
           }
         },
-        "orLabelSelectors": {
-          "description": "OrLabelSelectors is list of metav1.LabelSelector to filter with\nwhen adding individual objects to the backup. If multiple provided\nthey will be joined by the OR operator. LabelSelector as well as\nOrLabelSelectors cannot co-exist in backup request, only one of them\ncan be used."
+        "logLevel": {
+          "description": "LogLevel to be used n the Backup Job. It defaults to 'info'.",
+          "type": "string"
         },
-        "orderedResources": {
-          "description": "OrderedResources specifies the backup order of resources of specific Kind.\nThe map key is the resource name and value is a list of object names separated by commas.\nEach resource name has format \"namespace/objectname\".  For cluster resources, simply use \"objectname\".",
+        "mariaDbRef": {
+          "description": "MariaDBRef is a reference to a MariaDB object.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "waitForIt": {
+              "description": "WaitForIt indicates whether the controller using this reference should wait for MariaDB to be ready.",
+              "type": "boolean"
+            }
+          }
+        },
+        "maxRetention": {
+          "description": "MaxRetention defines the retention policy for backups. Old backups will be cleaned up by the Backup Job.\nIt defaults to 30 days.",
+          "type": "string"
+        },
+        "nodeSelector": {
+          "description": "NodeSelector to be used in the Pod.",
+          "type": "object",
           "additionalProperties": {
             "type": "string"
           }
         },
-        "resourcePolicy": {
-          "description": "ResourcePolicy specifies the referenced resource policies that backup should follow",
+        "podMetadata": {
+          "description": "PodMetadata defines extra metadata for the Pod.",
+          "type": "object",
+          "properties": {
+            "annotations": {
+              "description": "Annotations to be added to children resources.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "labels": {
+              "description": "Labels to be added to children resources.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "podSecurityContext": {
+          "description": "SecurityContext holds pod-level security attributes and common container settings.",
+          "type": "object",
+          "properties": {
+            "appArmorProfile": {
+              "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              }
+            },
+            "fsGroup": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "fsGroupChangePolicy": {
+              "description": "PodFSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume\nwhen volume is mounted.",
+              "type": "string"
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "seLinuxOptions": {
+              "description": "SELinuxOptions are the labels to be applied to the container",
+              "type": "object",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              }
+            },
+            "seccompProfile": {
+              "description": "SeccompProfile defines a pod/container's seccomp profile settings.\nOnly one profile source may be set.",
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              }
+            },
+            "supplementalGroups": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "x-kubernetes-list-type": "atomic"
+            }
+          }
+        },
+        "priorityClassName": {
+          "description": "PriorityClassName to be used in the Pod.",
+          "type": "string"
+        },
+        "resources": {
+          "description": "Resouces describes the compute resource requirements.",
+          "type": "object",
+          "properties": {
+            "limits": {
+              "description": "ResourceList is a set of (resource name, quantity) pairs.",
+              "type": "object",
+              "additionalProperties": {
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              }
+            },
+            "requests": {
+              "description": "ResourceList is a set of (resource name, quantity) pairs.",
+              "type": "object",
+              "additionalProperties": {
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              }
+            }
+          }
+        },
+        "restartPolicy": {
+          "description": "RestartPolicy to be added to the Backup Pod.",
+          "type": "string",
+          "enum": [
+            "Always",
+            "OnFailure",
+            "Never"
+          ]
+        },
+        "schedule": {
+          "description": "Schedule defines when the Backup will be taken.",
           "type": "object",
           "required": [
-            "kind",
-            "name"
+            "cron"
           ],
           "properties": {
-            "apiGroup": {
-              "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+            "cron": {
+              "description": "Cron is a cron expression that defines the schedule.",
               "type": "string"
             },
-            "kind": {
-              "description": "Kind is the type of resource being referenced",
-              "type": "string"
-            },
-            "name": {
-              "description": "Name is the name of resource being referenced",
-              "type": "string"
+            "suspend": {
+              "description": "Suspend defines whether the schedule is active or not.",
+              "type": "boolean"
             }
-          },
-          "x-kubernetes-map-type": "atomic"
+          }
         },
-        "snapshotMoveData": {
-          "description": "SnapshotMoveData specifies whether snapshot data should be moved"
+        "securityContext": {
+          "description": "SecurityContext holds security configuration that will be applied to a container.",
+          "type": "object",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "description": "Adds and removes POSIX capabilities from running containers.",
+              "type": "object",
+              "properties": {
+                "add": {
+                  "description": "Added capabilities",
+                  "type": "array",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "drop": {
+                  "description": "Removed capabilities",
+                  "type": "array",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                }
+              }
+            },
+            "privileged": {
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
         },
-        "snapshotVolumes": {
-          "description": "SnapshotVolumes specifies whether to take snapshots\nof any PV's referenced in the set of objects included\nin the Backup."
-        },
-        "storageLocation": {
-          "description": "StorageLocation is a string containing the name of a BackupStorageLocation where the backup should be stored.",
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the ServiceAccount to be used by the Pods.",
           "type": "string"
         },
-        "ttl": {
-          "description": "TTL is a time.Duration-parseable string describing how long\nthe Backup should be retained for.",
+        "stagingStorage": {
+          "description": "StagingStorage defines the temporary storage used to keep external backups (i.e. S3) while they are being processed.\nIt defaults to an emptyDir volume, meaning that the backups will be temporarily stored in the node where the Backup Job is scheduled.\nThe staging area gets cleaned up after each backup is completed, consider this for sizing it appropriately.",
+          "type": "object",
+          "properties": {
+            "persistentVolumeClaim": {
+              "description": "PersistentVolumeClaim is a Kubernetes PVC specification.",
+              "type": "object",
+              "properties": {
+                "accessModes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "resources": {
+                  "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+                  "type": "object",
+                  "properties": {
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "selector": {
+                  "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                  "type": "object",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                      "type": "array",
+                      "items": {
+                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "matchLabels": {
+                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "storageClassName": {
+                  "type": "string"
+                }
+              }
+            },
+            "volume": {
+              "description": "Volume is a Kubernetes volume specification.",
+              "type": "object",
+              "properties": {
+                "csi": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#csivolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "driver"
+                  ],
+                  "properties": {
+                    "driver": {
+                      "type": "string"
+                    },
+                    "fsType": {
+                      "type": "string"
+                    },
+                    "nodePublishSecretRef": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "volumeAttributes": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "emptyDir": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#emptydirvolumesource-v1-core.",
+                  "type": "object",
+                  "properties": {
+                    "medium": {
+                      "description": "StorageMedium defines ways that storage can be allocated to a volume.",
+                      "type": "string"
+                    },
+                    "sizeLimit": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  }
+                },
+                "nfs": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nfsvolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "server"
+                  ],
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "server": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "persistentVolumeClaim": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#persistentvolumeclaimvolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "claimName"
+                  ],
+                  "properties": {
+                    "claimName": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "storage": {
+          "description": "Storage defines the final storage for backups.",
+          "type": "object",
+          "properties": {
+            "persistentVolumeClaim": {
+              "description": "PersistentVolumeClaim is a Kubernetes PVC specification.",
+              "type": "object",
+              "properties": {
+                "accessModes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "resources": {
+                  "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+                  "type": "object",
+                  "properties": {
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "selector": {
+                  "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                  "type": "object",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                      "type": "array",
+                      "items": {
+                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "matchLabels": {
+                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "storageClassName": {
+                  "type": "string"
+                }
+              }
+            },
+            "s3": {
+              "description": "S3 defines the configuration to store backups in a S3 compatible storage.",
+              "type": "object",
+              "required": [
+                "bucket",
+                "endpoint"
+              ],
+              "properties": {
+                "accessKeyIdSecretKeyRef": {
+                  "description": "AccessKeyIdSecretKeyRef is a reference to a Secret key containing the S3 access key id.",
+                  "type": "object",
+                  "required": [
+                    "key"
+                  ],
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "bucket": {
+                  "description": "Bucket is the name Name of the bucket to store backups.",
+                  "type": "string"
+                },
+                "endpoint": {
+                  "description": "Endpoint is the S3 API endpoint without scheme.",
+                  "type": "string"
+                },
+                "prefix": {
+                  "description": "Prefix indicates a folder/subfolder in the bucket. For example: mariadb/ or mariadb/backups. A trailing slash '/' is added if not provided.",
+                  "type": "string"
+                },
+                "region": {
+                  "description": "Region is the S3 region name to use.",
+                  "type": "string"
+                },
+                "secretAccessKeySecretKeyRef": {
+                  "description": "AccessKeyIdSecretKeyRef is a reference to a Secret key containing the S3 secret key.",
+                  "type": "object",
+                  "required": [
+                    "key"
+                  ],
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "sessionTokenSecretKeyRef": {
+                  "description": "SessionTokenSecretKeyRef is a reference to a Secret key containing the S3 session token.",
+                  "type": "object",
+                  "required": [
+                    "key"
+                  ],
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "tls": {
+                  "description": "TLS provides the configuration required to establish TLS connections with S3.",
+                  "type": "object",
+                  "properties": {
+                    "caSecretKeyRef": {
+                      "description": "CASecretKeyRef is a reference to a Secret key containing a CA bundle in PEM format used to establish TLS connections with S3.\nBy default, the system trust chain will be used, but you can use this field to add more CAs to the bundle.",
+                      "type": "object",
+                      "required": [
+                        "key"
+                      ],
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "enabled": {
+                      "description": "Enabled is a flag to enable TLS.",
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            },
+            "volume": {
+              "description": "Volume is a Kubernetes volume specification.",
+              "type": "object",
+              "properties": {
+                "csi": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#csivolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "driver"
+                  ],
+                  "properties": {
+                    "driver": {
+                      "type": "string"
+                    },
+                    "fsType": {
+                      "type": "string"
+                    },
+                    "nodePublishSecretRef": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "volumeAttributes": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "emptyDir": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#emptydirvolumesource-v1-core.",
+                  "type": "object",
+                  "properties": {
+                    "medium": {
+                      "description": "StorageMedium defines ways that storage can be allocated to a volume.",
+                      "type": "string"
+                    },
+                    "sizeLimit": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  }
+                },
+                "nfs": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nfsvolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "server"
+                  ],
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "server": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "persistentVolumeClaim": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#persistentvolumeclaimvolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "claimName"
+                  ],
+                  "properties": {
+                    "claimName": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "successfulJobsHistoryLimit": {
+          "description": "SuccessfulJobsHistoryLimit defines the maximum number of successful Jobs to be displayed.",
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0
+        },
+        "timeZone": {
+          "description": "TimeZone defines the timezone associated with the cron expression.",
           "type": "string"
         },
-        "uploaderConfig": {
-          "description": "UploaderConfig specifies the configuration for the uploader."
-        },
-        "volumeSnapshotLocations": {
-          "description": "VolumeSnapshotLocations is a list containing names of VolumeSnapshotLocations associated with this backup.",
+        "tolerations": {
+          "description": "Tolerations to be used in the Pod.",
           "type": "array",
           "items": {
-            "type": "string"
+            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+            "type": "object",
+            "properties": {
+              "effect": {
+                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                "type": "string"
+              },
+              "operator": {
+                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                "type": "integer",
+                "format": "int64"
+              },
+              "value": {
+                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                "type": "string"
+              }
+            }
           }
         }
       }
     },
     "status": {
-      "description": "BackupStatus captures the current status of a Velero backup.",
+      "description": "BackupStatus defines the observed state of Backup",
       "type": "object",
       "properties": {
-        "backupItemOperationsAttempted": {
-          "description": "BackupItemOperationsAttempted is the total number of attempted\nasync BackupItemAction operations for this backup.",
-          "type": "integer"
-        },
-        "backupItemOperationsCompleted": {
-          "description": "BackupItemOperationsCompleted is the total number of successfully completed\nasync BackupItemAction operations for this backup.",
-          "type": "integer"
-        },
-        "backupItemOperationsFailed": {
-          "description": "BackupItemOperationsFailed is the total number of async\nBackupItemAction operations for this backup which ended with an error.",
-          "type": "integer"
-        },
-        "completionTimestamp": {
-          "description": "CompletionTimestamp records the time a backup was completed.\nCompletion time is recorded even on failed backups.\nCompletion time is recorded before uploading the backup object.\nThe server's time is used for CompletionTimestamps",
-          "format": "date-time"
-        },
-        "csiVolumeSnapshotsAttempted": {
-          "description": "CSIVolumeSnapshotsAttempted is the total number of attempted\nCSI VolumeSnapshots for this backup.",
-          "type": "integer"
-        },
-        "csiVolumeSnapshotsCompleted": {
-          "description": "CSIVolumeSnapshotsCompleted is the total number of successfully\ncompleted CSI VolumeSnapshots for this backup.",
-          "type": "integer"
-        },
-        "errors": {
-          "description": "Errors is a count of all error messages that were generated during\nexecution of the backup.  The actual errors are in the backup's log\nfile in object storage.",
-          "type": "integer"
-        },
-        "expiration": {
-          "description": "Expiration is when this Backup is eligible for garbage-collection.",
-          "format": "date-time"
-        },
-        "failureReason": {
-          "description": "FailureReason is an error that caused the entire backup to fail.",
-          "type": "string"
-        },
-        "formatVersion": {
-          "description": "FormatVersion is the backup format version, including major, minor, and patch version.",
-          "type": "string"
-        },
-        "hookStatus": {
-          "description": "HookStatus contains information about the status of the hooks."
-        },
-        "phase": {
-          "description": "Phase is the current state of the Backup.",
-          "type": "string",
-          "enum": [
-            "New",
-            "FailedValidation",
-            "InProgress",
-            "WaitingForPluginOperations",
-            "WaitingForPluginOperationsPartiallyFailed",
-            "Finalizing",
-            "FinalizingPartiallyFailed",
-            "Completed",
-            "PartiallyFailed",
-            "Failed",
-            "Deleting"
-          ]
-        },
-        "progress": {
-          "description": "Progress contains information about the backup's execution progress. Note\nthat this information is best-effort only -- if Velero fails to update it\nduring a backup for any reason, it may be inaccurate/stale."
-        },
-        "startTimestamp": {
-          "description": "StartTimestamp records the time a backup was started.\nSeparate from CreationTimestamp, since that value changes\non restores.\nThe server's time is used for StartTimestamps",
-          "format": "date-time"
-        },
-        "validationErrors": {
-          "description": "ValidationErrors is a slice of all validation errors (if\napplicable)."
-        },
-        "version": {
-          "description": "Version is the backup format major version.\nDeprecated: Please see FormatVersion",
-          "type": "integer"
-        },
-        "volumeSnapshotsAttempted": {
-          "description": "VolumeSnapshotsAttempted is the total number of attempted\nvolume snapshots for this backup.",
-          "type": "integer"
-        },
-        "volumeSnapshotsCompleted": {
-          "description": "VolumeSnapshotsCompleted is the total number of successfully\ncompleted volume snapshots for this backup.",
-          "type": "integer"
-        },
-        "warnings": {
-          "description": "Warnings is a count of all warning messages that were generated during\nexecution of the backup. The actual warnings are in the backup's log\nfile in object storage.",
-          "type": "integer"
+        "conditions": {
+          "description": "Conditions for the Backup object.",
+          "type": "array",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "type": "object",
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "type": "string",
+                "maxLength": 32768
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "type": "string",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+              }
+            }
+          }
         }
       }
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "velero.io",
+      "group": "k8s.mariadb.com",
       "kind": "Backup",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/backuplist.json
+++ b/class_generator/schema/backuplist.json
@@ -13,7 +13,7 @@
       "description": "List of backups. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.velero.v1.Backup"
+        "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Backup"
       }
     },
     "kind": {
@@ -27,9 +27,9 @@
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "velero.io",
+      "group": "k8s.mariadb.com",
       "kind": "BackupList",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/clusterinterceptor.json
+++ b/class_generator/schema/clusterinterceptor.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/clusterinterceptorlist.json
+++ b/class_generator/schema/clusterinterceptorlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/clustertask.json
+++ b/class_generator/schema/clustertask.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/clustertasklist.json
+++ b/class_generator/schema/clustertasklist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/clustertriggerbinding.json
+++ b/class_generator/schema/clustertriggerbinding.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/clustertriggerbindinglist.json
+++ b/class_generator/schema/clustertriggerbindinglist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/connection.json
+++ b/class_generator/schema/connection.json
@@ -18,7 +18,6 @@
       "description": "ConnectionSpec defines the desired state of Connection",
       "type": "object",
       "required": [
-        "passwordSecretKeyRef",
         "username"
       ],
       "properties": {
@@ -80,7 +79,7 @@
           }
         },
         "passwordSecretKeyRef": {
-          "description": "PasswordSecretKeyRef is a reference to the password to use for configuring the Connection.\nIf the referred Secret is labeled with \"k8s.mariadb.com/watch\", updates may be performed to the Secret in order to update the password.",
+          "description": "PasswordSecretKeyRef is a reference to the password to use for configuring the Connection.\nEither passwordSecretKeyRef or tlsClientCertSecretRef must be provided as client credentials.\nIf the referred Secret is labeled with \"k8s.mariadb.com/watch\", updates may be performed to the Secret in order to update the password.",
           "type": "object",
           "required": [
             "key"
@@ -162,6 +161,15 @@
           "description": "ServiceName to be used in the Connection.",
           "type": "string"
         },
+        "tlsClientCertSecretRef": {
+          "description": "TLSClientCertSecretRef is a reference to a Kubernetes TLS Secret used as authentication when checking the connection health.\nEither passwordSecretKeyRef or tlsClientCertSecretRef must be provided as client credentials.\nIf not provided, the client certificate provided by the referred MariaDB is used if TLS is enabled.\nIf the referred Secret is labeled with \"k8s.mariadb.com/watch\", updates may be performed to the Secret in order to update the client certificate.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        },
         "username": {
           "description": "Username to use for configuring the Connection.",
           "type": "string"
@@ -237,5 +245,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/connectionlist.json
+++ b/class_generator/schema/connectionlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/customrun.json
+++ b/class_generator/schema/customrun.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/customrunlist.json
+++ b/class_generator/schema/customrunlist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/database.json
+++ b/class_generator/schema/database.json
@@ -1,10 +1,6 @@
 {
-  "description": "Database is the Schema for the databases API",
+  "description": "Database is the Schema for the databases API. It is used to define a logical database as if you were running a 'CREATE DATABASE' statement.",
   "type": "object",
-  "required": [
-    "metadata",
-    "spec"
-  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -19,224 +15,126 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "Specification of the desired Database.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "description": "DatabaseSpec defines the desired state of Database",
       "type": "object",
       "required": [
-        "cluster",
-        "name",
-        "owner"
+        "mariaDbRef"
       ],
       "properties": {
-        "allowConnections": {
-          "description": "Maps to the `ALLOW_CONNECTIONS` parameter of `CREATE DATABASE` and\n`ALTER DATABASE`. If false then no one can connect to this database.",
-          "type": "boolean"
+        "characterSet": {
+          "description": "CharacterSet to use in the Database.",
+          "type": "string"
         },
-        "builtinLocale": {
-          "description": "Maps to the `BUILTIN_LOCALE` parameter of `CREATE DATABASE`. This\nsetting cannot be changed. Specifies the locale name when the\nbuiltin provider is used. This option requires `localeProvider` to\nbe set to `builtin`. Available from PostgreSQL 17.",
+        "cleanupPolicy": {
+          "description": "CleanupPolicy defines the behavior for cleaning up a SQL resource.",
           "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "builtinLocale is immutable",
-              "rule": "self == oldSelf"
-            }
+          "enum": [
+            "Skip",
+            "Delete"
           ]
         },
-        "cluster": {
-          "description": "The name of the PostgreSQL cluster hosting the database.",
+        "collate": {
+          "description": "Collate to use in the Database.",
+          "type": "string"
+        },
+        "mariaDbRef": {
+          "description": "MariaDBRef is a reference to a MariaDB object.",
           "type": "object",
           "properties": {
             "name": {
-              "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
               "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "waitForIt": {
+              "description": "WaitForIt indicates whether the controller using this reference should wait for MariaDB to be ready.",
+              "type": "boolean"
             }
-          },
-          "x-kubernetes-map-type": "atomic"
-        },
-        "collationVersion": {
-          "description": "Maps to the `COLLATION_VERSION` parameter of `CREATE DATABASE`. This\nsetting cannot be changed.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "collationVersion is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "connectionLimit": {
-          "description": "Maps to the `CONNECTION LIMIT` clause of `CREATE DATABASE` and\n`ALTER DATABASE`. How many concurrent connections can be made to\nthis database. -1 (the default) means no limit.",
-          "type": "integer"
-        },
-        "databaseReclaimPolicy": {
-          "description": "The policy for end-of-life maintenance of this database.",
-          "type": "string",
-          "enum": [
-            "delete",
-            "retain"
-          ]
-        },
-        "encoding": {
-          "description": "Maps to the `ENCODING` parameter of `CREATE DATABASE`. This setting\ncannot be changed. Character set encoding to use in the database.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "encoding is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "ensure": {
-          "description": "Ensure the PostgreSQL database is `present` or `absent` - defaults to \"present\".",
-          "type": "string",
-          "enum": [
-            "present",
-            "absent"
-          ]
-        },
-        "icuLocale": {
-          "description": "Maps to the `ICU_LOCALE` parameter of `CREATE DATABASE`. This\nsetting cannot be changed. Specifies the ICU locale when the ICU\nprovider is used. This option requires `localeProvider` to be set to\n`icu`. Available from PostgreSQL 15.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "icuLocale is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "icuRules": {
-          "description": "Maps to the `ICU_RULES` parameter of `CREATE DATABASE`. This setting\ncannot be changed. Specifies additional collation rules to customize\nthe behavior of the default collation. This option requires\n`localeProvider` to be set to `icu`. Available from PostgreSQL 16.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "icuRules is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "isTemplate": {
-          "description": "Maps to the `IS_TEMPLATE` parameter of `CREATE DATABASE` and `ALTER\nDATABASE`. If true, this database is considered a template and can\nbe cloned by any user with `CREATEDB` privileges.",
-          "type": "boolean"
-        },
-        "locale": {
-          "description": "Maps to the `LOCALE` parameter of `CREATE DATABASE`. This setting\ncannot be changed. Sets the default collation order and character\nclassification in the new database.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "locale is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "localeCType": {
-          "description": "Maps to the `LC_CTYPE` parameter of `CREATE DATABASE`. This setting\ncannot be changed.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "localeCType is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "localeCollate": {
-          "description": "Maps to the `LC_COLLATE` parameter of `CREATE DATABASE`. This\nsetting cannot be changed.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "localeCollate is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
-        },
-        "localeProvider": {
-          "description": "Maps to the `LOCALE_PROVIDER` parameter of `CREATE DATABASE`. This\nsetting cannot be changed. This option sets the locale provider for\ndatabases created in the new cluster. Available from PostgreSQL 16.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "localeProvider is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
+          }
         },
         "name": {
-          "description": "The name of the database to create inside PostgreSQL. This setting cannot be changed.",
+          "description": "Name overrides the default Database name provided by metadata.name.",
           "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "name is immutable",
-              "rule": "self == oldSelf"
-            },
-            {
-              "message": "the name postgres is reserved",
-              "rule": "self != 'postgres'"
-            },
-            {
-              "message": "the name template0 is reserved",
-              "rule": "self != 'template0'"
-            },
-            {
-              "message": "the name template1 is reserved",
-              "rule": "self != 'template1'"
-            }
-          ]
+          "maxLength": 80
         },
-        "owner": {
-          "description": "Maps to the `OWNER` parameter of `CREATE DATABASE`.\nMaps to the `OWNER TO` command of `ALTER DATABASE`.\nThe role name of the user who owns the database inside PostgreSQL.",
+        "requeueInterval": {
+          "description": "RequeueInterval is used to perform requeue reconciliations.",
           "type": "string"
         },
-        "tablespace": {
-          "description": "Maps to the `TABLESPACE` parameter of `CREATE DATABASE`.\nMaps to the `SET TABLESPACE` command of `ALTER DATABASE`.\nThe name of the tablespace (in PostgreSQL) that will be associated\nwith the new database. This tablespace will be the default\ntablespace used for objects created in this database.",
+        "retryInterval": {
+          "description": "RetryInterval is the interval used to perform retries.",
           "type": "string"
-        },
-        "template": {
-          "description": "Maps to the `TEMPLATE` parameter of `CREATE DATABASE`. This setting\ncannot be changed. The name of the template from which to create\nthis database.",
-          "type": "string",
-          "x-kubernetes-validations": [
-            {
-              "message": "template is immutable",
-              "rule": "self == oldSelf"
-            }
-          ]
         }
-      },
-      "x-kubernetes-validations": [
-        {
-          "message": "builtinLocale is only available when localeProvider is set to `builtin`",
-          "rule": "!has(self.builtinLocale) || self.localeProvider == 'builtin'"
-        },
-        {
-          "message": "icuLocale is only available when localeProvider is set to `icu`",
-          "rule": "!has(self.icuLocale) || self.localeProvider == 'icu'"
-        },
-        {
-          "message": "icuRules is only available when localeProvider is set to `icu`",
-          "rule": "!has(self.icuRules) || self.localeProvider == 'icu'"
-        }
-      ]
+      }
     },
     "status": {
-      "description": "Most recently observed status of the Database. This data may not be up to\ndate. Populated by the system. Read-only.\nMore info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+      "description": "DatabaseStatus defines the observed state of Database",
       "type": "object",
       "properties": {
-        "applied": {
-          "description": "Applied is true if the database was reconciled correctly",
-          "type": "boolean"
-        },
-        "message": {
-          "description": "Message is the reconciliation output message",
-          "type": "string"
-        },
-        "observedGeneration": {
-          "description": "A sequence number representing the latest\ndesired state that was synchronized",
-          "type": "integer",
-          "format": "int64"
+        "conditions": {
+          "description": "Conditions for the Database object.",
+          "type": "array",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "type": "object",
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "type": "string",
+                "maxLength": 32768
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "type": "string",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+              }
+            }
+          }
         }
       }
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "postgresql.cnpg.noobaa.io",
+      "group": "k8s.mariadb.com",
       "kind": "Database",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/databaselist.json
+++ b/class_generator/schema/databaselist.json
@@ -13,7 +13,7 @@
       "description": "List of databases. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.noobaa.cnpg.postgresql.v1.Database"
+        "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Database"
       }
     },
     "kind": {
@@ -27,9 +27,9 @@
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "postgresql.cnpg.noobaa.io",
+      "group": "k8s.mariadb.com",
       "kind": "DatabaseList",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/datasciencecluster.json
+++ b/class_generator/schema/datasciencecluster.json
@@ -197,7 +197,6 @@
                 "defaultDeploymentMode": {
                   "description": "Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.\nThe value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve.\nThis field is optional. If no default deployment mode is specified, Kserve will use Serverless mode.",
                   "type": "string",
-                  "pattern": "^(Serverless|RawDeployment)$",
                   "enum": [
                     "Serverless",
                     "RawDeployment"
@@ -254,9 +253,8 @@
                   }
                 },
                 "rawDeploymentServiceConfig": {
-                  "description": "Configures the type of service that is created for InferenceServices using RawDeployment.\nThe values for RawDeploymentServiceConfig can be \"Headless\" or \"Headed\".\nHeadless : sets \"ServiceClusterIPNone = true\" in the 'inferenceservice-config' configmap for Kserve.\nHeaded : sets \"ServiceClusterIPNone = false\" in the 'inferenceservice-config' configmap for Kserve.",
+                  "description": "Configures the type of service that is created for InferenceServices using RawDeployment.\nThe values for RawDeploymentServiceConfig can be \"Headless\" (default value) or \"Headed\".\nHeadless: to set \"ServiceClusterIPNone = true\" in the 'inferenceservice-config' configmap for Kserve.\nHeaded: to set \"ServiceClusterIPNone = false\" in the 'inferenceservice-config' configmap for Kserve.",
                   "type": "string",
-                  "pattern": "^(Headless|Headed)$",
                   "enum": [
                     "Headless",
                     "Headed"
@@ -620,7 +618,13 @@
                   "description": "Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to \"rhods-notebooks\"",
                   "type": "string",
                   "maxLength": 63,
-                  "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
+                  "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "WorkbenchNamespace is immutable",
+                      "rule": "self == oldSelf"
+                    }
+                  ]
                 }
               }
             }

--- a/class_generator/schema/destinationrule.json
+++ b/class_generator/schema/destinationrule.json
@@ -63,7 +63,7 @@
                         "type": "object",
                         "properties": {
                           "h2UpgradePolicy": {
-                            "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.",
+                            "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.\n\nValid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE",
                             "type": "string",
                             "enum": [
                               "DEFAULT",
@@ -83,7 +83,18 @@
                           },
                           "idleTimeout": {
                             "description": "The idle timeout for upstream connection pool connections.",
-                            "type": "string"
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
+                          },
+                          "maxConcurrentStreams": {
+                            "description": "The maximum number of concurrent streams allowed for a peer on one HTTP/2 connection.",
+                            "type": "integer",
+                            "format": "int32"
                           },
                           "maxRequestsPerConnection": {
                             "description": "Maximum number of requests per connection to a backend.",
@@ -107,11 +118,27 @@
                         "properties": {
                           "connectTimeout": {
                             "description": "TCP connection timeout.",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
+                          },
+                          "idleTimeout": {
+                            "description": "The idle timeout for TCP connections.",
                             "type": "string"
                           },
                           "maxConnectionDuration": {
                             "description": "The maximum duration of a connection.",
-                            "type": "string"
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
                           },
                           "maxConnections": {
                             "description": "Maximum number of HTTP1 /TCP connections to a destination host.",
@@ -124,15 +151,29 @@
                             "properties": {
                               "interval": {
                                 "description": "The time duration between keep-alive probes.",
-                                "type": "string"
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "must be a valid duration greater than 1ms",
+                                    "rule": "duration(self) >= duration('1ms')"
+                                  }
+                                ]
                               },
                               "probes": {
                                 "description": "Maximum number of keepalive probes to send without response before deciding the connection is dead.",
-                                "type": "integer"
+                                "type": "integer",
+                                "maximum": 4294967295,
+                                "minimum": 0
                               },
                               "time": {
                                 "description": "The time duration a connection needs to be idle before keep-alive probes start being sent.",
-                                "type": "string"
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "must be a valid duration greater than 1ms",
+                                    "rule": "duration(self) >= duration('1ms')"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -182,13 +223,15 @@
                             "properties": {
                               "tableSize": {
                                 "description": "The table size for Maglev hashing.",
-                                "type": "integer"
+                                "type": "integer",
+                                "minimum": 0
                               }
                             }
                           },
                           "minimumRingSize": {
                             "description": "Deprecated.",
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 0
                           },
                           "ringHash": {
                             "description": "The ring/modulo hash load balancer implements consistent hashing to backend hosts.",
@@ -196,7 +239,8 @@
                             "properties": {
                               "minimumRingSize": {
                                 "description": "The minimum number of virtual nodes to use for the hash ring.",
-                                "type": "integer"
+                                "type": "integer",
+                                "minimum": 0
                               }
                             }
                           },
@@ -223,14 +267,16 @@
                                   "description": "Map of upstream localities to traffic distribution weights.",
                                   "type": "object",
                                   "additionalProperties": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "maximum": 4294967295,
+                                    "minimum": 0
                                   }
                                 }
                               }
                             }
                           },
                           "enabled": {
-                            "description": "enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety."
+                            "description": "Enable locality load balancing."
                           },
                           "failover": {
                             "description": "Optional: only one of distribute, failover or failoverPriority can be set.",
@@ -259,6 +305,7 @@
                         }
                       },
                       "simple": {
+                        "description": "\n\nValid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST",
                         "type": "string",
                         "enum": [
                           "UNSPECIFIED",
@@ -269,9 +316,43 @@
                           "LEAST_REQUEST"
                         ]
                       },
+                      "warmup": {
+                        "description": "Represents the warmup configuration of Service.",
+                        "type": "object",
+                        "required": [
+                          "duration"
+                        ],
+                        "properties": {
+                          "aggression": {
+                            "description": "This parameter controls the speed of traffic increase over the warmup duration.",
+                            "format": "double",
+                            "minimum": 1
+                          },
+                          "duration": {
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
+                          },
+                          "minimumPercent": {
+                            "format": "double",
+                            "maximum": 100,
+                            "minimum": 0
+                          }
+                        }
+                      },
                       "warmupDurationSecs": {
-                        "description": "Represents the warmup duration of Service.",
-                        "type": "string"
+                        "description": "Deprecated: use `warmup` instead.",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       }
                     }
                   },
@@ -280,24 +361,42 @@
                     "properties": {
                       "baseEjectionTime": {
                         "description": "Minimum ejection duration.",
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       },
                       "consecutive5xxErrors": {
-                        "description": "Number of 5xx errors before a host is ejected from the connection pool."
+                        "description": "Number of 5xx errors before a host is ejected from the connection pool.",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "consecutiveErrors": {
                         "type": "integer",
                         "format": "int32"
                       },
                       "consecutiveGatewayErrors": {
-                        "description": "Number of gateway errors before a host is ejected from the connection pool."
+                        "description": "Number of gateway errors before a host is ejected from the connection pool.",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "consecutiveLocalOriginFailures": {
-                        "description": "The number of consecutive locally originated failures before ejection occurs."
+                        "description": "The number of consecutive locally originated failures before ejection occurs.",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "interval": {
                         "description": "Time interval between ejection sweep analysis.",
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       },
                       "maxEjectionPercent": {
                         "description": "Maximum % of hosts in the load balancing pool for the upstream service that can be ejected.",
@@ -305,7 +404,7 @@
                         "format": "int32"
                       },
                       "minHealthPercent": {
-                        "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode.",
+                        "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least `minHealthPercent` hosts in healthy mode.",
                         "type": "integer",
                         "format": "int32"
                       },
@@ -318,6 +417,7 @@
                   "portLevelSettings": {
                     "description": "Traffic policies specific to individual ports.",
                     "type": "array",
+                    "maxItems": 4096,
                     "items": {
                       "type": "object",
                       "properties": {
@@ -329,7 +429,7 @@
                               "type": "object",
                               "properties": {
                                 "h2UpgradePolicy": {
-                                  "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.",
+                                  "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.\n\nValid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE",
                                   "type": "string",
                                   "enum": [
                                     "DEFAULT",
@@ -349,7 +449,18 @@
                                 },
                                 "idleTimeout": {
                                   "description": "The idle timeout for upstream connection pool connections.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "must be a valid duration greater than 1ms",
+                                      "rule": "duration(self) >= duration('1ms')"
+                                    }
+                                  ]
+                                },
+                                "maxConcurrentStreams": {
+                                  "description": "The maximum number of concurrent streams allowed for a peer on one HTTP/2 connection.",
+                                  "type": "integer",
+                                  "format": "int32"
                                 },
                                 "maxRequestsPerConnection": {
                                   "description": "Maximum number of requests per connection to a backend.",
@@ -373,11 +484,27 @@
                               "properties": {
                                 "connectTimeout": {
                                   "description": "TCP connection timeout.",
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "must be a valid duration greater than 1ms",
+                                      "rule": "duration(self) >= duration('1ms')"
+                                    }
+                                  ]
+                                },
+                                "idleTimeout": {
+                                  "description": "The idle timeout for TCP connections.",
                                   "type": "string"
                                 },
                                 "maxConnectionDuration": {
                                   "description": "The maximum duration of a connection.",
-                                  "type": "string"
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "must be a valid duration greater than 1ms",
+                                      "rule": "duration(self) >= duration('1ms')"
+                                    }
+                                  ]
                                 },
                                 "maxConnections": {
                                   "description": "Maximum number of HTTP1 /TCP connections to a destination host.",
@@ -390,15 +517,29 @@
                                   "properties": {
                                     "interval": {
                                       "description": "The time duration between keep-alive probes.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "must be a valid duration greater than 1ms",
+                                          "rule": "duration(self) >= duration('1ms')"
+                                        }
+                                      ]
                                     },
                                     "probes": {
                                       "description": "Maximum number of keepalive probes to send without response before deciding the connection is dead.",
-                                      "type": "integer"
+                                      "type": "integer",
+                                      "maximum": 4294967295,
+                                      "minimum": 0
                                     },
                                     "time": {
                                       "description": "The time duration a connection needs to be idle before keep-alive probes start being sent.",
-                                      "type": "string"
+                                      "type": "string",
+                                      "x-kubernetes-validations": [
+                                        {
+                                          "message": "must be a valid duration greater than 1ms",
+                                          "rule": "duration(self) >= duration('1ms')"
+                                        }
+                                      ]
                                     }
                                   }
                                 }
@@ -448,13 +589,15 @@
                                   "properties": {
                                     "tableSize": {
                                       "description": "The table size for Maglev hashing.",
-                                      "type": "integer"
+                                      "type": "integer",
+                                      "minimum": 0
                                     }
                                   }
                                 },
                                 "minimumRingSize": {
                                   "description": "Deprecated.",
-                                  "type": "integer"
+                                  "type": "integer",
+                                  "minimum": 0
                                 },
                                 "ringHash": {
                                   "description": "The ring/modulo hash load balancer implements consistent hashing to backend hosts.",
@@ -462,7 +605,8 @@
                                   "properties": {
                                     "minimumRingSize": {
                                       "description": "The minimum number of virtual nodes to use for the hash ring.",
-                                      "type": "integer"
+                                      "type": "integer",
+                                      "minimum": 0
                                     }
                                   }
                                 },
@@ -489,14 +633,16 @@
                                         "description": "Map of upstream localities to traffic distribution weights.",
                                         "type": "object",
                                         "additionalProperties": {
-                                          "type": "integer"
+                                          "type": "integer",
+                                          "maximum": 4294967295,
+                                          "minimum": 0
                                         }
                                       }
                                     }
                                   }
                                 },
                                 "enabled": {
-                                  "description": "enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety."
+                                  "description": "Enable locality load balancing."
                                 },
                                 "failover": {
                                   "description": "Optional: only one of distribute, failover or failoverPriority can be set.",
@@ -525,6 +671,7 @@
                               }
                             },
                             "simple": {
+                              "description": "\n\nValid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST",
                               "type": "string",
                               "enum": [
                                 "UNSPECIFIED",
@@ -535,9 +682,43 @@
                                 "LEAST_REQUEST"
                               ]
                             },
+                            "warmup": {
+                              "description": "Represents the warmup configuration of Service.",
+                              "type": "object",
+                              "required": [
+                                "duration"
+                              ],
+                              "properties": {
+                                "aggression": {
+                                  "description": "This parameter controls the speed of traffic increase over the warmup duration.",
+                                  "format": "double",
+                                  "minimum": 1
+                                },
+                                "duration": {
+                                  "type": "string",
+                                  "x-kubernetes-validations": [
+                                    {
+                                      "message": "must be a valid duration greater than 1ms",
+                                      "rule": "duration(self) >= duration('1ms')"
+                                    }
+                                  ]
+                                },
+                                "minimumPercent": {
+                                  "format": "double",
+                                  "maximum": 100,
+                                  "minimum": 0
+                                }
+                              }
+                            },
                             "warmupDurationSecs": {
-                              "description": "Represents the warmup duration of Service.",
-                              "type": "string"
+                              "description": "Deprecated: use `warmup` instead.",
+                              "type": "string",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "must be a valid duration greater than 1ms",
+                                  "rule": "duration(self) >= duration('1ms')"
+                                }
+                              ]
                             }
                           }
                         },
@@ -546,24 +727,42 @@
                           "properties": {
                             "baseEjectionTime": {
                               "description": "Minimum ejection duration.",
-                              "type": "string"
+                              "type": "string",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "must be a valid duration greater than 1ms",
+                                  "rule": "duration(self) >= duration('1ms')"
+                                }
+                              ]
                             },
                             "consecutive5xxErrors": {
-                              "description": "Number of 5xx errors before a host is ejected from the connection pool."
+                              "description": "Number of 5xx errors before a host is ejected from the connection pool.",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             },
                             "consecutiveErrors": {
                               "type": "integer",
                               "format": "int32"
                             },
                             "consecutiveGatewayErrors": {
-                              "description": "Number of gateway errors before a host is ejected from the connection pool."
+                              "description": "Number of gateway errors before a host is ejected from the connection pool.",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             },
                             "consecutiveLocalOriginFailures": {
-                              "description": "The number of consecutive locally originated failures before ejection occurs."
+                              "description": "The number of consecutive locally originated failures before ejection occurs.",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             },
                             "interval": {
                               "description": "Time interval between ejection sweep analysis.",
-                              "type": "string"
+                              "type": "string",
+                              "x-kubernetes-validations": [
+                                {
+                                  "message": "must be a valid duration greater than 1ms",
+                                  "rule": "duration(self) >= duration('1ms')"
+                                }
+                              ]
                             },
                             "maxEjectionPercent": {
                               "description": "Maximum % of hosts in the load balancing pool for the upstream service that can be ejected.",
@@ -571,7 +770,7 @@
                               "format": "int32"
                             },
                             "minHealthPercent": {
-                              "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode.",
+                              "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least `minHealthPercent` hosts in healthy mode.",
                               "type": "integer",
                               "format": "int32"
                             },
@@ -586,7 +785,9 @@
                           "type": "object",
                           "properties": {
                             "number": {
-                              "type": "integer"
+                              "type": "integer",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             }
                           }
                         },
@@ -596,6 +797,10 @@
                           "properties": {
                             "caCertificates": {
                               "description": "OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL) to use in verifying a presented server certificate.",
                               "type": "string"
                             },
                             "clientCertificate": {
@@ -610,7 +815,7 @@
                               "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the CA signature and SAN for the server certificate corresponding to the host."
                             },
                             "mode": {
-                              "description": "Indicates whether connections to this port should be secured using TLS.",
+                              "description": "Indicates whether connections to this port should be secured using TLS.\n\nValid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL",
                               "type": "string",
                               "enum": [
                                 "DISABLE",
@@ -639,12 +844,30 @@
                       }
                     }
                   },
+                  "proxyProtocol": {
+                    "description": "The upstream PROXY protocol settings.",
+                    "type": "object",
+                    "properties": {
+                      "version": {
+                        "description": "The PROXY protocol version to use.\n\nValid Options: V1, V2",
+                        "type": "string",
+                        "enum": [
+                          "V1",
+                          "V2"
+                        ]
+                      }
+                    }
+                  },
                   "tls": {
                     "description": "TLS related settings for connections to the upstream service.",
                     "type": "object",
                     "properties": {
                       "caCertificates": {
                         "description": "OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate.",
+                        "type": "string"
+                      },
+                      "caCrl": {
+                        "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL) to use in verifying a presented server certificate.",
                         "type": "string"
                       },
                       "clientCertificate": {
@@ -659,7 +882,7 @@
                         "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the CA signature and SAN for the server certificate corresponding to the host."
                       },
                       "mode": {
-                        "description": "Indicates whether connections to this port should be secured using TLS.",
+                        "description": "Indicates whether connections to this port should be secured using TLS.\n\nValid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL",
                         "type": "string",
                         "enum": [
                           "DISABLE",
@@ -703,7 +926,9 @@
                       },
                       "targetPort": {
                         "description": "Specifies a port to which the downstream connection is tunneled.",
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       }
                     }
                   }
@@ -724,7 +949,7 @@
                   "type": "object",
                   "properties": {
                     "h2UpgradePolicy": {
-                      "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.",
+                      "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.\n\nValid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE",
                       "type": "string",
                       "enum": [
                         "DEFAULT",
@@ -744,7 +969,18 @@
                     },
                     "idleTimeout": {
                       "description": "The idle timeout for upstream connection pool connections.",
-                      "type": "string"
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "must be a valid duration greater than 1ms",
+                          "rule": "duration(self) >= duration('1ms')"
+                        }
+                      ]
+                    },
+                    "maxConcurrentStreams": {
+                      "description": "The maximum number of concurrent streams allowed for a peer on one HTTP/2 connection.",
+                      "type": "integer",
+                      "format": "int32"
                     },
                     "maxRequestsPerConnection": {
                       "description": "Maximum number of requests per connection to a backend.",
@@ -768,11 +1004,27 @@
                   "properties": {
                     "connectTimeout": {
                       "description": "TCP connection timeout.",
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "must be a valid duration greater than 1ms",
+                          "rule": "duration(self) >= duration('1ms')"
+                        }
+                      ]
+                    },
+                    "idleTimeout": {
+                      "description": "The idle timeout for TCP connections.",
                       "type": "string"
                     },
                     "maxConnectionDuration": {
                       "description": "The maximum duration of a connection.",
-                      "type": "string"
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "must be a valid duration greater than 1ms",
+                          "rule": "duration(self) >= duration('1ms')"
+                        }
+                      ]
                     },
                     "maxConnections": {
                       "description": "Maximum number of HTTP1 /TCP connections to a destination host.",
@@ -785,15 +1037,29 @@
                       "properties": {
                         "interval": {
                           "description": "The time duration between keep-alive probes.",
-                          "type": "string"
+                          "type": "string",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "must be a valid duration greater than 1ms",
+                              "rule": "duration(self) >= duration('1ms')"
+                            }
+                          ]
                         },
                         "probes": {
                           "description": "Maximum number of keepalive probes to send without response before deciding the connection is dead.",
-                          "type": "integer"
+                          "type": "integer",
+                          "maximum": 4294967295,
+                          "minimum": 0
                         },
                         "time": {
                           "description": "The time duration a connection needs to be idle before keep-alive probes start being sent.",
-                          "type": "string"
+                          "type": "string",
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "must be a valid duration greater than 1ms",
+                              "rule": "duration(self) >= duration('1ms')"
+                            }
+                          ]
                         }
                       }
                     }
@@ -843,13 +1109,15 @@
                       "properties": {
                         "tableSize": {
                           "description": "The table size for Maglev hashing.",
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     },
                     "minimumRingSize": {
                       "description": "Deprecated.",
-                      "type": "integer"
+                      "type": "integer",
+                      "minimum": 0
                     },
                     "ringHash": {
                       "description": "The ring/modulo hash load balancer implements consistent hashing to backend hosts.",
@@ -857,7 +1125,8 @@
                       "properties": {
                         "minimumRingSize": {
                           "description": "The minimum number of virtual nodes to use for the hash ring.",
-                          "type": "integer"
+                          "type": "integer",
+                          "minimum": 0
                         }
                       }
                     },
@@ -884,14 +1153,16 @@
                             "description": "Map of upstream localities to traffic distribution weights.",
                             "type": "object",
                             "additionalProperties": {
-                              "type": "integer"
+                              "type": "integer",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             }
                           }
                         }
                       }
                     },
                     "enabled": {
-                      "description": "enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety."
+                      "description": "Enable locality load balancing."
                     },
                     "failover": {
                       "description": "Optional: only one of distribute, failover or failoverPriority can be set.",
@@ -920,6 +1191,7 @@
                   }
                 },
                 "simple": {
+                  "description": "\n\nValid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST",
                   "type": "string",
                   "enum": [
                     "UNSPECIFIED",
@@ -930,9 +1202,43 @@
                     "LEAST_REQUEST"
                   ]
                 },
+                "warmup": {
+                  "description": "Represents the warmup configuration of Service.",
+                  "type": "object",
+                  "required": [
+                    "duration"
+                  ],
+                  "properties": {
+                    "aggression": {
+                      "description": "This parameter controls the speed of traffic increase over the warmup duration.",
+                      "format": "double",
+                      "minimum": 1
+                    },
+                    "duration": {
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "must be a valid duration greater than 1ms",
+                          "rule": "duration(self) >= duration('1ms')"
+                        }
+                      ]
+                    },
+                    "minimumPercent": {
+                      "format": "double",
+                      "maximum": 100,
+                      "minimum": 0
+                    }
+                  }
+                },
                 "warmupDurationSecs": {
-                  "description": "Represents the warmup duration of Service.",
-                  "type": "string"
+                  "description": "Deprecated: use `warmup` instead.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "must be a valid duration greater than 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
                 }
               }
             },
@@ -941,24 +1247,42 @@
               "properties": {
                 "baseEjectionTime": {
                   "description": "Minimum ejection duration.",
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "must be a valid duration greater than 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
                 },
                 "consecutive5xxErrors": {
-                  "description": "Number of 5xx errors before a host is ejected from the connection pool."
+                  "description": "Number of 5xx errors before a host is ejected from the connection pool.",
+                  "maximum": 4294967295,
+                  "minimum": 0
                 },
                 "consecutiveErrors": {
                   "type": "integer",
                   "format": "int32"
                 },
                 "consecutiveGatewayErrors": {
-                  "description": "Number of gateway errors before a host is ejected from the connection pool."
+                  "description": "Number of gateway errors before a host is ejected from the connection pool.",
+                  "maximum": 4294967295,
+                  "minimum": 0
                 },
                 "consecutiveLocalOriginFailures": {
-                  "description": "The number of consecutive locally originated failures before ejection occurs."
+                  "description": "The number of consecutive locally originated failures before ejection occurs.",
+                  "maximum": 4294967295,
+                  "minimum": 0
                 },
                 "interval": {
                   "description": "Time interval between ejection sweep analysis.",
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "must be a valid duration greater than 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
                 },
                 "maxEjectionPercent": {
                   "description": "Maximum % of hosts in the load balancing pool for the upstream service that can be ejected.",
@@ -966,7 +1290,7 @@
                   "format": "int32"
                 },
                 "minHealthPercent": {
-                  "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode.",
+                  "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least `minHealthPercent` hosts in healthy mode.",
                   "type": "integer",
                   "format": "int32"
                 },
@@ -979,6 +1303,7 @@
             "portLevelSettings": {
               "description": "Traffic policies specific to individual ports.",
               "type": "array",
+              "maxItems": 4096,
               "items": {
                 "type": "object",
                 "properties": {
@@ -990,7 +1315,7 @@
                         "type": "object",
                         "properties": {
                           "h2UpgradePolicy": {
-                            "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.",
+                            "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.\n\nValid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE",
                             "type": "string",
                             "enum": [
                               "DEFAULT",
@@ -1010,7 +1335,18 @@
                           },
                           "idleTimeout": {
                             "description": "The idle timeout for upstream connection pool connections.",
-                            "type": "string"
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
+                          },
+                          "maxConcurrentStreams": {
+                            "description": "The maximum number of concurrent streams allowed for a peer on one HTTP/2 connection.",
+                            "type": "integer",
+                            "format": "int32"
                           },
                           "maxRequestsPerConnection": {
                             "description": "Maximum number of requests per connection to a backend.",
@@ -1034,11 +1370,27 @@
                         "properties": {
                           "connectTimeout": {
                             "description": "TCP connection timeout.",
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
+                          },
+                          "idleTimeout": {
+                            "description": "The idle timeout for TCP connections.",
                             "type": "string"
                           },
                           "maxConnectionDuration": {
                             "description": "The maximum duration of a connection.",
-                            "type": "string"
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
                           },
                           "maxConnections": {
                             "description": "Maximum number of HTTP1 /TCP connections to a destination host.",
@@ -1051,15 +1403,29 @@
                             "properties": {
                               "interval": {
                                 "description": "The time duration between keep-alive probes.",
-                                "type": "string"
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "must be a valid duration greater than 1ms",
+                                    "rule": "duration(self) >= duration('1ms')"
+                                  }
+                                ]
                               },
                               "probes": {
                                 "description": "Maximum number of keepalive probes to send without response before deciding the connection is dead.",
-                                "type": "integer"
+                                "type": "integer",
+                                "maximum": 4294967295,
+                                "minimum": 0
                               },
                               "time": {
                                 "description": "The time duration a connection needs to be idle before keep-alive probes start being sent.",
-                                "type": "string"
+                                "type": "string",
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "must be a valid duration greater than 1ms",
+                                    "rule": "duration(self) >= duration('1ms')"
+                                  }
+                                ]
                               }
                             }
                           }
@@ -1109,13 +1475,15 @@
                             "properties": {
                               "tableSize": {
                                 "description": "The table size for Maglev hashing.",
-                                "type": "integer"
+                                "type": "integer",
+                                "minimum": 0
                               }
                             }
                           },
                           "minimumRingSize": {
                             "description": "Deprecated.",
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 0
                           },
                           "ringHash": {
                             "description": "The ring/modulo hash load balancer implements consistent hashing to backend hosts.",
@@ -1123,7 +1491,8 @@
                             "properties": {
                               "minimumRingSize": {
                                 "description": "The minimum number of virtual nodes to use for the hash ring.",
-                                "type": "integer"
+                                "type": "integer",
+                                "minimum": 0
                               }
                             }
                           },
@@ -1150,14 +1519,16 @@
                                   "description": "Map of upstream localities to traffic distribution weights.",
                                   "type": "object",
                                   "additionalProperties": {
-                                    "type": "integer"
+                                    "type": "integer",
+                                    "maximum": 4294967295,
+                                    "minimum": 0
                                   }
                                 }
                               }
                             }
                           },
                           "enabled": {
-                            "description": "enable locality load balancing, this is DestinationRule-level and will override mesh wide settings in entirety."
+                            "description": "Enable locality load balancing."
                           },
                           "failover": {
                             "description": "Optional: only one of distribute, failover or failoverPriority can be set.",
@@ -1186,6 +1557,7 @@
                         }
                       },
                       "simple": {
+                        "description": "\n\nValid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST",
                         "type": "string",
                         "enum": [
                           "UNSPECIFIED",
@@ -1196,9 +1568,43 @@
                           "LEAST_REQUEST"
                         ]
                       },
+                      "warmup": {
+                        "description": "Represents the warmup configuration of Service.",
+                        "type": "object",
+                        "required": [
+                          "duration"
+                        ],
+                        "properties": {
+                          "aggression": {
+                            "description": "This parameter controls the speed of traffic increase over the warmup duration.",
+                            "format": "double",
+                            "minimum": 1
+                          },
+                          "duration": {
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
+                          },
+                          "minimumPercent": {
+                            "format": "double",
+                            "maximum": 100,
+                            "minimum": 0
+                          }
+                        }
+                      },
                       "warmupDurationSecs": {
-                        "description": "Represents the warmup duration of Service.",
-                        "type": "string"
+                        "description": "Deprecated: use `warmup` instead.",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       }
                     }
                   },
@@ -1207,24 +1613,42 @@
                     "properties": {
                       "baseEjectionTime": {
                         "description": "Minimum ejection duration.",
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       },
                       "consecutive5xxErrors": {
-                        "description": "Number of 5xx errors before a host is ejected from the connection pool."
+                        "description": "Number of 5xx errors before a host is ejected from the connection pool.",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "consecutiveErrors": {
                         "type": "integer",
                         "format": "int32"
                       },
                       "consecutiveGatewayErrors": {
-                        "description": "Number of gateway errors before a host is ejected from the connection pool."
+                        "description": "Number of gateway errors before a host is ejected from the connection pool.",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "consecutiveLocalOriginFailures": {
-                        "description": "The number of consecutive locally originated failures before ejection occurs."
+                        "description": "The number of consecutive locally originated failures before ejection occurs.",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "interval": {
                         "description": "Time interval between ejection sweep analysis.",
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       },
                       "maxEjectionPercent": {
                         "description": "Maximum % of hosts in the load balancing pool for the upstream service that can be ejected.",
@@ -1232,7 +1656,7 @@
                         "format": "int32"
                       },
                       "minHealthPercent": {
-                        "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least min_health_percent hosts in healthy mode.",
+                        "description": "Outlier detection will be enabled as long as the associated load balancing pool has at least `minHealthPercent` hosts in healthy mode.",
                         "type": "integer",
                         "format": "int32"
                       },
@@ -1247,7 +1671,9 @@
                     "type": "object",
                     "properties": {
                       "number": {
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       }
                     }
                   },
@@ -1257,6 +1683,10 @@
                     "properties": {
                       "caCertificates": {
                         "description": "OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate.",
+                        "type": "string"
+                      },
+                      "caCrl": {
+                        "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL) to use in verifying a presented server certificate.",
                         "type": "string"
                       },
                       "clientCertificate": {
@@ -1271,7 +1701,7 @@
                         "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the CA signature and SAN for the server certificate corresponding to the host."
                       },
                       "mode": {
-                        "description": "Indicates whether connections to this port should be secured using TLS.",
+                        "description": "Indicates whether connections to this port should be secured using TLS.\n\nValid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL",
                         "type": "string",
                         "enum": [
                           "DISABLE",
@@ -1300,12 +1730,30 @@
                 }
               }
             },
+            "proxyProtocol": {
+              "description": "The upstream PROXY protocol settings.",
+              "type": "object",
+              "properties": {
+                "version": {
+                  "description": "The PROXY protocol version to use.\n\nValid Options: V1, V2",
+                  "type": "string",
+                  "enum": [
+                    "V1",
+                    "V2"
+                  ]
+                }
+              }
+            },
             "tls": {
               "description": "TLS related settings for connections to the upstream service.",
               "type": "object",
               "properties": {
                 "caCertificates": {
                   "description": "OPTIONAL: The path to the file containing certificate authority certificates to use in verifying a presented server certificate.",
+                  "type": "string"
+                },
+                "caCrl": {
+                  "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL) to use in verifying a presented server certificate.",
                   "type": "string"
                 },
                 "clientCertificate": {
@@ -1320,7 +1768,7 @@
                   "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the CA signature and SAN for the server certificate corresponding to the host."
                 },
                 "mode": {
-                  "description": "Indicates whether connections to this port should be secured using TLS.",
+                  "description": "Indicates whether connections to this port should be secured using TLS.\n\nValid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL",
                   "type": "string",
                   "enum": [
                     "DISABLE",
@@ -1364,7 +1812,9 @@
                 },
                 "targetPort": {
                   "description": "Specifies a port to which the downstream connection is tunneled.",
-                  "type": "integer"
+                  "type": "integer",
+                  "maximum": 4294967295,
+                  "minimum": 0
                 }
               }
             }
@@ -1377,9 +1827,27 @@
             "matchLabels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.",
               "type": "object",
+              "maxProperties": 4096,
               "additionalProperties": {
-                "type": "string"
-              }
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard not allowed in label value match",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "wildcard not allowed in label key match",
+                  "rule": "self.all(key, !key.contains('*'))"
+                },
+                {
+                  "message": "key must not be empty",
+                  "rule": "self.all(key, key.size() != 0)"
+                }
+              ]
             }
           }
         }

--- a/class_generator/schema/dscinitialization.json
+++ b/class_generator/schema/dscinitialization.json
@@ -174,7 +174,6 @@
           "description": "Conditions describes the state of the DSCInitializationStatus resource",
           "type": "array",
           "items": {
-            "description": "Condition represents the state of the operator's\nreconciliation functionality.",
             "type": "object",
             "required": [
               "status",
@@ -182,25 +181,47 @@
             ],
             "properties": {
               "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
                 "type": "string",
                 "format": "date-time"
               },
               "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
+                "description": "message is a human-readable message indicating details about the transition.",
                 "type": "string"
               },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
               "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
                 "type": "string"
               },
               "status": {
-                "type": "string"
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
               },
               "type": {
-                "description": "ConditionType is the state of the operator's reconciliation functionality.",
-                "type": "string"
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
               }
             }
           }

--- a/class_generator/schema/envoyfilter.json
+++ b/class_generator/schema/envoyfilter.json
@@ -24,7 +24,7 @@
             "type": "object",
             "properties": {
               "applyTo": {
-                "description": "Specifies where in the Envoy configuration, the patch should be applied.",
+                "description": "Specifies where in the Envoy configuration, the patch should be applied.\n\nValid Options: LISTENER, FILTER_CHAIN, NETWORK_FILTER, HTTP_FILTER, ROUTE_CONFIGURATION, VIRTUAL_HOST, HTTP_ROUTE, CLUSTER, EXTENSION_CONFIG, BOOTSTRAP, LISTENER_FILTER",
                 "type": "string",
                 "enum": [
                   "INVALID",
@@ -55,7 +55,9 @@
                       },
                       "portNumber": {
                         "description": "The service port for which this cluster was generated.",
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "service": {
                         "description": "The fully qualified service name for this cluster.",
@@ -68,7 +70,7 @@
                     }
                   },
                   "context": {
-                    "description": "The specific config generation context to match on.",
+                    "description": "The specific config generation context to match on.\n\nValid Options: ANY, SIDECAR_INBOUND, SIDECAR_OUTBOUND, GATEWAY",
                     "type": "string",
                     "enum": [
                       "ANY",
@@ -91,7 +93,9 @@
                           },
                           "destinationPort": {
                             "description": "The destination_port value used by a filter chain's match condition.",
-                            "type": "integer"
+                            "type": "integer",
+                            "maximum": 4294967295,
+                            "minimum": 0
                           },
                           "filter": {
                             "description": "The name of a specific filter to apply the patch to.",
@@ -140,7 +144,9 @@
                       },
                       "portNumber": {
                         "description": "The service port/gateway port to which traffic is being sent/received.",
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       }
                     }
                   },
@@ -149,7 +155,7 @@
                     "type": "object",
                     "properties": {
                       "metadata": {
-                        "description": "Match on the node metadata supplied by a proxy when connecting to Istio Pilot.",
+                        "description": "Match on the node metadata supplied by a proxy when connecting to istiod.",
                         "type": "object",
                         "additionalProperties": {
                           "type": "string"
@@ -179,7 +185,9 @@
                       },
                       "portNumber": {
                         "description": "The service port number or gateway server port number for which this route configuration was generated.",
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       },
                       "vhost": {
                         "description": "Match a specific virtual host in a route configuration and apply the patch to the virtual host.",
@@ -194,7 +202,7 @@
                             "type": "object",
                             "properties": {
                               "action": {
-                                "description": "Match a route with specific action type.",
+                                "description": "Match a route with specific action type.\n\nValid Options: ANY, ROUTE, REDIRECT, DIRECT_RESPONSE",
                                 "type": "string",
                                 "enum": [
                                   "ANY",
@@ -220,7 +228,7 @@
                 "type": "object",
                 "properties": {
                   "filterClass": {
-                    "description": "Determines the filter insertion order.",
+                    "description": "Determines the filter insertion order.\n\nValid Options: AUTHN, AUTHZ, STATS",
                     "type": "string",
                     "enum": [
                       "UNSPECIFIED",
@@ -230,7 +238,7 @@
                     ]
                   },
                   "operation": {
-                    "description": "Determines how the patch should be applied.",
+                    "description": "Determines how the patch should be applied.\n\nValid Options: MERGE, ADD, REMOVE, INSERT_BEFORE, INSERT_AFTER, INSERT_FIRST, REPLACE",
                     "type": "string",
                     "enum": [
                       "INVALID",
@@ -257,6 +265,55 @@
           "type": "integer",
           "format": "int32"
         },
+        "targetRefs": {
+          "description": "Optional.",
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "name"
+            ],
+            "properties": {
+              "group": {
+                "description": "group is the group of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+              },
+              "kind": {
+                "description": "kind is kind of the target resource.",
+                "type": "string",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+              },
+              "name": {
+                "description": "name is the name of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "minLength": 1
+              },
+              "namespace": {
+                "description": "namespace is the namespace of the referent.",
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "cross namespace referencing is not currently supported",
+                    "rule": "self.size() == 0"
+                  }
+                ]
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+                "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+              }
+            ]
+          }
+        },
         "workloadSelector": {
           "description": "Criteria used to select the specific set of pods/VMs on which this patch configuration should be applied.",
           "type": "object",
@@ -264,13 +321,27 @@
             "labels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which the configuration should be applied.",
               "type": "object",
+              "maxProperties": 256,
               "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard is not supported in selector",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
               }
             }
           }
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "only one of targetRefs or workloadSelector can be set",
+          "rule": "(has(self.workloadSelector)?1:0)+(has(self.targetRefs)?1:0)<=1"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/eventlistener.json
+++ b/class_generator/schema/eventlistener.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/eventlistenerlist.json
+++ b/class_generator/schema/eventlistenerlist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/featuretracker.json
+++ b/class_generator/schema/featuretracker.json
@@ -42,7 +42,6 @@
         "conditions": {
           "type": "array",
           "items": {
-            "description": "Condition represents the state of the operator's\nreconciliation functionality.",
             "type": "object",
             "required": [
               "status",
@@ -50,25 +49,47 @@
             ],
             "properties": {
               "lastHeartbeatTime": {
+                "description": "The last time we got an update on a given condition, this should not be set and is\npresent only for backward compatibility reasons",
                 "type": "string",
                 "format": "date-time"
               },
               "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.\nIf that is not known, then using the time when the API field changed is acceptable.",
                 "type": "string",
                 "format": "date-time"
               },
               "message": {
+                "description": "message is a human-readable message indicating details about the transition.",
                 "type": "string"
               },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration\nis 9, the condition is out of date with respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
               "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nThe value should be a CamelCase string.",
+                "type": "string"
+              },
+              "severity": {
+                "description": "Severity with which to treat failures of this type of condition.\nWhen this is not specified, it defaults to Error.",
                 "type": "string"
               },
               "status": {
-                "type": "string"
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
               },
               "type": {
-                "description": "ConditionType is the state of the operator's reconciliation functionality.",
-                "type": "string"
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
               }
             }
           }

--- a/class_generator/schema/gateway.json
+++ b/class_generator/schema/gateway.json
@@ -67,14 +67,18 @@
                   },
                   "number": {
                     "description": "A valid non-negative integer port number.",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   },
                   "protocol": {
                     "description": "The protocol exposed on the port.",
                     "type": "string"
                   },
                   "targetPort": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   }
                 }
               },
@@ -84,6 +88,10 @@
                 "properties": {
                   "caCertificates": {
                     "description": "REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.",
+                    "type": "string"
+                  },
+                  "caCrl": {
+                    "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL) to use in verifying a presented client side certificate.",
                     "type": "string"
                   },
                   "cipherSuites": {
@@ -102,7 +110,7 @@
                     "type": "boolean"
                   },
                   "maxProtocolVersion": {
-                    "description": "Optional: Maximum TLS protocol version.",
+                    "description": "Optional: Maximum TLS protocol version.\n\nValid Options: TLS_AUTO, TLSV1_0, TLSV1_1, TLSV1_2, TLSV1_3",
                     "type": "string",
                     "enum": [
                       "TLS_AUTO",
@@ -113,7 +121,7 @@
                     ]
                   },
                   "minProtocolVersion": {
-                    "description": "Optional: Minimum TLS protocol version.",
+                    "description": "Optional: Minimum TLS protocol version.\n\nValid Options: TLS_AUTO, TLSV1_0, TLSV1_1, TLSV1_2, TLSV1_3",
                     "type": "string",
                     "enum": [
                       "TLS_AUTO",
@@ -124,7 +132,7 @@
                     ]
                   },
                   "mode": {
-                    "description": "Optional: Indicates whether connections to this port should be secured using TLS.",
+                    "description": "Optional: Indicates whether connections to this port should be secured using TLS.\n\nValid Options: PASSTHROUGH, SIMPLE, MUTUAL, AUTO_PASSTHROUGH, ISTIO_MUTUAL, OPTIONAL_MUTUAL",
                     "type": "string",
                     "enum": [
                       "PASSTHROUGH",

--- a/class_generator/schema/grant.json
+++ b/class_generator/schema/grant.json
@@ -154,5 +154,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/grantlist.json
+++ b/class_generator/schema/grantlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/inferenceservice.json
+++ b/class_generator/schema/inferenceservice.json
@@ -1276,6 +1276,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -2262,6 +2265,9 @@
                           ],
                           "properties": {
                             "name": {
+                              "type": "string"
+                            },
+                            "request": {
                               "type": "string"
                             }
                           }
@@ -3310,6 +3316,9 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "request": {
+                              "type": "string"
                             }
                           }
                         },
@@ -3729,16 +3738,11 @@
                   "name": {
                     "type": "string"
                   },
-                  "source": {
-                    "type": "object",
-                    "properties": {
-                      "resourceClaimName": {
-                        "type": "string"
-                      },
-                      "resourceClaimTemplateName": {
-                        "type": "string"
-                      }
-                    }
+                  "resourceClaimName": {
+                    "type": "string"
+                  },
+                  "resourceClaimTemplateName": {
+                    "type": "string"
                   }
                 }
               },
@@ -3859,6 +3863,9 @@
                     "format": "int64"
                   },
                   "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "type": "array",
@@ -4584,6 +4591,17 @@
                         "type": "string"
                       },
                       "type": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "image": {
+                    "type": "object",
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
                         "type": "string"
                       }
                     }
@@ -6422,6 +6440,9 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "request": {
+                              "type": "string"
                             }
                           }
                         },
@@ -7443,6 +7464,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -8420,6 +8444,9 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "request": {
+                              "type": "string"
                             }
                           }
                         },
@@ -9351,6 +9378,9 @@
                         ],
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         }
@@ -10345,6 +10375,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -11308,6 +11341,9 @@
                         ],
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         }
@@ -12275,6 +12311,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -13225,6 +13264,9 @@
                         ],
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         }
@@ -14187,6 +14229,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -14562,16 +14607,11 @@
                   "name": {
                     "type": "string"
                   },
-                  "source": {
-                    "type": "object",
-                    "properties": {
-                      "resourceClaimName": {
-                        "type": "string"
-                      },
-                      "resourceClaimTemplateName": {
-                        "type": "string"
-                      }
-                    }
+                  "resourceClaimName": {
+                    "type": "string"
+                  },
+                  "resourceClaimTemplateName": {
+                    "type": "string"
                   }
                 }
               },
@@ -14692,6 +14732,9 @@
                     "format": "int64"
                   },
                   "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "type": "array",
@@ -15343,6 +15386,9 @@
                         ],
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         }
@@ -16297,6 +16343,9 @@
                         ],
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         }
@@ -17364,6 +17413,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -18270,6 +18322,17 @@
                         "type": "string"
                       },
                       "type": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "image": {
+                    "type": "object",
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
                         "type": "string"
                       }
                     }
@@ -20084,6 +20147,9 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
                                 }
                               }
                             },
@@ -21063,6 +21129,9 @@
                               ],
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               }
@@ -22055,6 +22124,9 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
                                 }
                               }
                             },
@@ -22446,16 +22518,11 @@
                       "name": {
                         "type": "string"
                       },
-                      "source": {
-                        "type": "object",
-                        "properties": {
-                          "resourceClaimName": {
-                            "type": "string"
-                          },
-                          "resourceClaimTemplateName": {
-                            "type": "string"
-                          }
-                        }
+                      "resourceClaimName": {
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "type": "string"
                       }
                     }
                   },
@@ -22564,6 +22631,9 @@
                         "format": "int64"
                       },
                       "x-kubernetes-list-type": "atomic"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "type": "string"
                     },
                     "sysctls": {
                       "type": "array",
@@ -23288,6 +23358,17 @@
                             "type": "string"
                           },
                           "type": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "image": {
+                        "type": "object",
+                        "properties": {
+                          "pullPolicy": {
+                            "type": "string"
+                          },
+                          "reference": {
                             "type": "string"
                           }
                         }
@@ -24439,6 +24520,9 @@
                         ],
                         "properties": {
                           "name": {
+                            "type": "string"
+                          },
+                          "request": {
                             "type": "string"
                           }
                         }
@@ -26079,6 +26163,9 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "request": {
+                              "type": "string"
                             }
                           }
                         },
@@ -27126,6 +27213,9 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "request": {
+                              "type": "string"
                             }
                           }
                         },
@@ -27545,16 +27635,11 @@
                   "name": {
                     "type": "string"
                   },
-                  "source": {
-                    "type": "object",
-                    "properties": {
-                      "resourceClaimName": {
-                        "type": "string"
-                      },
-                      "resourceClaimTemplateName": {
-                        "type": "string"
-                      }
-                    }
+                  "resourceClaimName": {
+                    "type": "string"
+                  },
+                  "resourceClaimTemplateName": {
+                    "type": "string"
                   }
                 }
               },
@@ -27675,6 +27760,9 @@
                     "format": "int64"
                   },
                   "x-kubernetes-list-type": "atomic"
+                },
+                "supplementalGroupsPolicy": {
+                  "type": "string"
                 },
                 "sysctls": {
                   "type": "array",
@@ -28400,6 +28488,17 @@
                         "type": "string"
                       },
                       "type": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "image": {
+                    "type": "object",
+                    "properties": {
+                      "pullPolicy": {
+                        "type": "string"
+                      },
+                      "reference": {
                         "type": "string"
                       }
                     }

--- a/class_generator/schema/interceptor.json
+++ b/class_generator/schema/interceptor.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/interceptorlist.json
+++ b/class_generator/schema/interceptorlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/istio.json
+++ b/class_generator/schema/istio.json
@@ -1,0 +1,7207 @@
+{
+  "description": "Istio represents an Istio Service Mesh deployment consisting of one or more\ncontrol plane instances (represented by one or more IstioRevision objects).\nTo deploy an Istio Service Mesh, a user creates an Istio object with the\ndesired Istio version and configuration. The operator then creates\nan IstioRevision object, which in turn creates the underlying Deployment\nobjects for istiod and other control plane components, similar to how a\nDeployment object in Kubernetes creates ReplicaSets that create the Pods.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
+    "spec": {
+      "description": "IstioSpec defines the desired state of Istio",
+      "type": "object",
+      "required": [
+        "namespace",
+        "version"
+      ],
+      "properties": {
+        "namespace": {
+          "description": "Namespace to which the Istio components should be installed. Note that this field is immutable.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "profile": {
+          "description": "The built-in installation configuration profile to use.\nThe 'default' profile is always applied. On OpenShift, the 'openshift' profile is also applied on top of 'default'.\nMust be one of: ambient, default, demo, empty, openshift-ambient, openshift, preview, remote, stable.",
+          "type": "string",
+          "enum": [
+            "ambient",
+            "default",
+            "demo",
+            "empty",
+            "openshift-ambient",
+            "openshift",
+            "preview",
+            "remote",
+            "stable"
+          ]
+        },
+        "updateStrategy": {
+          "description": "Defines the update strategy to use when the version in the Istio CR is updated.",
+          "type": "object",
+          "properties": {
+            "inactiveRevisionDeletionGracePeriodSeconds": {
+              "description": "Defines how many seconds the operator should wait before removing a non-active revision after all\nthe workloads have stopped using it. You may want to set this value on the order of minutes.\nThe minimum is 0 and the default value is 30.",
+              "type": "integer",
+              "format": "int64",
+              "minimum": 0
+            },
+            "type": {
+              "description": "Type of strategy to use. Can be \"InPlace\" or \"RevisionBased\". When the \"InPlace\" strategy\nis used, the existing Istio control plane is updated in-place. The workloads therefore\ndon't need to be moved from one control plane instance to another. When the \"RevisionBased\"\nstrategy is used, a new Istio control plane instance is created for every change to the\nIstio.spec.version field. The old control plane remains in place until all workloads have\nbeen moved to the new control plane instance.\n\nThe \"InPlace\" strategy is the default.\tTODO: change default to \"RevisionBased\"",
+              "type": "string",
+              "enum": [
+                "InPlace",
+                "RevisionBased"
+              ]
+            },
+            "updateWorkloads": {
+              "description": "Defines whether the workloads should be moved from one control plane instance to another\nautomatically. If updateWorkloads is true, the operator moves the workloads from the old\ncontrol plane instance to the new one after the new control plane is ready.\nIf updateWorkloads is false, the user must move the workloads manually by updating the\nistio.io/rev labels on the namespace and/or the pods.\nDefaults to false.",
+              "type": "boolean"
+            }
+          }
+        },
+        "values": {
+          "description": "Defines the values to be passed to the Helm charts when installing Istio.",
+          "type": "object",
+          "properties": {
+            "base": {
+              "description": "Configuration for the base component.",
+              "type": "object",
+              "properties": {
+                "excludedCRDs": {
+                  "description": "CRDs to exclude. Requires `enableCRDTemplates`",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "validationCABundle": {
+                  "description": "validation webhook CA bundle",
+                  "type": "string"
+                },
+                "validationURL": {
+                  "description": "URL to use for validating webhook.",
+                  "type": "string"
+                }
+              }
+            },
+            "compatibilityVersion": {
+              "description": "Specifies the compatibility version to use. When this is set, the control plane will\nbe configured with the same defaults as the specified version.",
+              "type": "string"
+            },
+            "defaultRevision": {
+              "description": "The name of the default revision in the cluster.",
+              "type": "string"
+            },
+            "experimental": {
+              "description": "Specifies experimental helm fields that could be removed or changed in the future",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "global": {
+              "description": "Global configuration for Istio components.",
+              "type": "object",
+              "properties": {
+                "arch": {
+                  "description": "Specifies pod scheduling arch(amd64, ppc64le, s390x, arm64) and weight as follows:\n\n\t0 - Never scheduled\n\t1 - Least preferred\n\t2 - No preference\n\t3 - Most preferred\n\nDeprecated: replaced by the affinity k8s settings which allows architecture nodeAffinity configuration of this behavior.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "amd64": {
+                      "description": "Sets pod scheduling weight for amd64 arch",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "arm64": {
+                      "description": "Sets pod scheduling weight for arm64 arch.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "ppc64le": {
+                      "description": "Sets pod scheduling weight for ppc64le arch.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "s390x": {
+                      "description": "Sets pod scheduling weight for s390x arch.",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "caAddress": {
+                  "description": "The address of the CA for CSR.",
+                  "type": "string"
+                },
+                "caName": {
+                  "description": "The name of the CA for workloads.\nFor example, when caName=GkeWorkloadCertificate, GKE workload certificates\nwill be used as the certificates for workloads.\nThe default value is \"\" and when caName=\"\", the CA will be configured by other\nmechanisms (e.g., environmental variable CA_PROVIDER).",
+                  "type": "string"
+                },
+                "certSigners": {
+                  "description": "List of certSigners to allow \"approve\" action in the ClusterRole",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "configCluster": {
+                  "description": "Controls whether a remote cluster is the config cluster for an external istiod",
+                  "type": "boolean"
+                },
+                "configValidation": {
+                  "description": "Controls whether the server-side validation is enabled.",
+                  "type": "boolean"
+                },
+                "defaultNodeSelector": {
+                  "description": "Default k8s node selector for all the Istio control plane components\n\nSee https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "defaultPodDisruptionBudget": {
+                  "description": "Specifies the default pod disruption budget configuration.",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Controls whether a PodDisruptionBudget with a default minAvailable value of 1 is created for each deployment.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "defaultResources": {
+                  "description": "Default k8s resources settings for all Istio control plane components.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "defaultTolerations": {
+                  "description": "Default node tolerations to be applied to all deployments so that all pods can be\nscheduled to nodes with matching taints. Each component can overwrite\nthese default values by adding its tolerations block in the relevant section below\nand setting the desired values.\nConfigure this field in case that all pods of Istio control plane are expected to\nbe scheduled to particular nodes with specified taints.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "array",
+                  "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                    "type": "object",
+                    "properties": {
+                      "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "value": {
+                        "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "externalIstiod": {
+                  "description": "Controls whether one external istiod is enabled.",
+                  "type": "boolean"
+                },
+                "hub": {
+                  "description": "Specifies the docker hub for Istio images.",
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "Specifies the image pull policy for the Istio images. one of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.\n\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ]
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets for the control plane ServiceAccount, list of secrets in the same namespace\nto use for pulling any images in pods that reference this ServiceAccount.\nMust be set for any cluster configured with private docker registry.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ipFamilies": {
+                  "description": "Defines which IP family to use for single stack or the order of IP families for dual-stack.\nValid list items are \"IPv4\", \"IPv6\".\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ipFamilyPolicy": {
+                  "description": "Controls whether Services are configured to use IPv4, IPv6, or both. Valid options\nare PreferDualStack, RequireDualStack, and SingleStack.\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "string"
+                },
+                "istioNamespace": {
+                  "description": "Specifies the default namespace for the Istio control plane components.",
+                  "type": "string"
+                },
+                "istiod": {
+                  "description": "Specifies the configution of istiod",
+                  "type": "object",
+                  "properties": {
+                    "enableAnalysis": {
+                      "description": "If enabled, istiod will perform config analysis",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jwtPolicy": {
+                  "description": "Configure the policy for validating JWT.\nThis is deprecated and has no effect.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "string"
+                },
+                "logAsJson": {
+                  "description": "Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.",
+                  "type": "boolean"
+                },
+                "logging": {
+                  "description": "Specifies the global logging level settings for the Istio control plane components.",
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "description": "Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>\nThe control plane has different scopes depending on component, but can configure default log level across all components\nIf empty, default scope and level will be used as configured in code",
+                      "type": "string"
+                    }
+                  }
+                },
+                "meshID": {
+                  "description": "The Mesh Identifier. It should be unique within the scope where\nmeshes will interact with each other, but it is not required to be\nglobally/universally unique. For example, if any of the following are true,\nthen two meshes must have different Mesh IDs:\n- Meshes will have their telemetry aggregated in one place\n- Meshes will be federated together\n- Policy will be written referencing one mesh from the other\n\nIf an administrator expects that any of these conditions may become true in\nthe future, they should ensure their meshes have different Mesh IDs\nassigned.\n\nWithin a multicluster mesh, each cluster must be (manually or auto)\nconfigured to have the same Mesh ID value. If an existing cluster 'joins' a\nmulticluster mesh, it will need to be migrated to the new mesh ID. Details\nof migration TBD, and it may be a disruptive operation to change the Mesh\nID post-install.\n\nIf the mesh admin does not specify a value, Istio will use the value of the\nmesh's Trust Domain. The best practice is to select a proper Trust Domain\nvalue.",
+                  "type": "string"
+                },
+                "meshNetworks": {
+                  "description": "Configure the mesh networks to be used by the Split Horizon EDS.\n\nThe following example defines two networks with different endpoints association methods.\nFor `network1` all endpoints that their IP belongs to the provided CIDR range will be\nmapped to network1. The gateway for this network example is specified by its public IP\naddress and port.\nThe second network, `network2`, in this example is defined differently with all endpoints\nretrieved through the specified Multi-Cluster registry being mapped to network2. The\ngateway is also defined differently with the name of the gateway service on the remote\ncluster. The public IP for the gateway will be determined from that remote service (only\nLoadBalancer gateway service type is currently supported, for a NodePort type gateway service,\nit still need to be configured manually).\n\nmeshNetworks:\n\n\tnetwork1:\n\t  endpoints:\n\t  - fromCidr: \"192.168.0.1/24\"\n\t  gateways:\n\t  - address: 1.1.1.1\n\t    port: 80\n\tnetwork2:\n\t  endpoints:\n\t  - fromRegistry: reg1\n\t  gateways:\n\t  - registryServiceName: istio-ingressgateway.istio-system.svc.cluster.local\n\t    port: 443",
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "Network provides information about the endpoints in a routable L3\nnetwork. A single routable L3 network can have one or more service\nregistries. Note that the network has no relation to the locality of the\nendpoint. The endpoint locality will be obtained from the service\nregistry.",
+                    "type": "object",
+                    "properties": {
+                      "endpoints": {
+                        "description": "The list of endpoints in the network (obtained through the\nconstituent service registries or from CIDR ranges). All endpoints in\nthe network are directly accessible to one another.",
+                        "type": "array",
+                        "items": {
+                          "description": "NetworkEndpoints describes how the network associated with an endpoint\nshould be inferred. An endpoint will be assigned to a network based on\nthe following rules:\n\n1. Implicitly: If the registry explicitly provides information about\nthe network to which the endpoint belongs to. In some cases, its\npossible to indicate the network associated with the endpoint by\nadding the `ISTIO_META_NETWORK` environment variable to the sidecar.\n\n2. Explicitly:\n\n\ta. By matching the registry name with one of the \"fromRegistry\"\n\tin the mesh config. A \"fromRegistry\" can only be assigned to a\n\tsingle network.\n\n\tb. By matching the IP against one of the CIDR ranges in a mesh\n\tconfig network. The CIDR ranges must not overlap and be assigned to\n\ta single network.\n\n(2) will override (1) if both are present.",
+                          "type": "object",
+                          "properties": {
+                            "fromCidr": {
+                              "description": "A CIDR range for the set of endpoints in this network. The CIDR\nranges for endpoints from different networks must not overlap.",
+                              "type": "string"
+                            },
+                            "fromRegistry": {
+                              "description": "Add all endpoints from the specified registry into this network.\nThe names of the registries should correspond to the kubeconfig file name\ninside the secret that was used to configure the registry (Kubernetes\nmulticluster) or supplied by MCP server.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "At most one of [fromCidr fromRegistry] should be set",
+                              "rule": "(has(self.fromCidr)?1:0) + (has(self.fromRegistry)?1:0) <= 1"
+                            }
+                          ]
+                        }
+                      },
+                      "gateways": {
+                        "description": "Set of gateways associated with the network.",
+                        "type": "array",
+                        "items": {
+                          "description": "The gateway associated with this network. Traffic from remote networks\nwill arrive at the specified gateway:port. All incoming traffic must\nuse mTLS.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "IP address or externally resolvable DNS address associated with the gateway.",
+                              "type": "string"
+                            },
+                            "locality": {
+                              "description": "The locality associated with an explicitly specified gateway (i.e. ip)",
+                              "type": "string"
+                            },
+                            "port": {
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "registryServiceName": {
+                              "description": "A fully qualified domain name of the gateway service.  istiod will\nlookup the service from the service registries in the network and\nobtain the endpoint IPs of the gateway from the service\nregistry. Note that while the service name is a fully qualified\ndomain name, it need not be resolvable outside the orchestration\nplatform for the registry. e.g., this could be\nistio-ingressgateway.istio-system.svc.cluster.local.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "At most one of [registryServiceName address] should be set",
+                              "rule": "(has(self.registryServiceName)?1:0) + (has(self.address)?1:0) <= 1"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "mountMtlsCerts": {
+                  "description": "Controls whether the in-cluster MTLS key and certs are loaded from the secret volume mounts.",
+                  "type": "boolean"
+                },
+                "multiCluster": {
+                  "description": "Specifies the Configuration for Istio mesh across multiple clusters through Istio gateways.",
+                  "type": "object",
+                  "properties": {
+                    "clusterName": {
+                      "description": "The name of the cluster this installation will run in. This is required for sidecar injection\nto properly label proxies",
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "Enables the connection between two kubernetes clusters via their respective ingressgateway services.\nUse if the pods in each cluster cannot directly talk to one another.",
+                      "type": "boolean"
+                    },
+                    "globalDomainSuffix": {
+                      "description": "The suffix for global service names.",
+                      "type": "string"
+                    },
+                    "includeEnvoyFilter": {
+                      "description": "Enable envoy filter to translate `globalDomainSuffix` to cluster local suffix for cross cluster communication.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "network": {
+                  "description": "Network defines the network this cluster belong to. This name\ncorresponds to the networks in the map of mesh networks.",
+                  "type": "string"
+                },
+                "omitSidecarInjectorConfigMap": {
+                  "description": "Controls whether the creation of the sidecar injector ConfigMap should be skipped.\nDefaults to false. When set to true, the sidecar injector ConfigMap will not be created.",
+                  "type": "boolean"
+                },
+                "operatorManageWebhooks": {
+                  "description": "Controls whether the WebhookConfiguration resource(s) should be created. The current behavior\nof Istiod is to manage its own webhook configurations.\nWhen this option is set to true, Istio Operator, instead of webhooks, manages the\nwebhook configurations. When this option is set as false, webhooks manage their\nown webhook configurations.",
+                  "type": "boolean"
+                },
+                "pilotCertProvider": {
+                  "description": "Configure the Pilot certificate provider.\nCurrently, four providers are supported: \"kubernetes\", \"istiod\", \"custom\" and \"none\".",
+                  "type": "string"
+                },
+                "platform": {
+                  "description": "Platform in which Istio is deployed. Possible values are: \"openshift\" and \"gcp\"\nAn empty value means it is a vanilla Kubernetes distribution, therefore no special\ntreatment will be considered.",
+                  "type": "string"
+                },
+                "podDNSSearchNamespaces": {
+                  "description": "Custom DNS config for the pod to resolve names of services in other\nclusters. Use this to add additional search domains, and other settings.\nsee https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#dns-config\nThis does not apply to gateway pods as they typically need a different\nset of DNS settings than the normal application pods (e.g. in multicluster scenarios).",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "priorityClassName": {
+                  "description": "Specifies the k8s priorityClassName for the istio control plane components.\n\nSee https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "string"
+                },
+                "proxy": {
+                  "description": "Specifies how proxies are configured within Istio.",
+                  "type": "object",
+                  "properties": {
+                    "autoInject": {
+                      "description": "Controls the 'policy' in the sidecar injector.",
+                      "type": "string"
+                    },
+                    "clusterDomain": {
+                      "description": "Domain for the cluster, default: \"cluster.local\".\n\nK8s allows this to be customized, see https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/",
+                      "type": "string"
+                    },
+                    "componentLogLevel": {
+                      "description": "Per Component log level for proxy, applies to gateways and sidecars.\n\nIf a component level is not set, then the global \"logLevel\" will be used. If left empty, \"misc:error\" is used.",
+                      "type": "string"
+                    },
+                    "enableCoreDump": {
+                      "description": "Enables core dumps for newly injected sidecars.\n\nIf set, newly injected sidecars will have core dumps enabled.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "boolean"
+                    },
+                    "excludeIPRanges": {
+                      "description": "Lists the excluded IP ranges of Istio egress traffic that the sidecar captures.",
+                      "type": "string"
+                    },
+                    "excludeInboundPorts": {
+                      "description": "Specifies the Istio ingress ports not to capture.",
+                      "type": "string"
+                    },
+                    "excludeOutboundPorts": {
+                      "description": "A comma separated list of outbound ports to be excluded from redirection to Envoy.",
+                      "type": "string"
+                    },
+                    "holdApplicationUntilProxyStarts": {
+                      "description": "Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready\n\nDeprecated: replaced by ProxyConfig setting which allows per-pod configuration of this behavior.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "boolean"
+                    },
+                    "image": {
+                      "description": "Image name or path for the proxy, default: \"proxyv2\".\n\nIf registry or tag are not specified, global.hub and global.tag are used.\n\nExamples: my-proxy (uses global.hub/tag), docker.io/myrepo/my-proxy:v1.0.0",
+                      "type": "string"
+                    },
+                    "includeIPRanges": {
+                      "description": "Lists the IP ranges of Istio egress traffic that the sidecar captures.\n\nExample: \"172.30.0.0/16,172.20.0.0/16\"\nThis would only capture egress traffic on those two IP Ranges, all other outbound traffic would # be allowed by the sidecar.\"",
+                      "type": "string"
+                    },
+                    "includeInboundPorts": {
+                      "description": "A comma separated list of inbound ports for which traffic is to be redirected to Envoy.\nThe wildcard character '*' can be used to configure redirection for all ports.",
+                      "type": "string"
+                    },
+                    "includeOutboundPorts": {
+                      "description": "A comma separated list of outbound ports for which traffic is to be redirected to Envoy, regardless of the destination IP.",
+                      "type": "string"
+                    },
+                    "lifecycle": {
+                      "description": "The k8s lifecycle hooks definition (pod.spec.containers.lifecycle) for the proxy container.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                      "type": "object",
+                      "properties": {
+                        "postStart": {
+                          "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                          "type": "object",
+                          "properties": {
+                            "exec": {
+                              "description": "Exec specifies a command to execute in the container.",
+                              "type": "object",
+                              "properties": {
+                                "command": {
+                                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "httpGet": {
+                              "description": "HTTPGet specifies an HTTP GET request to perform.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The header field value",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "path": {
+                                  "description": "Path to access on the HTTP server.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "sleep": {
+                              "description": "Sleep represents a duration that the container should sleep.",
+                              "type": "object",
+                              "required": [
+                                "seconds"
+                              ],
+                              "properties": {
+                                "seconds": {
+                                  "description": "Seconds is the number of seconds to sleep.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              }
+                            },
+                            "tcpSocket": {
+                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preStop": {
+                          "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                          "type": "object",
+                          "properties": {
+                            "exec": {
+                              "description": "Exec specifies a command to execute in the container.",
+                              "type": "object",
+                              "properties": {
+                                "command": {
+                                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "httpGet": {
+                              "description": "HTTPGet specifies an HTTP GET request to perform.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The header field value",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "path": {
+                                  "description": "Path to access on the HTTP server.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "sleep": {
+                              "description": "Sleep represents a duration that the container should sleep.",
+                              "type": "object",
+                              "required": [
+                                "seconds"
+                              ],
+                              "properties": {
+                                "seconds": {
+                                  "description": "Seconds is the number of seconds to sleep.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              }
+                            },
+                            "tcpSocket": {
+                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "logLevel": {
+                      "description": "Log level for proxy, applies to gateways and sidecars. If left empty, \"warning\" is used. Expected values are: trace\\|debug\\|info\\|warning\\|error\\|critical\\|off",
+                      "type": "string"
+                    },
+                    "outlierLogPath": {
+                      "description": "Path to the file to which the proxy will write outlier detection logs.\n\nExample: \"/dev/stdout\"\nThis would write the logs to standard output.",
+                      "type": "string"
+                    },
+                    "privileged": {
+                      "description": "Enables privileged securityContext for the istio-proxy container.\n\nSee https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                      "type": "boolean"
+                    },
+                    "readinessFailureThreshold": {
+                      "description": "Sets the number of successive failed probes before indicating readiness failure.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "readinessInitialDelaySeconds": {
+                      "description": "Sets the initial delay for readiness probes in seconds.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "readinessPeriodSeconds": {
+                      "description": "Sets the interval between readiness probes in seconds.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "resources": {
+                      "description": "K8s resources settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "startupProbe": {
+                      "description": "Configures the startup probe for the istio-proxy container.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "description": "Enables or disables a startup probe.\nFor optimal startup times, changing this should be tied to the readiness probe values.\n\nIf the probe is enabled, it is recommended to have delay=0s,period=15s,failureThreshold=4.\nThis ensures the pod is marked ready immediately after the startup probe passes (which has a 1s poll interval),\nand doesn't spam the readiness endpoint too much\n\nIf the probe is disabled, it is recommended to have delay=1s,period=2s,failureThreshold=30.\nThis ensures the startup is reasonable fast (polling every 2s). 1s delay is used since the startup is not often ready instantly.",
+                          "type": "boolean"
+                        },
+                        "failureThreshold": {
+                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "statusPort": {
+                      "description": "Default port used for the Pilot agent's health checks.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "tracer": {
+                      "description": "Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.\nIf using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.",
+                      "type": "string",
+                      "enum": [
+                        "zipkin",
+                        "lightstep",
+                        "datadog",
+                        "stackdriver",
+                        "openCensusAgent",
+                        "none"
+                      ]
+                    }
+                  }
+                },
+                "proxy_init": {
+                  "description": "Specifies the Configuration for proxy_init container which sets the pods' networking to intercept the inbound/outbound traffic.",
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "description": "Specifies the image for the proxy_init container.",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "K8s resources settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "remotePilotAddress": {
+                  "description": "Specifies the Istio control plane\u2019s pilot Pod IP address or remote cluster DNS resolvable hostname.",
+                  "type": "string"
+                },
+                "revision": {
+                  "description": "Configures the revision this control plane is a part of",
+                  "type": "string"
+                },
+                "sds": {
+                  "description": "Specifies the Configuration for the SecretDiscoveryService instead of using K8S secrets to mount the certificates.",
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "description": "Deprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "object",
+                      "properties": {
+                        "aud": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "sts": {
+                  "description": "Specifies the configuration for Security Token Service.",
+                  "type": "object",
+                  "properties": {
+                    "servicePort": {
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "tag": {
+                  "description": "Specifies the tag for the Istio docker images.",
+                  "type": "string"
+                },
+                "tracer": {
+                  "description": "Specifies the Configuration for each of the supported tracers.",
+                  "type": "object",
+                  "properties": {
+                    "datadog": {
+                      "description": "Configuration for the datadog tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address in host:port format for reporting trace data to the Datadog agent.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "lightstep": {
+                      "description": "Configuration for the lightstep tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "accessToken": {
+                          "description": "Sets the lightstep access token.",
+                          "type": "string"
+                        },
+                        "address": {
+                          "description": "Sets the lightstep satellite pool address in host:port format for reporting trace data.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "stackdriver": {
+                      "description": "Configuration for the stackdriver tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "debug": {
+                          "description": "enables trace output to stdout.",
+                          "type": "boolean"
+                        },
+                        "maxNumberOfAnnotations": {
+                          "description": "The global default max number of annotation events per span.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "maxNumberOfAttributes": {
+                          "description": "The global default max number of attributes per span.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "maxNumberOfMessageEvents": {
+                          "description": "The global default max number of message events per span.",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "zipkin": {
+                      "description": "Configuration for the zipkin tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address of zipkin instance in host:port format for reporting trace data.\n\nExample: <zipkin-collector-service>.<zipkin-collector-namespace>:941",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "variant": {
+                  "description": "The variant of the Istio container images to use. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                },
+                "waypoint": {
+                  "description": "Specifies how waypoints are configured within Istio.",
+                  "type": "object",
+                  "properties": {
+                    "affinity": {
+                      "description": "K8s affinity settings for waypoint pods.\n\nSee https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity",
+                      "type": "object",
+                      "properties": {
+                        "nodeAffinity": {
+                          "description": "Describes node affinity scheduling rules for the pod.",
+                          "type": "object",
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                              "type": "array",
+                              "items": {
+                                "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                "type": "object",
+                                "required": [
+                                  "preference",
+                                  "weight"
+                                ],
+                                "properties": {
+                                  "preference": {
+                                    "description": "A node selector term, associated with the corresponding weight.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "A list of node selector requirements by node's labels.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchFields": {
+                                        "description": "A list of node selector requirements by node's fields.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "weight": {
+                                    "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                              "type": "object",
+                              "required": [
+                                "nodeSelectorTerms"
+                              ],
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "description": "Required. A list of node selector terms. The terms are ORed.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "A list of node selector requirements by node's labels.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchFields": {
+                                        "description": "A list of node selector requirements by node's fields.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          }
+                        },
+                        "podAffinity": {
+                          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                          "type": "object",
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                              "type": "array",
+                              "items": {
+                                "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                "type": "object",
+                                "required": [
+                                  "podAffinityTerm",
+                                  "weight"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                    "type": "object",
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                              "type": "array",
+                              "items": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "podAntiAffinity": {
+                          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                          "type": "object",
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                              "type": "array",
+                              "items": {
+                                "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                "type": "object",
+                                "required": [
+                                  "podAffinityTerm",
+                                  "weight"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                    "type": "object",
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                              "type": "array",
+                              "items": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "nodeSelector": {
+                      "description": "K8s node labels settings.\n\nSee https://kubernetes.io/docs/user-guide/node-selection/",
+                      "type": "object",
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "type": "array",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "resources": {
+                      "description": "K8s resource settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "toleration": {
+                      "description": "K8s tolerations settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/",
+                      "type": "array",
+                      "items": {
+                        "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                        "type": "object",
+                        "properties": {
+                          "effect": {
+                            "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "value": {
+                            "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "topologySpreadConstraints": {
+                      "description": "K8s topology spread constraints settings.\n\nSee https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
+                      "type": "array",
+                      "items": {
+                        "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                        "type": "object",
+                        "required": [
+                          "maxSkew",
+                          "topologyKey",
+                          "whenUnsatisfiable"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "maxSkew": {
+                            "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "minDomains": {
+                            "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "nodeAffinityPolicy": {
+                            "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "istiodRemote": {
+              "description": "Configuration for istiod-remote.\nDEPRECATED - istiod-remote chart is removed and replaced with\n`istio-discovery --set values.istiodRemote.enabled=true`\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Indicates if this cluster/install should consume a \"remote\" istiod instance,",
+                  "type": "boolean"
+                },
+                "injectionCABundle": {
+                  "description": "injector ca bundle",
+                  "type": "string"
+                },
+                "injectionPath": {
+                  "description": "Path to use for the sidecar injector webhook service.",
+                  "type": "string"
+                },
+                "injectionURL": {
+                  "description": "URL to use for sidecar injector webhook.",
+                  "type": "string"
+                }
+              }
+            },
+            "meshConfig": {
+              "description": "Defines runtime configuration of components, including Istiod and istio-agent behavior.\nSee https://istio.io/docs/reference/config/istio.mesh.v1alpha1/ for all available options.",
+              "type": "object",
+              "properties": {
+                "accessLogEncoding": {
+                  "description": "Encoding for the proxy access log (`TEXT` or `JSON`).\nDefault value is `TEXT`.",
+                  "type": "string",
+                  "enum": [
+                    "TEXT",
+                    "JSON"
+                  ]
+                },
+                "accessLogFile": {
+                  "description": "File address for the proxy access log (e.g. /dev/stdout).\nEmpty value disables access logging.",
+                  "type": "string"
+                },
+                "accessLogFormat": {
+                  "description": "Format for the proxy access log\nEmpty value results in proxy's default access log format",
+                  "type": "string"
+                },
+                "ca": {
+                  "description": "If specified, Istiod will authorize and forward the CSRs from the workloads to the specified external CA\nusing the Istio CA gRPC API.",
+                  "type": "object",
+                  "required": [
+                    "address"
+                  ],
+                  "properties": {
+                    "address": {
+                      "description": "REQUIRED. Address of the CA server implementing the Istio CA gRPC API.\nCan be IP address or a fully qualified DNS name with port\nEg: custom-ca.default.svc.cluster.local:8932, 192.168.23.2:9000",
+                      "type": "string"
+                    },
+                    "istiodSide": {
+                      "description": "Use istiodSide to specify CA Server integrate to Istiod side or Agent side\nDefault: true",
+                      "type": "boolean"
+                    },
+                    "requestTimeout": {
+                      "description": "timeout for forward CSR requests from Istiod to External CA\nDefault: 10s",
+                      "type": "string"
+                    },
+                    "tlsSettings": {
+                      "description": "Use the tlsSettings to specify the tls mode to use.\nRegarding tlsSettings:\n- DISABLE MODE is legitimate for the case Istiod is making the request via an Envoy sidecar.\nDISABLE MODE can also be used for testing\n- TLS MUTUAL MODE be on by default. If the CA certificates\n(cert bundle to verify the CA server's certificate) is omitted, Istiod will\nuse the system root certs to verify the CA server's certificate.",
+                      "type": "object",
+                      "properties": {
+                        "caCertificates": {
+                          "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                          "type": "string"
+                        },
+                        "caCrl": {
+                          "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                          "type": "string"
+                        },
+                        "clientCertificate": {
+                          "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                          "type": "string"
+                        },
+                        "credentialName": {
+                          "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                          "type": "string"
+                        },
+                        "insecureSkipVerify": {
+                          "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                          "type": "boolean"
+                        },
+                        "mode": {
+                          "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                          "type": "string",
+                          "enum": [
+                            "DISABLE",
+                            "SIMPLE",
+                            "MUTUAL",
+                            "ISTIO_MUTUAL"
+                          ]
+                        },
+                        "privateKey": {
+                          "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                          "type": "string"
+                        },
+                        "sni": {
+                          "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                          "type": "string"
+                        },
+                        "subjectAltNames": {
+                          "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "caCertificates": {
+                  "description": "The extra root certificates for workload-to-workload communication.\nThe plugin certificates (the 'cacerts' secret) or self-signed certificates (the 'istio-ca-secret' secret)\nare automatically added by Istiod.\nThe CA certificate that signs the workload certificates is automatically added by Istio Agent.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "certSigners": {
+                        "description": "when Istiod is acting as RA(registration authority)\nIf set, they are used for these signers. Otherwise, this trustAnchor is used for all signers.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "pem": {
+                        "description": "The PEM data of the certificate.",
+                        "type": "string"
+                      },
+                      "spiffeBundleUrl": {
+                        "description": "The SPIFFE bundle endpoint URL that complies to:\nhttps://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#the-spiffe-trust-domain-and-bundle\nThe endpoint should support authentication based on Web PKI:\nhttps://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#521-web-pki\nThe certificate is retrieved from the endpoint.",
+                        "type": "string"
+                      },
+                      "trustDomains": {
+                        "description": "Optional. Specify the list of trust domains to which this trustAnchor data belongs.\nIf set, they are used for these trust domains. Otherwise, this trustAnchor is used for default trust domain\nand its aliases.\nNote that we can have multiple trustAnchor data for a same trustDomain.\nIn that case, trustAnchors with a same trust domain will be merged and used together to verify peer certificates.\nIf neither certSigners nor trustDomains is set, this trustAnchor is used for all trust domains and all signers.\nIf only trustDomains is set, this trustAnchor is used for these trustDomains and all signers.\nIf only certSigners is set, this trustAnchor is used for these certSigners and all trust domains.\nIf both certSigners and trustDomains is set, this trustAnchor is only used for these signers and trust domains.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "At most one of [pem spiffeBundleUrl] should be set",
+                        "rule": "(has(self.pem)?1:0) + (has(self.spiffeBundleUrl)?1:0) <= 1"
+                      }
+                    ]
+                  }
+                },
+                "certificates": {
+                  "description": "Configure the provision of certificates.\n\nNote: Deprecated, please refer to Cert-Manager or other cert provisioning solutions to sign DNS certificates.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                  "type": "array",
+                  "items": {
+                    "description": "Certificate configures the provision of a certificate and its key.\nExample 1: key and cert stored in a secret\n```\n{ secretName: galley-cert\n\n\t  secretNamespace: istio-system\n\t  dnsNames:\n\t    - galley.istio-system.svc\n\t    - galley.mydomain.com\n\t}\n\n```\nExample 2: key and cert stored in a directory\n```\n{ dnsNames:\n  - pilot.istio-system\n  - pilot.istio-system.svc\n  - pilot.mydomain.com\n    }\n\n```",
+                    "type": "object",
+                    "properties": {
+                      "dnsNames": {
+                        "description": "The DNS names for the certificate. A certificate may contain\nmultiple DNS names.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "secretName": {
+                        "description": "Name of the secret the certificate and its key will be stored into.\nIf it is empty, it will not be stored into a secret.\nInstead, the certificate and its key will be stored into a hard-coded directory.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "configSources": {
+                  "description": "ConfigSource describes a source of configuration data for networking\nrules, and other Istio configuration artifacts. Multiple data sources\ncan be configured for a single control plane.",
+                  "type": "array",
+                  "items": {
+                    "description": "ConfigSource describes information about a configuration store inside a\nmesh. A single control plane instance can interact with one or more data\nsources.",
+                    "type": "object",
+                    "properties": {
+                      "address": {
+                        "description": "Address of the server implementing the Istio Mesh Configuration\nprotocol (MCP). Can be IP address or a fully qualified DNS name.\nUse xds:// to specify a grpc-based xds backend, k8s:// to specify a k8s controller or\nfs:/// to specify a file-based backend with absolute path to the directory.",
+                        "type": "string"
+                      },
+                      "subscribedResources": {
+                        "description": "Describes the source of configuration, if nothing is specified default is MCP",
+                        "type": "array",
+                        "items": {
+                          "description": "Resource describes the source of configuration",
+                          "type": "string",
+                          "enum": [
+                            "SERVICE_REGISTRY"
+                          ]
+                        }
+                      },
+                      "tlsSettings": {
+                        "description": "Use the tlsSettings to specify the tls mode to use. If the MCP server\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                        "type": "object",
+                        "properties": {
+                          "caCertificates": {
+                            "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                            "type": "string"
+                          },
+                          "caCrl": {
+                            "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                            "type": "string"
+                          },
+                          "clientCertificate": {
+                            "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                            "type": "string"
+                          },
+                          "credentialName": {
+                            "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                            "type": "string"
+                          },
+                          "insecureSkipVerify": {
+                            "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                            "type": "boolean"
+                          },
+                          "mode": {
+                            "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                            "type": "string",
+                            "enum": [
+                              "DISABLE",
+                              "SIMPLE",
+                              "MUTUAL",
+                              "ISTIO_MUTUAL"
+                            ]
+                          },
+                          "privateKey": {
+                            "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                            "type": "string"
+                          },
+                          "sni": {
+                            "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                            "type": "string"
+                          },
+                          "subjectAltNames": {
+                            "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "connectTimeout": {
+                  "description": "Connection timeout used by Envoy. (MUST be >=1ms)\nDefault timeout is 10s.",
+                  "type": "string"
+                },
+                "defaultConfig": {
+                  "description": "Default proxy config used by gateway and sidecars.\nIn case of Kubernetes, the proxy config is applied once during the injection process,\nand remain constant for the duration of the pod. The rest of the mesh config can be changed\nat runtime and config gets distributed dynamically.\nOn Kubernetes, this can be overridden on individual pods with the `proxy.istio.io/config` annotation.",
+                  "type": "object",
+                  "properties": {
+                    "availabilityZone": {
+                      "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    },
+                    "binaryPath": {
+                      "description": "Path to the proxy binary",
+                      "type": "string"
+                    },
+                    "caCertificatesPem": {
+                      "description": "The PEM data of the extra root certificates for workload-to-workload communication.\nThis includes the certificates defined in MeshConfig and any other certificates that Istiod uses as CA.\nThe plugin certificates (the 'cacerts' secret), self-signed certificates (the 'istio-ca-secret' secret)\nare added automatically by Istiod.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "concurrency": {
+                      "description": "The number of worker threads to run.\nIf unset, which is recommended, this will be automatically determined based on CPU requests/limits.\nIf set to 0, all cores on the machine will be used, ignoring CPU requests or limits. This can lead to major performance\nissues if CPU limits are also set.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "configPath": {
+                      "description": "Path to the generated configuration file directory.\nProxy agent generates the actual configuration and stores it in this directory.",
+                      "type": "string"
+                    },
+                    "controlPlaneAuthPolicy": {
+                      "description": "AuthenticationPolicy defines how the proxy is authenticated when it connects to the control plane.\nDefault is set to `MUTUAL_TLS`.",
+                      "type": "string",
+                      "enum": [
+                        "NONE",
+                        "MUTUAL_TLS",
+                        "INHERIT"
+                      ]
+                    },
+                    "customConfigFile": {
+                      "description": "File path of custom proxy configuration, currently used by proxies\nin front of istiod.",
+                      "type": "string"
+                    },
+                    "discoveryAddress": {
+                      "description": "Address of the discovery service exposing xDS with mTLS connection.\nThe inject configuration may override this value.",
+                      "type": "string"
+                    },
+                    "discoveryRefreshDelay": {
+                      "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    },
+                    "drainDuration": {
+                      "description": "restart. MUST be >=1s (e.g., _1s/1m/1h_)\nDefault drain duration is `45s`.",
+                      "type": "string"
+                    },
+                    "envoyAccessLogService": {
+                      "description": "Address of the service to which access logs from Envoys should be\nsent. (e.g. `accesslog-service:15000`). See [Access Log\nService](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto)\nfor details about Envoy's gRPC Access Log Service API.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address of a remove service used for various purposes (access log\nreceiver, metrics receiver, etc.). Can be IP address or a fully\nqualified DNS name.",
+                          "type": "string"
+                        },
+                        "tcpKeepalive": {
+                          "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                              "type": "string"
+                            },
+                            "probes": {
+                              "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "time": {
+                              "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "tlsSettings": {
+                          "description": "Use the `tlsSettings` to specify the tls mode to use. If the remote service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                          "type": "object",
+                          "properties": {
+                            "caCertificates": {
+                              "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                              "type": "string"
+                            },
+                            "clientCertificate": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "credentialName": {
+                              "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                              "type": "string"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                              "type": "string",
+                              "enum": [
+                                "DISABLE",
+                                "SIMPLE",
+                                "MUTUAL",
+                                "ISTIO_MUTUAL"
+                              ]
+                            },
+                            "privateKey": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "sni": {
+                              "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                              "type": "string"
+                            },
+                            "subjectAltNames": {
+                              "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envoyMetricsService": {
+                      "description": "Address of the Envoy Metrics Service implementation (e.g. `metrics-service:15000`).\nSee [Metric Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto)\nfor details about Envoy's Metrics Service API.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address of a remove service used for various purposes (access log\nreceiver, metrics receiver, etc.). Can be IP address or a fully\nqualified DNS name.",
+                          "type": "string"
+                        },
+                        "tcpKeepalive": {
+                          "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                              "type": "string"
+                            },
+                            "probes": {
+                              "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "time": {
+                              "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "tlsSettings": {
+                          "description": "Use the `tlsSettings` to specify the tls mode to use. If the remote service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                          "type": "object",
+                          "properties": {
+                            "caCertificates": {
+                              "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                              "type": "string"
+                            },
+                            "clientCertificate": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "credentialName": {
+                              "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                              "type": "string"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                              "type": "string",
+                              "enum": [
+                                "DISABLE",
+                                "SIMPLE",
+                                "MUTUAL",
+                                "ISTIO_MUTUAL"
+                              ]
+                            },
+                            "privateKey": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "sni": {
+                              "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                              "type": "string"
+                            },
+                            "subjectAltNames": {
+                              "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envoyMetricsServiceAddress": {
+                      "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    },
+                    "extraStatTags": {
+                      "description": "An additional list of tags to extract from the in-proxy Istio telemetry. These extra tags can be\nadded by configuring the telemetry extension. Each additional tag needs to be present in this list.\nExtra tags emitted by the telemetry extensions must be listed here so that they can be processed\nand exposed as Prometheus metrics.\nDeprecated: `istio.stats` is a native filter now, this field is no longer needed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "gatewayTopology": {
+                      "description": "Topology encapsulates the configuration which describes where the proxy is\nlocated i.e. behind a (or N) trusted proxy (proxies) or directly exposed\nto the internet. This configuration only effects gateways and is applied\nto all the gateways in the cluster unless overridden via annotations of the\ngateway workloads.",
+                      "type": "object",
+                      "properties": {
+                        "forwardClientCertDetails": {
+                          "description": "Configures how the gateway proxy handles x-forwarded-client-cert (XFCC)\nheader in the incoming request.",
+                          "type": "string",
+                          "enum": [
+                            "UNDEFINED",
+                            "SANITIZE",
+                            "FORWARD_ONLY",
+                            "APPEND_FORWARD",
+                            "SANITIZE_SET",
+                            "ALWAYS_FORWARD_ONLY"
+                          ]
+                        },
+                        "numTrustedProxies": {
+                          "description": "Number of trusted proxies deployed in front of the Istio gateway proxy.\nWhen this option is set to value N greater than zero, the trusted client\naddress is assumed to be the Nth address from the right end of the\nX-Forwarded-For (XFF) header from the incoming request. If the\nX-Forwarded-For (XFF) header is missing or has fewer than N addresses, the\ngateway proxy falls back to using the immediate downstream connection's\nsource address as the trusted client address.\nNote that the gateway proxy will append the downstream connection's source\naddress to the X-Forwarded-For (XFF) address and set the\nX-Envoy-External-Address header to the trusted client address before\nforwarding it to the upstream services in the cluster.\nThe default value of numTrustedProxies is 0.\nSee [Envoy XFF](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-for)\nheader handling for more details.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "proxyProtocol": {
+                          "description": "Enables [PROXY protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) for\ndownstream connections on a gateway.",
+                          "type": "object"
+                        }
+                      }
+                    },
+                    "holdApplicationUntilProxyStarts": {
+                      "description": "Boolean flag for enabling/disabling the holdApplicationUntilProxyStarts behavior.\nThis feature adds hooks to delay application startup until the pod proxy\nis ready to accept traffic, mitigating some startup race conditions.\nDefault value is 'false'.",
+                      "type": "boolean"
+                    },
+                    "image": {
+                      "description": "Specifies the details of the proxy image.",
+                      "type": "object",
+                      "properties": {
+                        "imageType": {
+                          "description": "The image type of the image.\nIstio publishes default, debug, and distroless images.\nOther values are allowed if those image types (example: centos) are published to the specified hub.\nsupported values: default, debug, distroless.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "interceptionMode": {
+                      "description": "The mode used to redirect inbound traffic to Envoy.",
+                      "type": "string",
+                      "enum": [
+                        "REDIRECT",
+                        "TPROXY",
+                        "NONE"
+                      ]
+                    },
+                    "meshId": {
+                      "description": "The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)\nAll control planes running in the same service mesh should specify the same mesh ID.\nMesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.",
+                      "type": "string"
+                    },
+                    "privateKeyProvider": {
+                      "description": "Specifies the details of the Private Key Provider configuration for gateway and sidecar proxies.",
+                      "type": "object",
+                      "properties": {
+                        "cryptomb": {
+                          "description": "Use CryptoMb private key provider",
+                          "type": "object",
+                          "properties": {
+                            "fallback": {
+                              "description": "If the private key provider isn\u2019t available (eg. the required hardware capability doesn\u2019t existed)\nEnvoy will fallback to the BoringSSL default implementation when the fallback is true.\nThe default value is false.",
+                              "type": "boolean"
+                            },
+                            "pollDelay": {
+                              "description": "How long to wait until the per-thread processing queue should be processed. If the processing queue\ngets full (eight sign or decrypt requests are received) it is processed immediately.\nHowever, if the queue is not filled before the delay has expired, the requests already in the queue\nare processed, even if the queue is not full.\nIn effect, this value controls the balance between latency and throughput.\nThe duration needs to be set to a value greater than or equal to 1 millisecond.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "qat": {
+                          "description": "Use QAT private key provider",
+                          "type": "object",
+                          "properties": {
+                            "fallback": {
+                              "description": "If the private key provider isn\u2019t available (eg. the required hardware capability doesn\u2019t existed)\nEnvoy will fallback to the BoringSSL default implementation when the fallback is true.\nThe default value is false.",
+                              "type": "boolean"
+                            },
+                            "pollDelay": {
+                              "description": "How long to wait before polling the hardware accelerator after a request has been submitted there.\nHaving a small value leads to quicker answers from the hardware but causes more polling loop spins,\nleading to potentially larger CPU usage.\nThe duration needs to be set to a value greater than or equal to 1 millisecond.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "At most one of [cryptomb qat] should be set",
+                          "rule": "(has(self.cryptomb)?1:0) + (has(self.qat)?1:0) <= 1"
+                        }
+                      ]
+                    },
+                    "proxyAdminPort": {
+                      "description": "Port on which Envoy should listen for administrative commands.\nDefault port is `15000`.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "proxyBootstrapTemplatePath": {
+                      "description": "Path to the proxy bootstrap template file",
+                      "type": "string"
+                    },
+                    "proxyHeaders": {
+                      "description": "Define the set of headers to add/modify for HTTP request/responses.\n\nTo enable an optional header, simply set the field. If no specific configuration is required, an empty object (`{}`) will enable it.\nNote: currently all headers are enabled by default.\n\nBelow shows an example of customizing the `server` header and disabling the `X-Envoy-Attempt-Count` header:\n\n```yaml\nproxyHeaders:\n\n\tserver:\n\t  value: \"my-custom-server\"\n\t# Explicitly enable Request IDs.\n\t# As this is the default, this has no effect.\n\trequestId: {}\n\tattemptCount:\n\t  disabled: true\n\n```\n\nSome headers are enabled by default, and require explicitly disabling. See below for an example of disabling all default-enabled headers:\n\n```yaml\nproxyHeaders:\n\n\tforwardedClientCert: SANITIZE\n\tserver:\n\t  disabled: true\n\trequestId:\n\t  disabled: true\n\tattemptCount:\n\t  disabled: true\n\tenvoyDebugHeaders:\n\t  disabled: true\n\tmetadataExchangeHeaders:\n\t  mode: IN_MESH\n\n```",
+                      "type": "object",
+                      "properties": {
+                        "attemptCount": {
+                          "description": "Controls the `X-Envoy-Attempt-Count` header.\nIf enabled, this header will be added on outbound request headers (including gateways) that have retries configured.\nIf disabled, this header will not be set. If it is already present, it will be preserved.\nThis header is enabled by default if not configured.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "envoyDebugHeaders": {
+                          "description": "Controls various `X-Envoy-*` headers, such as `X-Envoy-Overloaded` and `X-Envoy-Upstream-Service-Time`. If enabled,\nthese headers will be included.\nIf disabled, these headers will not be set. If they are already present, they will be preserved.\nSee the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/router/v3/router.proto#envoy-v3-api-field-extensions-filters-http-router-v3-router-suppress-envoy-headers) for more details.\nThese headers are enabled by default if not configured.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "forwardedClientCert": {
+                          "description": "Controls the `X-Forwarded-Client-Cert` header for inbound sidecar requests. To set this on gateways, use the `Topology` setting.\nTo disable the header, configure either `SANITIZE` (to always remove the header, if present) or `FORWARD_ONLY` (to leave the header as-is).\nBy default, `APPEND_FORWARD` will be used.",
+                          "type": "string",
+                          "enum": [
+                            "UNDEFINED",
+                            "SANITIZE",
+                            "FORWARD_ONLY",
+                            "APPEND_FORWARD",
+                            "SANITIZE_SET",
+                            "ALWAYS_FORWARD_ONLY"
+                          ]
+                        },
+                        "metadataExchangeHeaders": {
+                          "description": "Controls Istio metadata exchange headers `X-Envoy-Peer-Metadata` and `X-Envoy-Peer-Metadata-Id`.\nBy default, the behavior is unspecified.\nIf IN_MESH, these headers will not be appended to outbound requests from sidecars to services not in-mesh.",
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "UNDEFINED",
+                                "IN_MESH"
+                              ]
+                            }
+                          }
+                        },
+                        "requestId": {
+                          "description": "Controls the `X-Request-Id` header. If enabled, a request ID is generated for each request if one is not already set.\nThis applies to all types of traffic (inbound, outbound, and gateways).\nIf disabled, no request ID will be generate for the request. If it is already present, it will be preserved.\nWarning: request IDs are a critical component to mesh tracing and logging, so disabling this is not recommended.\nThis header is enabled by default if not configured.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "server": {
+                          "description": "Controls the `server` header. If enabled, the `Server: istio-envoy` header is set in response headers for inbound traffic (including gateways).\nIf disabled, the `Server` header is not modified. If it is already present, it will be preserved.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            },
+                            "value": {
+                              "description": "If set, and the server header is enabled, this value will be set as the server header. By default, `istio-envoy` will be used.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "setCurrentClientCertDetails": {
+                          "description": "This field is valid only when forward_client_cert_details is APPEND_FORWARD or SANITIZE_SET\nand the client connection is mTLS. It specifies the fields in\nthe client certificate to be forwarded. Note that `Hash` is always set, and\n`By` is always set when the client certificate presents the URI type Subject Alternative Name value.",
+                          "type": "object",
+                          "properties": {
+                            "cert": {
+                              "description": "Whether to forward the entire client cert in URL encoded PEM format. This will appear in the\nXFCC header comma separated from other values with the value Cert=\"PEM\".\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "chain": {
+                              "description": "Whether to forward the entire client cert chain (including the leaf cert) in URL encoded PEM\nformat. This will appear in the XFCC header comma separated from other values with the value\nChain=\"PEM\".\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "dns": {
+                              "description": "Whether to forward the DNS type Subject Alternative Names of the client cert.\nDefaults to true.",
+                              "type": "boolean"
+                            },
+                            "subject": {
+                              "description": "Whether to forward the subject of the client cert. Defaults to true.",
+                              "type": "boolean"
+                            },
+                            "uri": {
+                              "description": "Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to\ntrue.",
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "proxyMetadata": {
+                      "description": "Additional environment variables for the proxy.\nNames starting with `ISTIO_META_` will be included in the generated bootstrap and sent to the XDS server.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "proxyStatsMatcher": {
+                      "description": "Proxy stats matcher defines configuration for reporting custom Envoy stats.\nTo reduce memory and CPU overhead from Envoy stats system, Istio proxies by\ndefault create and expose only a subset of Envoy stats. This option is to\ncontrol creation of additional Envoy stats with prefix, suffix, and regex\nexpressions match on the name of the stats. This replaces the stats\ninclusion annotations\n(`sidecar.istio.io/statsInclusionPrefixes`,\n`sidecar.istio.io/statsInclusionRegexps`, and\n`sidecar.istio.io/statsInclusionSuffixes`). For example, to enable stats\nfor circuit breakers, request retries, upstream connections, and request timeouts,\nyou can specify stats matcher as follows:\n```yaml\nproxyStatsMatcher:\n\n\tinclusionRegexps:\n\t  - .*outlier_detection.*\n\t  - .*upstream_rq_retry.*\n\t  - .*upstream_cx_.*\n\tinclusionSuffixes:\n\t  - upstream_rq_timeout\n\n```\nNote including more Envoy stats might increase number of time series\ncollected by prometheus significantly. Care needs to be taken on Prometheus\nresource provision and configuration to reduce cardinality.",
+                      "type": "object",
+                      "properties": {
+                        "inclusionPrefixes": {
+                          "description": "Proxy stats name prefix matcher for inclusion.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "inclusionRegexps": {
+                          "description": "Proxy stats name regexps matcher for inclusion.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "inclusionSuffixes": {
+                          "description": "Proxy stats name suffix matcher for inclusion.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "readinessProbe": {
+                      "description": "VM Health Checking readiness probe. This health check config exactly mirrors the\nkubernetes readiness probe configuration both in schema and logic.\nOnly one health check method of 3 can be set at a time.",
+                      "type": "object",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec specifies a command to execute in the container.",
+                          "type": "object",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "failureThreshold": {
+                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "grpc": {
+                          "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                          "type": "object",
+                          "required": [
+                            "port"
+                          ],
+                          "properties": {
+                            "port": {
+                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "service": {
+                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "httpGet": {
+                          "description": "HTTPGet specifies an HTTP GET request to perform.",
+                          "type": "object",
+                          "required": [
+                            "port"
+                          ],
+                          "properties": {
+                            "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                              "type": "array",
+                              "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The header field value",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "path": {
+                              "description": "Path to access on the HTTP server.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "initialDelaySeconds": {
+                          "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "periodSeconds": {
+                          "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "successThreshold": {
+                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "tcpSocket": {
+                          "description": "TCPSocket specifies a connection to a TCP port.",
+                          "type": "object",
+                          "required": [
+                            "port"
+                          ],
+                          "properties": {
+                            "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                          "type": "integer",
+                          "format": "int64"
+                        },
+                        "timeoutSeconds": {
+                          "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "runtimeValues": {
+                      "description": "Envoy [runtime configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime) to set during bootstrapping.\nThis enables setting experimental, unsafe, unsupported, and deprecated features that should be used with extreme caution.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "sds": {
+                      "description": "Secret Discovery Service(SDS) configuration to be used by the proxy.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "description": "True if SDS is enabled.",
+                          "type": "boolean"
+                        },
+                        "k8sSaJwtPath": {
+                          "description": "Path of k8s service account JWT path.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "serviceCluster": {
+                      "description": "Service cluster defines the name for the `service_cluster` that is\nshared by all Envoy instances. This setting corresponds to\n`--service-cluster` flag in Envoy.  In a typical Envoy deployment, the\n`service-cluster` flag is used to identify the caller, for\nsource-based routing scenarios.\n\nSince Istio does not assign a local `service/service` version to each\nEnvoy instance, the name is same for all of them.  However, the\nsource/caller's identity (e.g., IP address) is encoded in the\n`--service-node` flag when launching Envoy.  When the RDS service\nreceives API calls from Envoy, it uses the value of the `service-node`\nflag to compute routes that are relative to the service instances\nlocated at that IP address.",
+                      "type": "string"
+                    },
+                    "statNameLength": {
+                      "description": "Maximum length of name field in Envoy's metrics. The length of the name field\nis determined by the length of a name field in a service and the set of labels that\ncomprise a particular version of the service. The default value is set to 189 characters.\nEnvoy's internal metrics take up 67 characters, for a total of 256 character name per metric.\nIncrease the value of this field if you find that the metrics from Envoys are truncated.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "statsdUdpAddress": {
+                      "description": "IP Address and Port of a statsd UDP listener (e.g. `10.75.241.127:9125`).",
+                      "type": "string"
+                    },
+                    "statusPort": {
+                      "description": "Port on which the agent should listen for administrative commands such as readiness probe.\nDefault is set to port `15020`.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "terminationDrainDuration": {
+                      "description": "The amount of time allowed for connections to complete on proxy shutdown.\nOn receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start gracefully draining,\ndiscouraging any new connections and allowing existing connections to complete. It then\nsleeps for the `terminationDrainDuration` and then kills any remaining active Envoy processes.\nIf not set, a default of `5s` will be applied.",
+                      "type": "string"
+                    },
+                    "tracing": {
+                      "description": "Tracing configuration to be used by the proxy.",
+                      "type": "object",
+                      "properties": {
+                        "customTags": {
+                          "description": "and gateways).\nThe key represents the name of the tag.\nEx:\n```yaml\ncustom_tags:\n\n\tnew_tag_name:\n\t  header:\n\t    name: custom-http-header-name\n\t    default_value: defaulted-value-from-custom-header\n\n```",
+                          "type": "object",
+                          "additionalProperties": {
+                            "description": "Configure custom tags that will be added to any active span.\nTags can be generated via literals, environment variables or an incoming request header.",
+                            "type": "object",
+                            "properties": {
+                              "environment": {
+                                "description": "The custom tag's value should be populated from an environmental\nvariable",
+                                "type": "object",
+                                "properties": {
+                                  "defaultValue": {
+                                    "description": "When the environment variable is not found,\nthe tag's value will be populated with this default value if specified,\notherwise the tag will not be populated.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the environment variable used to populate the tag's value",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "header": {
+                                "description": "The custom tag's value is populated by an http header from\nan incoming request.",
+                                "type": "object",
+                                "properties": {
+                                  "defaultValue": {
+                                    "description": "Default value to be used for the tag when the named HTTP header does not exist.\nThe tag will be skipped if no default value is provided.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "HTTP header name used to obtain the value from to populate the tag value.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "literal": {
+                                "description": "The custom tag's value is the specified literal.",
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "description": "Static literal value used to populate the tag value.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "At most one of [literal environment header] should be set",
+                                "rule": "(has(self.literal)?1:0) + (has(self.environment)?1:0) + (has(self.header)?1:0) <= 1"
+                              }
+                            ]
+                          }
+                        },
+                        "datadog": {
+                          "description": "Use a Datadog tracer.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "Address of the Datadog Agent.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "lightstep": {
+                          "description": "Use a Lightstep tracer.\nNOTE: For Istio 1.15+, this configuration option will result\nin using OpenTelemetry-based Lightstep integration.",
+                          "type": "object",
+                          "properties": {
+                            "accessToken": {
+                              "description": "The Lightstep access token.",
+                              "type": "string"
+                            },
+                            "address": {
+                              "description": "Address of the Lightstep Satellite pool.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "maxPathTagLength": {
+                          "description": "Configures the maximum length of the request path to extract and include in the\nHttpUrl tag. Used to truncate length request paths to meet the needs of tracing\nbackend. If not set, then a length of 256 will be used.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "openCensusAgent": {
+                          "description": "Use an OpenCensus tracer exporting to an OpenCensus agent.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "gRPC address for the OpenCensus agent (e.g. dns://authority/host:port or\nunix:path). See [gRPC naming\ndocs](https://github.com/grpc/grpc/blob/master/doc/naming.md) for\ndetails.",
+                              "type": "string"
+                            },
+                            "context": {
+                              "description": "Specifies the set of context propagation headers used for distributed\ntracing. Default is `[\"W3C_TRACE_CONTEXT\"]`. If multiple values are specified,\nthe proxy will attempt to read each header for each request and will\nwrite all headers.",
+                              "type": "array",
+                              "items": {
+                                "description": "TraceContext selects the context propagation headers used for\ndistributed tracing.",
+                                "type": "string",
+                                "enum": [
+                                  "UNSPECIFIED",
+                                  "W3C_TRACE_CONTEXT",
+                                  "GRPC_BIN",
+                                  "CLOUD_TRACE_CONTEXT",
+                                  "B3"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "sampling": {
+                          "description": "The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation,\nif not requested by the client or not forced. Default is 1.0.",
+                          "type": "number"
+                        },
+                        "stackdriver": {
+                          "description": "Use a Stackdriver tracer.",
+                          "type": "object",
+                          "properties": {
+                            "debug": {
+                              "description": "debug enables trace output to stdout.",
+                              "type": "boolean"
+                            },
+                            "maxNumberOfAnnotations": {
+                              "description": "The global default max number of annotation events per span.\ndefault is 200.",
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "maxNumberOfAttributes": {
+                              "description": "The global default max number of attributes per span.\ndefault is 200.",
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "maxNumberOfMessageEvents": {
+                              "description": "The global default max number of message events per span.\ndefault is 200.",
+                              "type": "integer",
+                              "format": "int64"
+                            }
+                          }
+                        },
+                        "tlsSettings": {
+                          "description": "Use the tlsSettings to specify the tls mode to use. If the remote tracing service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                          "type": "object",
+                          "properties": {
+                            "caCertificates": {
+                              "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                              "type": "string"
+                            },
+                            "clientCertificate": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "credentialName": {
+                              "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                              "type": "string"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                              "type": "string",
+                              "enum": [
+                                "DISABLE",
+                                "SIMPLE",
+                                "MUTUAL",
+                                "ISTIO_MUTUAL"
+                              ]
+                            },
+                            "privateKey": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "sni": {
+                              "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                              "type": "string"
+                            },
+                            "subjectAltNames": {
+                              "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "zipkin": {
+                          "description": "Use a Zipkin tracer.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "Address of the Zipkin service (e.g. _zipkin:9411_).",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "At most one of [zipkin lightstep datadog stackdriver openCensusAgent] should be set",
+                          "rule": "(has(self.zipkin)?1:0) + (has(self.lightstep)?1:0) + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0) + (has(self.openCensusAgent)?1:0) <= 1"
+                        }
+                      ]
+                    },
+                    "tracingServiceName": {
+                      "description": "Used by Envoy proxies to assign the values for the service names in trace\nspans.",
+                      "type": "string",
+                      "enum": [
+                        "APP_LABEL_AND_NAMESPACE",
+                        "CANONICAL_NAME_ONLY",
+                        "CANONICAL_NAME_AND_NAMESPACE"
+                      ]
+                    },
+                    "zipkinAddress": {
+                      "description": "Address of the Zipkin service (e.g. _zipkin:9411_).\nDEPRECATED: Use [tracing][istio.mesh.v1alpha1.ProxyConfig.tracing] instead.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "At most one of [serviceCluster tracingServiceName] should be set",
+                      "rule": "(has(self.serviceCluster)?1:0) + (has(self.tracingServiceName)?1:0) <= 1"
+                    }
+                  ]
+                },
+                "defaultDestinationRuleExportTo": {
+                  "description": "The default value for the `DestinationRule.exportTo` field. Has the same\nsyntax as `defaultServiceExportTo`.\n\nIf not set the system will use \"*\" as the default value which implies that\ndestination rules are exported to all namespaces",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "defaultHttpRetryPolicy": {
+                  "description": "Configure the default HTTP retry policy.\nThe default number of retry attempts is set at 2 for these errors:\n\n\t\"connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes\".\n\nSetting the number of attempts to 0 disables retry policy globally.\nThis setting can be overridden on a per-host basis using the Virtual Service\nAPI.\nAll settings in the retry policy except `perTryTimeout` can currently be\nconfigured globally via this field.",
+                  "type": "object",
+                  "properties": {
+                    "attempts": {
+                      "description": "Number of retries to be allowed for a given request. The interval\nbetween retries will be determined automatically (25ms+). When request\n`timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)\nor `per_try_timeout` is configured, the actual number of retries attempted also depends on\nthe specified request `timeout` and `per_try_timeout` values. MUST be >= 0. If `0`, retries will be disabled.\nThe maximum possible number of requests made will be 1 + `attempts`.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "perTryTimeout": {
+                      "description": "Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST be >=1ms.\nDefault is same value as request\n`timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute),\nwhich means no timeout.",
+                      "type": "string"
+                    },
+                    "retryOn": {
+                      "description": "Specifies the conditions under which retry takes place.\nOne or more policies can be specified using a \u2018,\u2019 delimited list.\nSee the [retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on)\nand [gRPC retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on) for more details.\n\nIn addition to the policies specified above, a list of HTTP status codes can be passed, such as `retryOn: \"503,reset\"`.\nNote these status codes refer to the actual responses received from the destination.\nFor example, if a connection is reset, Istio will translate this to 503 for it's response.\nHowever, the destination did not return a 503 error, so this would not match `\"503\"` (it would, however, match `\"reset\"`).\n\nIf not specified, this defaults to `connect-failure,refused-stream,unavailable,cancelled,503`.",
+                      "type": "string"
+                    },
+                    "retryRemoteLocalities": {
+                      "description": "Flag to specify whether the retries should retry to other localities.\nSee the [retry plugin configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_connection_management#retry-plugin-configuration) for more details.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "defaultProviders": {
+                  "description": "Specifies extension providers to use by default in Istio configuration resources.",
+                  "type": "object",
+                  "properties": {
+                    "accessLogging": {
+                      "description": "Name of the default provider(s) for access logging.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "metrics": {
+                      "description": "Name of the default provider(s) for metrics.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "tracing": {
+                      "description": "Name of the default provider(s) for tracing.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "defaultServiceExportTo": {
+                  "description": "The default value for the ServiceEntry.exportTo field and services\nimported through container registry integrations, e.g. this applies to\nKubernetes Service resources. The value is a list of namespace names and\nreserved namespace aliases. The allowed namespace aliases are:\n```\n* - All Namespaces\n. - Current Namespace\n~ - No Namespace\n```\nIf not set the system will use \"*\" as the default value which implies that\nservices are exported to all namespaces.\n\n`All namespaces` is a reasonable default for implementations that don't\nneed to restrict access or visibility of services across namespace\nboundaries. If that requirement is present it is generally good practice to\nmake the default `Current namespace` so that services are only visible\nwithin their own namespaces by default. Operators can then expand the\nvisibility of services to other namespaces as needed. Use of `No Namespace`\nis expected to be rare but can have utility for deployments where\ndependency management needs to be precise even within the scope of a single\nnamespace.\n\nFor further discussion see the reference documentation for `ServiceEntry`,\n`Sidecar`, and `Gateway`.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "defaultVirtualServiceExportTo": {
+                  "description": "The default value for the VirtualService.exportTo field. Has the same\nsyntax as `defaultServiceExportTo`.\n\nIf not set the system will use \"*\" as the default value which implies that\nvirtual services are exported to all namespaces",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "disableEnvoyListenerLog": {
+                  "description": "This flag disables Envoy Listener logs.\nSee [Listener Access Log](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-access-log)\nIstio Enables Envoy's listener access logs on \"NoRoute\" response flag.\nDefault value is `false`.",
+                  "type": "boolean"
+                },
+                "discoverySelectors": {
+                  "description": "A list of Kubernetes selectors that specify the set of namespaces that Istio considers when\ncomputing configuration updates for sidecars. This can be used to reduce Istio's computational load\nby limiting the number of entities (including services, pods, and endpoints) that are watched and processed.\nIf omitted, Istio will use the default behavior of processing all namespaces in the cluster.\nElements in the list are disjunctive (OR semantics), i.e. a namespace will be included if it matches any selector.\nThe following example selects any namespace that matches either below:\n1. The namespace has both of these labels: `env: prod` and `region: us-east1`\n2. The namespace has label `app` equal to `cassandra` or `spark`.\n```yaml\ndiscoverySelectors:\n  - matchLabels:\n    env: prod\n    region: us-east1\n  - matchExpressions:\n  - key: app\n    operator: In\n    values:\n  - cassandra\n  - spark\n\n```\nRefer to the [Kubernetes selector docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)\nfor additional detail on selector semantics.",
+                  "type": "array",
+                  "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "type": "array",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                },
+                "dnsRefreshRate": {
+                  "description": "Configures DNS refresh rate for Envoy clusters of type `STRICT_DNS`\nDefault refresh rate is `60s`.",
+                  "type": "string"
+                },
+                "enableAutoMtls": {
+                  "description": "This flag is used to enable mutual `TLS` automatically for service to service communication\nwithin the mesh, default true.\nIf set to true, and a given service does not have a corresponding `DestinationRule` configured,\nor its `DestinationRule` does not have ClientTLSSettings specified, Istio configures client side\nTLS configuration appropriately. More specifically,\nIf the upstream authentication policy is in `STRICT` mode, use Istio provisioned certificate\nfor mutual `TLS` to connect to upstream.\nIf upstream service is in plain text mode, use plain text.\nIf the upstream authentication policy is in PERMISSIVE mode, Istio configures clients to use\nmutual `TLS` when server sides are capable of accepting mutual `TLS` traffic.\nIf service `DestinationRule` exists and has `ClientTLSSettings` specified, that is always used instead.",
+                  "type": "boolean"
+                },
+                "enableEnvoyAccessLogService": {
+                  "description": "This flag enables Envoy's gRPC Access Log Service.\nSee [Access Log Service](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/grpc/v3/als.proto)\nfor details about Envoy's gRPC Access Log Service API.\nDefault value is `false`.",
+                  "type": "boolean"
+                },
+                "enablePrometheusMerge": {
+                  "description": "If enabled, Istio agent will merge metrics exposed by the application with metrics from Envoy\nand Istio agent. The sidecar injection will replace `prometheus.io` annotations present on the pod\nand redirect them towards Istio agent, which will then merge metrics of from the application with Istio metrics.\nThis relies on the annotations `prometheus.io/scrape`, `prometheus.io/port`, and\n`prometheus.io/path` annotations.\nIf you are running a separately managed Envoy with an Istio sidecar, this may cause issues, as the metrics will collide.\nIn this case, it is recommended to disable aggregation on that deployment with the\n`prometheus.istio.io/merge-metrics: \"false\"` annotation.\nIf not specified, this will be enabled by default.",
+                  "type": "boolean"
+                },
+                "enableTracing": {
+                  "description": "Flag to control generation of trace spans and request IDs.\nRequires a trace span collector defined in the proxy configuration.",
+                  "type": "boolean"
+                },
+                "extensionProviders": {
+                  "description": "Defines a list of extension providers that extend Istio's functionality. For example, the AuthorizationPolicy\ncan be used with an extension provider to delegate the authorization decision to a custom authorization system.",
+                  "type": "array",
+                  "maxItems": 1000,
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "datadog": {
+                        "description": "Configures a Datadog tracing provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the Datadog agent.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"datadog.default.svc.cluster.local\" or \"bar/datadog.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyExtAuthzGrpc": {
+                        "description": "Configures an external authorizer that implements the Envoy ext_authz filter authorization check service using the gRPC API.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "failOpen": {
+                            "description": "If true, the HTTP request or TCP connection will be allowed even if the communication with the authorization service has failed,\nor if the authorization service has returned a HTTP 5xx error.\nDefault is false. For HTTP request, it will be rejected with 403 (HTTP Forbidden). For TCP connection, it will be closed immediately.",
+                            "type": "boolean"
+                          },
+                          "includeRequestBodyInCheck": {
+                            "description": "If set, the client request body will be included in the authorization request sent to the authorization service.",
+                            "type": "object",
+                            "properties": {
+                              "allowPartialMessage": {
+                                "description": "When this field is true, ext-authz filter will buffer the message until maxRequestBytes is reached.\nThe authorization request will be dispatched and no 413 HTTP error will be returned by the filter.\nA \"x-envoy-auth-partial-body: false|true\" metadata header will be added to the authorization request message\nindicating if the body data is partial.",
+                                "type": "boolean"
+                              },
+                              "maxRequestBytes": {
+                                "description": "Sets the maximum size of a message body that the ext-authz filter will hold in memory.\nIf maxRequestBytes is reached, and allowPartialMessage is false, Envoy will return a 413 (Payload Too Large).\nOtherwise the request will be sent to the provider with a partial message.\nNote that this setting will have precedence over the failOpen field, the 413 will be returned even when the\nfailOpen is set to true.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "packAsBytes": {
+                                "description": "If true, the body sent to the external authorization service in the gRPC authorization request is set with raw bytes\nin the [raw_body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153).\nOtherwise, it will be filled with UTF-8 string in the [body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147).\nThis field only works with the envoyExtAuthzGrpc provider and has no effect for the envoyExtAuthzHttp provider.",
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ext_authz gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"my-ext-authz.foo.svc.cluster.local\" or \"bar/my-ext-authz.example.com\".",
+                            "type": "string"
+                          },
+                          "statusOnError": {
+                            "description": "Sets the HTTP status that is returned to the client when there is a network error to the authorization service.\nThe default status is \"403\" (HTTP Forbidden).",
+                            "type": "string"
+                          },
+                          "timeout": {
+                            "description": "The maximum duration that the proxy will wait for a response from the provider, this is the timeout for a specific request (default timeout: 600s).\nWhen this timeout condition is met, the proxy marks the communication to the authorization service as failure.\nIn this situation, the response sent back to the client will depend on the configured `failOpen` field.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyExtAuthzHttp": {
+                        "description": "Configures an external authorizer that implements the Envoy ext_authz filter authorization check service using the HTTP API.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "failOpen": {
+                            "description": "If true, the user request will be allowed even if the communication with the authorization service has failed,\nor if the authorization service has returned a HTTP 5xx error.\nDefault is false and the request will be rejected with \"Forbidden\" response.",
+                            "type": "boolean"
+                          },
+                          "headersToDownstreamOnAllow": {
+                            "description": "List of headers from the authorization service that should be forwarded to downstream when the authorization\ncheck result is allowed (HTTP code 200).\nIf not specified, the original response will not be modified and forwarded to downstream as-is.\nNote, any existing headers will be overridden.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "headersToDownstreamOnDeny": {
+                            "description": "List of headers from the authorization service that should be forwarded to downstream when the authorization\ncheck result is not allowed (HTTP code other than 200).\nIf not specified, all the authorization response headers, except *Authority (Host)* will be in the response to\nthe downstream.\nWhen a header is included in this list, *Path*, *Status*, *Content-Length*, *WWWAuthenticate* and *Location* are\nautomatically added.\nNote, the body from the authorization service is always included in the response to downstream.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "headersToUpstreamOnAllow": {
+                            "description": "List of headers from the authorization service that should be added or overridden in the original request and\nforwarded to the upstream when the authorization check result is allowed (HTTP code 200).\nIf not specified, the original request will not be modified and forwarded to backend as-is.\nNote, any existing headers will be overridden.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "includeAdditionalHeadersInCheck": {
+                            "description": "Set of additional fixed headers that should be included in the authorization request sent to the authorization service.\nKey is the header name and value is the header value.\nNote that client request of the same key or headers specified in includeRequestHeadersInCheck will be overridden.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "includeHeadersInCheck": {
+                            "description": "DEPRECATED. Use includeRequestHeadersInCheck instead.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "includeRequestBodyInCheck": {
+                            "description": "If set, the client request body will be included in the authorization request sent to the authorization service.",
+                            "type": "object",
+                            "properties": {
+                              "allowPartialMessage": {
+                                "description": "When this field is true, ext-authz filter will buffer the message until maxRequestBytes is reached.\nThe authorization request will be dispatched and no 413 HTTP error will be returned by the filter.\nA \"x-envoy-auth-partial-body: false|true\" metadata header will be added to the authorization request message\nindicating if the body data is partial.",
+                                "type": "boolean"
+                              },
+                              "maxRequestBytes": {
+                                "description": "Sets the maximum size of a message body that the ext-authz filter will hold in memory.\nIf maxRequestBytes is reached, and allowPartialMessage is false, Envoy will return a 413 (Payload Too Large).\nOtherwise the request will be sent to the provider with a partial message.\nNote that this setting will have precedence over the failOpen field, the 413 will be returned even when the\nfailOpen is set to true.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "packAsBytes": {
+                                "description": "If true, the body sent to the external authorization service in the gRPC authorization request is set with raw bytes\nin the [raw_body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153).\nOtherwise, it will be filled with UTF-8 string in the [body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147).\nThis field only works with the envoyExtAuthzGrpc provider and has no effect for the envoyExtAuthzHttp provider.",
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "includeRequestHeadersInCheck": {
+                            "description": "List of client request headers that should be included in the authorization request sent to the authorization service.\nNote that in addition to the headers specified here following headers are included by default:\n1. *Host*, *Method*, *Path* and *Content-Length* are automatically sent.\n2. *Content-Length* will be set to 0 and the request will not have a message body. However, the authorization\nrequest can include the buffered client request body (controlled by includeRequestBodyInCheck setting),\nconsequently the value of Content-Length of the authorization request reflects the size of its payload size.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "pathPrefix": {
+                            "description": "Sets a prefix to the value of authorization request header *Path*.\nFor example, setting this to \"/check\" for an original user request at path \"/admin\" will cause the\nauthorization check request to be sent to the authorization service at the path \"/check/admin\" instead of \"/admin\".",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ext_authz HTTP authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"my-ext-authz.foo.svc.cluster.local\" or \"bar/my-ext-authz.example.com\".",
+                            "type": "string"
+                          },
+                          "statusOnError": {
+                            "description": "Sets the HTTP status that is returned to the client when there is a network error to the authorization service.\nThe default status is \"403\" (HTTP Forbidden).",
+                            "type": "string"
+                          },
+                          "timeout": {
+                            "description": "The maximum duration that the proxy will wait for a response from the provider (default timeout: 600s).\nWhen this timeout condition is met, the proxy marks the communication to the authorization service as failure.\nIn this situation, the response sent back to the client will depend on the configured `failOpen` field.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyFileAccessLog": {
+                        "description": "Configures an Envoy File Access Log provider.",
+                        "type": "object",
+                        "properties": {
+                          "logFormat": {
+                            "description": "Optional. Allows overriding of the default access log format.",
+                            "type": "object",
+                            "properties": {
+                              "labels": {
+                                "description": "JSON structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)\ncan be used as values for fields within the Struct. Values are rendered\nas strings, numbers, or boolean values, as appropriate\n(see: [format dictionaries](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries)). Nested JSON is\nsupported for some command operators (e.g. `FILTER_STATE` or `DYNAMIC_METADATA`).\nUse `labels: {}` for default envoy JSON log format.\n\nExample:\n```\nlabels:\n\n\tstatus: \"%RESPONSE_CODE%\"\n\tmessage: \"%LOCAL_REPLY_BODY%\"\n\n```",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "text": {
+                                "description": "Textual format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be\nused in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)\nprovides more information.\n\nNOTE: Istio will insert a newline ('\\n') on all formats (if missing).\n\nExample: `text: \"%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\"`",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "At most one of [text labels] should be set",
+                                "rule": "(has(self.text)?1:0) + (has(self.labels)?1:0) <= 1"
+                              }
+                            ]
+                          },
+                          "path": {
+                            "description": "Path to a local file to write the access log entries.\nThis may be used to write to streams, via `/dev/stderr` and `/dev/stdout`\nIf unspecified, defaults to `/dev/stdout`.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyHttpAls": {
+                        "description": "Configures an Envoy Access Logging Service provider for HTTP traffic.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "additionalRequestHeadersToLog": {
+                            "description": "Optional. Additional request headers to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalResponseHeadersToLog": {
+                            "description": "Optional. Additional response headers to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalResponseTrailersToLog": {
+                            "description": "Optional. Additional response trailers to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "filterStateObjectsToLog": {
+                            "description": "Optional. Additional filter state objects to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "logName": {
+                            "description": "Optional. The friendly name of the access log.\nDefaults:\n-  \"http_envoy_accesslog\"\n-  \"listener_envoy_accesslog\"",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyOtelAls": {
+                        "description": "Configures an Envoy Open Telemetry Access Logging Service provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "logFormat": {
+                            "description": "Optional. Format for the proxy access log\nEmpty value results in proxy's default access log format, following Envoy access logging formatting.",
+                            "type": "object",
+                            "properties": {
+                              "labels": {
+                                "description": "Optional. Additional attributes that describe the specific event occurrence.\nStructured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)\ncan be used as values for fields within the Struct. Values are rendered\nas strings, numbers, or boolean values, as appropriate\n(see: [format dictionaries](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries)). Nested JSON is\nsupported for some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).\nAlias to `attributes` field in [Open Telemetry](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/open_telemetry/v3/logs_service.proto)\n\nExample:\n```\nlabels:\n\n\tstatus: \"%RESPONSE_CODE%\"\n\tmessage: \"%LOCAL_REPLY_BODY%\"\n\n```",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "text": {
+                                "description": "Textual format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be\nused in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)\nprovides more information.\nAlias to `body` field in [Open Telemetry](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/open_telemetry/v3/logs_service.proto)\nExample: `text: \"%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\"`",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "logName": {
+                            "description": "Optional. The friendly name of the access log.\nDefaults:\n- \"otel_envoy_accesslog\"",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyTcpAls": {
+                        "description": "Configures an Envoy Access Logging Service provider for TCP traffic.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "filterStateObjectsToLog": {
+                            "description": "Optional. Additional filter state objects to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "logName": {
+                            "description": "Optional. The friendly name of the access log.\nDefaults:\n- \"tcp_envoy_accesslog\"\n- \"listener_envoy_accesslog\"",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "lightstep": {
+                        "description": "Configures a Lightstep tracing provider.\nDeprecated: For Istio 1.15+, please use an OpenTelemetryTracingProvider instead, more details can be found at https://github.com/istio/istio/issues/40027\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "accessToken": {
+                            "description": "The Lightstep access token.",
+                            "type": "string"
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the Lightstep collector.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"lightstep.default.svc.cluster.local\" or \"bar/lightstep.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "REQUIRED. A unique name identifying the extension provider.",
+                        "type": "string"
+                      },
+                      "opencensus": {
+                        "description": "Configures an OpenCensusAgent tracing provider.\nDeprecated: OpenCensus is deprecated, more details can be found at https://opentelemetry.io/blog/2023/sunsetting-opencensus/\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "context": {
+                            "description": "Specifies the set of context propagation headers used for distributed\ntracing. Default is `[\"W3C_TRACE_CONTEXT\"]`. If multiple values are specified,\nthe proxy will attempt to read each header for each request and will\nwrite all headers.",
+                            "type": "array",
+                            "items": {
+                              "description": "TraceContext selects the context propagation headers used for\ndistributed tracing.",
+                              "type": "string",
+                              "enum": [
+                                "UNSPECIFIED",
+                                "W3C_TRACE_CONTEXT",
+                                "GRPC_BIN",
+                                "CLOUD_TRACE_CONTEXT",
+                                "B3"
+                              ]
+                            }
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the OpenCensusAgent.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"ocagent.default.svc.cluster.local\" or \"bar/ocagent.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "opentelemetry": {
+                        "description": "Configures an OpenTelemetry tracing provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "dynatraceSampler": {
+                            "description": "The Dynatrace adaptive traffic management (ATM) sampler.\n\nExample configuration:\n\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: \"{your-environment-id}.live.dynatrace.com\"\n    http:\n    path: \"/api/v2/otlp/v1/traces\"\n    timeout: 10s\n    headers:\n  - name: \"Authorization\"\n    value: \"Api-Token dt0c01.\"\n    resourceDetectors:\n    dynatrace: {}\n    dynatraceSampler:\n    tenant: \"{your-environment-id}\"\n    clusterId: 1234",
+                            "type": "object",
+                            "required": [
+                              "clusterId",
+                              "tenant"
+                            ],
+                            "properties": {
+                              "clusterId": {
+                                "description": "REQUIRED. The identifier of the cluster in the Dynatrace platform.\nThe cluster here is Dynatrace-specific concept and not related to the cluster concept in Istio/Envoy.\n\nThe value can be obtained from the Istio deployment page in Dynatrace.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "httpService": {
+                                "description": "Optional. Dynatrace HTTP API to obtain sampling configuration.\n\nWhen not provided, the Dynatrace Sampler will re-use the configuration from the OpenTelemetryTracingProvider HTTP Exporter\n(`service`, `port` and `http`), including the access token.",
+                                "type": "object",
+                                "required": [
+                                  "http",
+                                  "port",
+                                  "service"
+                                ],
+                                "properties": {
+                                  "http": {
+                                    "description": "REQUIRED. Specifies sampling configuration URI.",
+                                    "type": "object",
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "headers": {
+                                        "description": "Optional. Allows specifying custom HTTP headers that will be added\nto each HTTP request sent.",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "REQUIRED. The HTTP header name.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "REQUIRED. The HTTP header value.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "REQUIRED. Specifies the path on the service.",
+                                        "type": "string"
+                                      },
+                                      "timeout": {
+                                        "description": "Optional. Specifies the timeout for the HTTP request.\nIf not specified, the default is 3s.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "port": {
+                                    "description": "REQUIRED. Specifies the port of the service.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "service": {
+                                    "description": "REQUIRED. Specifies the Dynatrace environment to obtain the sampling configuration.\nThe format is `<Hostname>`, where `<Hostname>` is the fully qualified Dynatrace environment\nhost name defined in the ServiceEntry.\n\nExample: \"{your-environment-id}.live.dynatrace.com\".",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "rootSpansPerMinute": {
+                                "description": "Optional. Number of sampled spans per minute to be used\nwhen the adaptive value cannot be obtained from the Dynatrace API.\n\nA default value of `1000` is used when:\n\n- `rootSpansPerMinute` is unset\n- `rootSpansPerMinute` is set to 0",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "tenant": {
+                                "description": "REQUIRED. The Dynatrace customer's tenant identifier.\n\nThe value can be obtained from the Istio deployment page in Dynatrace.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "grpc": {
+                            "description": "Optional. Specifies the configuration for exporting OTLP traces via GRPC.\nWhen empty, traces will check whether HTTP is set.\nIf not, traces will use default GRPC configurations.\n\nThe following example shows how to configure the OpenTelemetry ExtensionProvider to export via GRPC:\n\n1. Add/change the OpenTelemetry extension provider in `MeshConfig`\n```yaml\n  - name: opentelemetry\n    opentelemetry:\n    port: 8090\n    service: tracing.example.com\n    grpc:\n    timeout: 10s\n    initialMetadata:\n  - name: \"Authentication\"\n    value: \"token-xxxxx\"\n\n```\n\n2. Deploy a `ServiceEntry` for the observability back-end\n```yaml\napiVersion: networking.istio.io/v1alpha3\nkind: ServiceEntry\nmetadata:\n\n\tname: tracing-grpc\n\nspec:\n\n\thosts:\n\t- tracing.example.com\n\tports:\n\t- number: 8090\n\t  name: grpc-port\n\t  protocol: GRPC\n\tresolution: DNS\n\tlocation: MESH_EXTERNAL\n\n```",
+                            "type": "object",
+                            "properties": {
+                              "initialMetadata": {
+                                "description": "Optional. Additional metadata to include in streams initiated to the GrpcService. This can be used for\nscenarios in which additional ad hoc authorization headers (e.g. \"x-foo-bar: baz-key\") are to\nbe injected.",
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "REQUIRED. The HTTP header name.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "REQUIRED. The HTTP header value.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "timeout": {
+                                "description": "Optional. Specifies the timeout for the GRPC request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "http": {
+                            "description": "Optional. Specifies the configuration for exporting OTLP traces via HTTP.\nWhen empty, traces will be exported via gRPC.\n\nThe following example shows how to configure the OpenTelemetry ExtensionProvider to export via HTTP:\n\n1. Add/change the OpenTelemetry extension provider in `MeshConfig`\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: my.olly-backend.com\n    http:\n    path: \"/api/otlp/traces\"\n    timeout: 10s\n    headers:\n  - name: \"my-custom-header\"\n    value: \"some value\"\n\n```\n\n2. Deploy a `ServiceEntry` for the observability back-end\n```yaml\napiVersion: networking.istio.io/v1alpha3\nkind: ServiceEntry\nmetadata:\n\n\tname: my-olly-backend\n\nspec:\n\n\thosts:\n\t- my.olly-backend.com\n\tports:\n\t- number: 443\n\t  name: https-port\n\t  protocol: HTTPS\n\tresolution: DNS\n\tlocation: MESH_EXTERNAL\n\n---\napiVersion: networking.istio.io/v1alpha3\nkind: DestinationRule\nmetadata:\n\n\tname: my-olly-backend\n\nspec:\n\n\thost: my.olly-backend.com\n\ttrafficPolicy:\n\t  portLevelSettings:\n\t  - port:\n\t      number: 443\n\t    tls:\n\t      mode: SIMPLE\n\n```",
+                            "type": "object",
+                            "required": [
+                              "path"
+                            ],
+                            "properties": {
+                              "headers": {
+                                "description": "Optional. Allows specifying custom HTTP headers that will be added\nto each HTTP request sent.",
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "REQUIRED. The HTTP header name.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "REQUIRED. The HTTP header value.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "REQUIRED. Specifies the path on the service.",
+                                "type": "string"
+                              },
+                              "timeout": {
+                                "description": "Optional. Specifies the timeout for the HTTP request.\nIf not specified, the default is 3s.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "resourceDetectors": {
+                            "description": "Optional. Specifies [Resource Detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/)\nto be used by the OpenTelemetry Tracer. When multiple resources are provided, they are merged\naccording to the OpenTelemetry [Resource specification](https://opentelemetry.io/docs/specs/otel/resource/sdk/#merge).\n\nThe following example shows how to configure the Environment Resource Detector, that will\nread the attributes from the environment variable `OTEL_RESOURCE_ATTRIBUTES`:\n\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: my.olly-backend.com\n    resourceDetectors:\n    environment: {}\n\n```",
+                            "type": "object",
+                            "properties": {
+                              "dynatrace": {
+                                "description": "Dynatrace Resource Detector.\nThe resource detector reads from the Dynatrace enrichment files\nand adds host/process related attributes to the OpenTelemetry resource.\n\nSee: [Enrich ingested data with Dynatrace-specific dimensions](https://docs.dynatrace.com/docs/shortlink/enrichment-files)",
+                                "type": "object"
+                              },
+                              "environment": {
+                                "description": "OpenTelemetry Environment Resource Detector.\nThe resource detector reads attributes from the environment variable `OTEL_RESOURCE_ATTRIBUTES`\nand adds them to the OpenTelemetry resource.\n\nSee: [Resource specification](https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable)",
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the OpenTelemetry endpoint that will receive OTLP traces.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"otlp.default.svc.cluster.local\" or \"bar/otlp.example.com\".",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "At most one of [dynatraceSampler] should be set",
+                            "rule": "(has(self.dynatraceSampler)?1:0) <= 1"
+                          }
+                        ]
+                      },
+                      "prometheus": {
+                        "description": "Configures a Prometheus metrics provider.",
+                        "type": "object"
+                      },
+                      "skywalking": {
+                        "description": "Configures a Apache SkyWalking provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "accessToken": {
+                            "description": "Optional. The SkyWalking OAP access token.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the SkyWalking receiver.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"skywalking.default.svc.cluster.local\" or \"bar/skywalking.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "stackdriver": {
+                        "description": "Configures a Stackdriver provider.",
+                        "type": "object",
+                        "properties": {
+                          "debug": {
+                            "description": "debug enables trace output to stdout.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "boolean"
+                          },
+                          "logging": {
+                            "description": "Optional. Controls Stackdriver logging behavior.",
+                            "type": "object",
+                            "properties": {
+                              "labels": {
+                                "description": "Collection of tag names and tag expressions to include in the log\nentry. Conflicts are resolved by the tag name by overriding previously\nsupplied values.\n\nExample:\n\n\tlabels:\n\t  path: request.url_path\n\t  foo: request.headers['x-foo']",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "maxNumberOfAnnotations": {
+                            "description": "The global default max number of annotation events per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "maxNumberOfAttributes": {
+                            "description": "The global default max number of attributes per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "maxNumberOfMessageEvents": {
+                            "description": "The global default max number of message events per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "zipkin": {
+                        "description": "Configures a tracing provider that uses the Zipkin API.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "enable64bitTraceId": {
+                            "description": "Optional. A 128 bit trace id will be used in Istio.\nIf true, will result in a 64 bit trace id being used.",
+                            "type": "boolean"
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "path": {
+                            "description": "Optional. Specifies the endpoint of Zipkin API.\nThe default value is \"/api/v2/spans\".",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that the Zipkin API.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"zipkin.default.svc.cluster.local\" or \"bar/zipkin.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "At most one of [envoyExtAuthzHttp envoyExtAuthzGrpc zipkin lightstep datadog stackdriver opencensus skywalking opentelemetry prometheus envoyFileAccessLog envoyHttpAls envoyTcpAls envoyOtelAls] should be set",
+                        "rule": "(has(self.envoyExtAuthzHttp)?1:0) + (has(self.envoyExtAuthzGrpc)?1:0) + (has(self.zipkin)?1:0) + (has(self.lightstep)?1:0) + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0) + (has(self.opencensus)?1:0) + (has(self.skywalking)?1:0) + (has(self.opentelemetry)?1:0) + (has(self.prometheus)?1:0) + (has(self.envoyFileAccessLog)?1:0) + (has(self.envoyHttpAls)?1:0) + (has(self.envoyTcpAls)?1:0) + (has(self.envoyOtelAls)?1:0) <= 1"
+                      }
+                    ]
+                  }
+                },
+                "h2UpgradePolicy": {
+                  "description": "Specify if http1.1 connections should be upgraded to http2 by default.\nif sidecar is installed on all pods in the mesh, then this should be set to `UPGRADE`.\nIf one or more services or namespaces do not have sidecar(s), then this should be set to `DO_NOT_UPGRADE`.\nIt can be enabled by destination using the `destinationRule.trafficPolicy.connectionPool.http.h2UpgradePolicy` override.",
+                  "type": "string",
+                  "enum": [
+                    "DO_NOT_UPGRADE",
+                    "UPGRADE"
+                  ]
+                },
+                "inboundClusterStatName": {
+                  "description": "Name to be used while emitting statistics for inbound clusters. The same pattern is used while computing stat prefix for\nnetwork filters like TCP and Redis.\nBy default, Istio emits statistics with the pattern `inbound|<port>|<port-name>|<service-FQDN>`.\nFor example `inbound|7443|grpc-reviews|reviews.prod.svc.cluster.local`. This can be used to override that pattern.\n\nA Pattern can be composed of various pre-defined variables. The following variables are supported.\n\n- `%SERVICE%` - Will be substituted with short hostname of the service.\n- `%SERVICE_NAME%` - Will be substituted with name of the service.\n- `%SERVICE_FQDN%` - Will be substituted with FQDN of the service.\n- `%SERVICE_PORT%` - Will be substituted with port of the service.\n- `%TARGET_PORT%`  - Will be substituted with the target port of the service.\n- `%SERVICE_PORT_NAME%` - Will be substituted with port name of the service.\n\nFollowing are some examples of supported patterns for reviews:\n\n- `%SERVICE_FQDN%_%SERVICE_PORT%` will use reviews.prod.svc.cluster.local_7443 as the stats name.\n- `%SERVICE%` will use reviews.prod as the stats name.",
+                  "type": "string"
+                },
+                "inboundTrafficPolicy": {
+                  "description": "Set the default behavior of the sidecar for handling inbound\ntraffic to the application.  If your application listens on\nlocalhost, you will need to set this to `LOCALHOST`.",
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "PASSTHROUGH",
+                        "LOCALHOST"
+                      ]
+                    }
+                  }
+                },
+                "ingressClass": {
+                  "description": "Class of ingress resources to be processed by Istio ingress\ncontroller. This corresponds to the value of\n`kubernetes.io/ingress.class` annotation.",
+                  "type": "string"
+                },
+                "ingressControllerMode": {
+                  "description": "Defines whether to use Istio ingress controller for annotated or all ingress resources.\nDefault mode is `STRICT`.",
+                  "type": "string",
+                  "enum": [
+                    "UNSPECIFIED",
+                    "OFF",
+                    "DEFAULT",
+                    "STRICT"
+                  ]
+                },
+                "ingressSelector": {
+                  "description": "Defines which gateway deployment to use as the Ingress controller. This field corresponds to\nthe Gateway.selector field, and will be set as `istio: INGRESS_SELECTOR`.\nBy default, `ingressgateway` is used, which will select the default IngressGateway as it has the\n`istio: ingressgateway` labels.\nIt is recommended that this is the same value as ingressService.",
+                  "type": "string"
+                },
+                "ingressService": {
+                  "description": "Name of the Kubernetes service used for the istio ingress controller.\nIf no ingress controller is specified, the default value `istio-ingressgateway` is used.",
+                  "type": "string"
+                },
+                "localityLbSetting": {
+                  "description": "Locality based load balancing distribution or failover settings.\nIf unspecified, locality based load balancing will be enabled by default.\nHowever, this requires outlierDetection to actually take effect for a particular\nservice, see https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/",
+                  "type": "object",
+                  "properties": {
+                    "distribute": {
+                      "description": "Optional: only one of distribute, failover or failoverPriority can be set.\nExplicitly specify loadbalancing weight across different zones and geographical locations.\nRefer to [Locality weighted load balancing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight)\nIf empty, the locality weight is set according to the endpoints number within it.",
+                      "type": "array",
+                      "items": {
+                        "description": "Describes how traffic originating in the 'from' zone or sub-zone is\ndistributed over a set of 'to' zones. Syntax for specifying a zone is\n{region}/{zone}/{sub-zone} and terminal wildcards are allowed on any\nsegment of the specification. Examples:\n\n`*` - matches all localities\n\n`us-west/*` - all zones and sub-zones within the us-west region\n\n`us-west/zone-1/*` - all sub-zones within us-west/zone-1",
+                        "type": "object",
+                        "properties": {
+                          "from": {
+                            "description": "Originating locality, '/' separated, e.g. 'region/zone/sub_zone'.",
+                            "type": "string"
+                          },
+                          "to": {
+                            "description": "Map of upstream localities to traffic distribution weights. The sum of\nall weights should be 100. Any locality not present will\nreceive no traffic.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable locality load balancing. This is DestinationRule-level and will override mesh-wide settings in entirety.\ne.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh-wide settings is.",
+                      "type": "boolean"
+                    },
+                    "failover": {
+                      "description": "Optional: only one of distribute, failover or failoverPriority can be set.\nExplicitly specify the region traffic will land on when endpoints in local region becomes unhealthy.\nShould be used together with OutlierDetection to detect unhealthy endpoints.\nNote: if no OutlierDetection specified, this will not take effect.",
+                      "type": "array",
+                      "items": {
+                        "description": "Specify the traffic failover policy across regions. Since zone and sub-zone\nfailover is supported by default this only needs to be specified for\nregions when the operator needs to constrain traffic failover so that\nthe default behavior of failing over to any endpoint globally does not\napply. This is useful when failing over traffic across regions would not\nimprove service health or may need to be restricted for other reasons\nlike regulatory controls.",
+                        "type": "object",
+                        "properties": {
+                          "from": {
+                            "description": "Originating region.",
+                            "type": "string"
+                          },
+                          "to": {
+                            "description": "Destination region the traffic will fail over to when endpoints in\nthe 'from' region becomes unhealthy.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "failoverPriority": {
+                      "description": "failoverPriority is an ordered list of labels used to sort endpoints to do priority based load balancing.\nThis is to support traffic failover across different groups of endpoints.\nTwo kinds of labels can be specified:\n\n  - Specify only label keys `[key1, key2, key3]`, istio would compare the label values of client with endpoints.\n    Suppose there are total N label keys `[key1, key2, key3, ...keyN]` specified:\n\n    1. Endpoints matching all N labels with the client proxy have priority P(0) i.e. the highest priority.\n    2. Endpoints matching the first N-1 labels with the client proxy have priority P(1) i.e. second highest priority.\n    3. By extension of this logic, endpoints matching only the first label with the client proxy has priority P(N-1) i.e. second lowest priority.\n    4. All the other endpoints have priority P(N) i.e. lowest priority.\n\n  - Specify labels with key and value `[key1=value1, key2=value2, key3=value3]`, istio would compare the labels with endpoints.\n    Suppose there are total N labels `[key1=value1, key2=value2, key3=value3, ...keyN=valueN]` specified:\n\n    1. Endpoints matching all N labels have priority P(0) i.e. the highest priority.\n    2. Endpoints matching the first N-1 labels have priority P(1) i.e. second highest priority.\n    3. By extension of this logic, endpoints matching only the first label has priority P(N-1) i.e. second lowest priority.\n    4. All the other endpoints have priority P(N) i.e. lowest priority.\n\nNote: For a label to be considered for match, the previous labels must match, i.e. nth label would be considered matched only if first n-1 labels match.\n\nIt can be any label specified on both client and server workloads.\nThe following labels which have special semantic meaning are also supported:\n\n  - `topology.istio.io/network` is used to match the network metadata of an endpoint, which can be specified by pod/namespace label `topology.istio.io/network`, sidecar env `ISTIO_META_NETWORK` or MeshNetworks.\n  - `topology.istio.io/cluster` is used to match the clusterID of an endpoint, which can be specified by pod label `topology.istio.io/cluster` or pod env `ISTIO_META_CLUSTER_ID`.\n  - `topology.kubernetes.io/region` is used to match the region metadata of an endpoint, which maps to Kubernetes node label `topology.kubernetes.io/region` or the deprecated label `failure-domain.beta.kubernetes.io/region`.\n  - `topology.kubernetes.io/zone` is used to match the zone metadata of an endpoint, which maps to Kubernetes node label `topology.kubernetes.io/zone` or the deprecated label `failure-domain.beta.kubernetes.io/zone`.\n  - `topology.istio.io/subzone` is used to match the subzone metadata of an endpoint, which maps to Istio node label `topology.istio.io/subzone`.\n  - `kubernetes.io/hostname` is used to match the current node of an endpoint, which maps to Kubernetes node label `kubernetes.io/hostname`.\n\nThe below topology config indicates the following priority levels:\n\n```yaml\nfailoverPriority:\n- \"topology.istio.io/network\"\n- \"topology.kubernetes.io/region\"\n- \"topology.kubernetes.io/zone\"\n- \"topology.istio.io/subzone\"\n```\n\n1. endpoints match same [network, region, zone, subzone] label with the client proxy have the highest priority.\n2. endpoints have same [network, region, zone] label but different [subzone] label with the client proxy have the second highest priority.\n3. endpoints have same [network, region] label but different [zone] label with the client proxy have the third highest priority.\n4. endpoints have same [network] but different [region] labels with the client proxy have the fourth highest priority.\n5. all the other endpoints have the same lowest priority.\n\nSuppose a service associated endpoints reside in multi clusters, the below example represents:\n1. endpoints in `clusterA` and has `version=v1` label have P(0) priority.\n2. endpoints not in `clusterA` but has `version=v1` label have P(1) priority.\n2. all the other endpoints have P(2) priority.\n\n```yaml\nfailoverPriority:\n- \"version=v1\"\n- \"topology.istio.io/cluster=clusterA\"\n```\n\nOptional: only one of distribute, failover or failoverPriority can be set.\nAnd it should be used together with `OutlierDetection` to detect unhealthy endpoints, otherwise has no effect.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "meshMTLS": {
+                  "description": "The below configuration parameters can be used to specify TLSConfig for mesh traffic.\nFor example, a user could enable min TLS version for ISTIO_MUTUAL traffic and specify a curve for non ISTIO_MUTUAL traffic like below:\n```yaml\nmeshConfig:\n\n\tmeshMTLS:\n\t  minProtocolVersion: TLSV1_3\n\ttlsDefaults:\n\t  Note: applicable only for non ISTIO_MUTUAL scenarios\n\t  ecdhCurves:\n\t    - P-256\n\t    - P-512\n\n```\nConfiguration of mTLS for traffic between workloads with ISTIO_MUTUAL TLS traffic.\n\nNote: Mesh mTLS does not respect ECDH curves.",
+                  "type": "object",
+                  "properties": {
+                    "cipherSuites": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified cipher list when negotiating TLS 1.0-1.2.\nIf not specified, the following cipher suites will be used:\n```\nECDHE-ECDSA-AES256-GCM-SHA384\nECDHE-RSA-AES256-GCM-SHA384\nECDHE-ECDSA-AES128-GCM-SHA256\nECDHE-RSA-AES128-GCM-SHA256\nAES256-GCM-SHA384\nAES128-GCM-SHA256\n```",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "ecdhCurves": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified ECDH curves for the DH key exchange.\nIf not specified, the default curves enforced by Envoy will be used. For details about the default curves, refer to\n[Ecdh Curves](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "minProtocolVersion": {
+                      "description": "Optional: the minimum TLS protocol version. The default minimum\nTLS version will be TLS 1.2. As servers may not be Envoy and be\nset to TLS 1.2 (e.g., workloads using mTLS without sidecars), the\nminimum TLS version for clients may also be TLS 1.2.\nIn the current Istio implementation, the maximum TLS protocol version\nis TLS 1.3.",
+                      "type": "string",
+                      "enum": [
+                        "TLS_AUTO",
+                        "TLSV1_2",
+                        "TLSV1_3"
+                      ]
+                    }
+                  }
+                },
+                "outboundClusterStatName": {
+                  "description": "Name to be used while emitting statistics for outbound clusters. The same pattern is used while computing stat prefix for\nnetwork filters like TCP and Redis.\nBy default, Istio emits statistics with the pattern `outbound|<port>|<subsetname>|<service-FQDN>`.\nFor example `outbound|8080|v2|reviews.prod.svc.cluster.local`. This can be used to override that pattern.\n\nA Pattern can be composed of various pre-defined variables. The following variables are supported.\n\n- `%SERVICE%` - Will be substituted with short hostname of the service.\n- `%SERVICE_NAME%` - Will be substituted with name of the service.\n- `%SERVICE_FQDN%` - Will be substituted with FQDN of the service.\n- `%SERVICE_PORT%` - Will be substituted with port of the service.\n- `%SERVICE_PORT_NAME%` - Will be substituted with port name of the service.\n- `%SUBSET_NAME%` - Will be substituted with subset.\n\nFollowing are some examples of supported patterns for reviews:\n\n- `%SERVICE_FQDN%_%SERVICE_PORT%` will use `reviews.prod.svc.cluster.local_7443` as the stats name.\n- `%SERVICE%` will use reviews.prod as the stats name.",
+                  "type": "string"
+                },
+                "outboundTrafficPolicy": {
+                  "description": "Set the default behavior of the sidecar for handling outbound\ntraffic from the application.\n\nCan be overridden at a Sidecar level by setting the `OutboundTrafficPolicy` in the\n[Sidecar API](https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy).\n\nDefault mode is `ALLOW_ANY`, which means outbound traffic to unknown destinations will be allowed.",
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "REGISTRY_ONLY",
+                        "ALLOW_ANY"
+                      ]
+                    }
+                  }
+                },
+                "pathNormalization": {
+                  "description": "ProxyPathNormalization configures how URL paths in incoming and outgoing HTTP requests are\nnormalized by the sidecars and gateways.\nThe normalized paths will be used in all aspects through the requests' lifetime on the\nsidecars and gateways, which includes routing decisions in outbound direction (client proxy),\nauthorization policy match and enforcement in inbound direction (server proxy), and the URL\npath proxied to the upstream service.\nIf not set, the NormalizationType.DEFAULT configuration will be used.",
+                  "type": "object",
+                  "properties": {
+                    "normalization": {
+                      "type": "string",
+                      "enum": [
+                        "DEFAULT",
+                        "NONE",
+                        "BASE",
+                        "MERGE_SLASHES",
+                        "DECODE_AND_MERGE_SLASHES"
+                      ]
+                    }
+                  }
+                },
+                "protocolDetectionTimeout": {
+                  "description": "Automatic protocol detection uses a set of heuristics to\ndetermine whether the connection is using TLS or not (on the\nserver side), as well as the application protocol being used\n(e.g., http vs tcp). These heuristics rely on the client sending\nthe first bits of data. For server first protocols like MySQL,\nMongoDB, etc. Envoy will timeout on the protocol detection after\nthe specified period, defaulting to non mTLS plain TCP\ntraffic. Set this field to tweak the period that Envoy will wait\nfor the client to send the first bits of data. (MUST be >=1ms or\n0s to disable). Default detection timeout is 0s (no timeout).\n\nSetting a timeout is not recommended nor safe. Even high timeouts (>5s) will be hit\noccasionally, and when they occur the result is typically broken traffic that may not\nrecover on its own. Exceptionally high values might solve this, but injecting 60s delays\nonto new connections is generally not tenable anyways.",
+                  "type": "string"
+                },
+                "proxyHttpPort": {
+                  "description": "Port on which Envoy should listen for HTTP PROXY requests if set.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "proxyInboundListenPort": {
+                  "description": "Port on which Envoy should listen for all inbound traffic to the pod/vm will be captured to.\nDefault port is 15006.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "proxyListenPort": {
+                  "description": "Port on which Envoy should listen for all outbound traffic to other services.\nDefault port is 15001.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "rootNamespace": {
+                  "description": "The namespace to treat as the administrative root namespace for\nIstio configuration. When processing a leaf namespace Istio will search for\ndeclarations in that namespace first and if none are found it will\nsearch in the root namespace. Any matching declaration found in the root\nnamespace is processed as if it were declared in the leaf namespace.\n\nThe precise semantics of this processing are documented on each resource\ntype.",
+                  "type": "string"
+                },
+                "serviceSettings": {
+                  "description": "Settings to be applied to select services.",
+                  "type": "array",
+                  "items": {
+                    "description": "Settings to be applied to select services.\n\nFor example, the following configures all services in namespace \"foo\" as well as the\n\"bar\" service in namespace \"baz\" to be considered cluster-local:\n\n```yaml\nserviceSettings:\n  - settings:\n    clusterLocal: true\n    hosts:\n  - \"*.foo.svc.cluster.local\"\n  - \"bar.baz.svc.cluster.local\"\n\n```",
+                    "type": "object",
+                    "properties": {
+                      "hosts": {
+                        "description": "The services to which the Settings should be applied. Services are selected using the hostname\nmatching rules used by DestinationRule.\n\nFor example: foo.bar.svc.cluster.local, *.baz.svc.cluster.local",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "settings": {
+                        "description": "The settings to apply to the selected services.",
+                        "type": "object",
+                        "properties": {
+                          "clusterLocal": {
+                            "description": "If true, specifies that the client and service endpoints must reside in the same cluster.\nBy default, in multi-cluster deployments, the Istio control plane assumes all service\nendpoints to be reachable from any client in any of the clusters which are part of the\nmesh. This configuration option limits the set of service endpoints visible to a client\nto be cluster scoped.\n\nThere are some common scenarios when this can be useful:\n\n  - A service (or group of services) is inherently local to the cluster and has local storage\n    for that cluster. For example, the kube-system namespace (e.g. the Kube API Server).\n  - A mesh administrator wants to slowly migrate services to Istio. They might start by first\n    having services cluster-local and then slowly transition them to mesh-wide. They could do\n    this service-by-service (e.g. mysvc.myns.svc.cluster.local) or as a group\n    (e.g. *.myns.svc.cluster.local).\n\nBy default Istio will consider kubernetes.default.svc (i.e. the API Server) as well as all\nservices in the kube-system namespace to be cluster-local, unless explicitly overridden here.",
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "tcpKeepalive": {
+                  "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                  "type": "object",
+                  "properties": {
+                    "interval": {
+                      "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                      "type": "string"
+                    },
+                    "probes": {
+                      "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "time": {
+                      "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                      "type": "string"
+                    }
+                  }
+                },
+                "tlsDefaults": {
+                  "description": "Configuration of TLS for all traffic except for ISTIO_MUTUAL mode.\nCurrently, this supports configuration of ecdhCurves and cipherSuites only.\nFor ISTIO_MUTUAL TLS settings, use meshMTLS configuration.",
+                  "type": "object",
+                  "properties": {
+                    "cipherSuites": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified cipher list when negotiating TLS 1.0-1.2.\nIf not specified, the following cipher suites will be used:\n```\nECDHE-ECDSA-AES256-GCM-SHA384\nECDHE-RSA-AES256-GCM-SHA384\nECDHE-ECDSA-AES128-GCM-SHA256\nECDHE-RSA-AES128-GCM-SHA256\nAES256-GCM-SHA384\nAES128-GCM-SHA256\n```",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "ecdhCurves": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified ECDH curves for the DH key exchange.\nIf not specified, the default curves enforced by Envoy will be used. For details about the default curves, refer to\n[Ecdh Curves](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "minProtocolVersion": {
+                      "description": "Optional: the minimum TLS protocol version. The default minimum\nTLS version will be TLS 1.2. As servers may not be Envoy and be\nset to TLS 1.2 (e.g., workloads using mTLS without sidecars), the\nminimum TLS version for clients may also be TLS 1.2.\nIn the current Istio implementation, the maximum TLS protocol version\nis TLS 1.3.",
+                      "type": "string",
+                      "enum": [
+                        "TLS_AUTO",
+                        "TLSV1_2",
+                        "TLSV1_3"
+                      ]
+                    }
+                  }
+                },
+                "trustDomain": {
+                  "description": "The trust domain corresponds to the trust root of a system.\nRefer to [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)",
+                  "type": "string"
+                },
+                "trustDomainAliases": {
+                  "description": "The trust domain aliases represent the aliases of `trustDomain`.\nFor example, if we have\n```yaml\ntrustDomain: td1\ntrustDomainAliases: [\"td2\", \"td3\"]\n```\nAny service with the identity `td1/ns/foo/sa/a-service-account`, `td2/ns/foo/sa/a-service-account`,\nor `td3/ns/foo/sa/a-service-account` will be treated the same in the Istio mesh.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "verifyCertificateAtClient": {
+                  "description": "`VerifyCertificateAtClient` sets the mesh global default for peer certificate validation\nat the client-side proxy when `SIMPLE` TLS or `MUTUAL` TLS (non `ISTIO_MUTUAL`) origination\nmodes are used. This setting can be overridden at the host level via DestinationRule API.\nBy default, `VerifyCertificateAtClient` is `true`.\n\n`CaCertificates`: If set, proxy verifies CA signature based on given CaCertificates. If unset,\nand VerifyCertificateAtClient is true, proxy uses default System CA bundle. If unset and\n`VerifyCertificateAtClient` is false, proxy will not verify the CA.\n\n`SubjectAltNames`: If set, proxy verifies subject alt names are present in the SAN. If unset,\nand `VerifyCertificateAtClient` is true, proxy uses host in destination rule to verify the SANs.\nIf unset, and `VerifyCertificateAtClient` is false, proxy does not verify SANs.\n\nFor SAN, client-side proxy will exact match host in `DestinationRule` as well as one level\nwildcard if the specified host in DestinationRule doesn't contain a wildcard.\nFor example, if the host in `DestinationRule` is `x.y.com`, client-side proxy will\nmatch either `x.y.com` or `*.y.com` for the SAN in the presented server certificate.\nFor wildcard host name in DestinationRule, client-side proxy will do a suffix match. For example,\nif host is `*.x.y.com`, client-side proxy will verify the presented server certificate SAN matches\n\u201c.x.y.com` suffix.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                  "type": "boolean"
+                }
+              }
+            },
+            "pilot": {
+              "description": "Configuration for the Pilot component.",
+              "type": "object",
+              "properties": {
+                "affinity": {
+                  "description": "K8s affinity to set on the Pilot Pods.",
+                  "type": "object",
+                  "properties": {
+                    "nodeAffinity": {
+                      "description": "Describes node affinity scheduling rules for the pod.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                            "type": "object",
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "A node selector term, associated with the corresponding weight.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                          "type": "object",
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                              "type": "array",
+                              "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      }
+                    },
+                    "podAffinity": {
+                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    },
+                    "podAntiAffinity": {
+                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    }
+                  }
+                },
+                "autoscaleBehavior": {
+                  "description": "See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior",
+                  "type": "object",
+                  "properties": {
+                    "scaleDown": {
+                      "description": "scaleDown is scaling policy for scaling Down.\nIf not set, the default value is to allow to scale down to minReplicas pods, with a\n300 second stabilization window (i.e., the highest recommendation for\nthe last 300sec is used).",
+                      "type": "object",
+                      "properties": {
+                        "policies": {
+                          "description": "policies is a list of potential scaling polices which can be used during scaling.\nAt least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
+                          "type": "array",
+                          "items": {
+                            "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                            "type": "object",
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "periodSeconds": {
+                                "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "type": {
+                                "description": "type is used to specify the scaling policy.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "scaleUp": {
+                      "description": "scaleUp is scaling policy for scaling Up.\nIf not set, the default value is the higher of:\n  * increase no more than 4 pods per 60 seconds\n  * double the number of pods per 60 seconds\nNo stabilization is used.",
+                      "type": "object",
+                      "properties": {
+                        "policies": {
+                          "description": "policies is a list of potential scaling polices which can be used during scaling.\nAt least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
+                          "type": "array",
+                          "items": {
+                            "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                            "type": "object",
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "periodSeconds": {
+                                "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "type": {
+                                "description": "type is used to specify the scaling policy.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    }
+                  }
+                },
+                "autoscaleEnabled": {
+                  "description": "Controls whether a HorizontalPodAutoscaler is installed for Pilot.",
+                  "type": "boolean"
+                },
+                "autoscaleMax": {
+                  "description": "Maximum number of replicas in the HorizontalPodAutoscaler for Pilot.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "autoscaleMin": {
+                  "description": "Minimum number of replicas in the HorizontalPodAutoscaler for Pilot.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "cni": {
+                  "description": "Configures whether to use an existing CNI installation for workloads",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Controls whether CNI should be used.",
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "description": "Specifies the CNI provider. Can be either \"default\" or \"multus\". When set to \"multus\", an annotation\n`k8s.v1.cni.cncf.io/networks` is set on injected pods to point to a NetworkAttachmentDefinition",
+                      "type": "string"
+                    }
+                  }
+                },
+                "configMap": {
+                  "description": "Configuration settings passed to Pilot as a ConfigMap.\n\nThis controls whether the mesh config map, generated from values.yaml is generated.\nIf false, pilot wil use default values or user-supplied values, in that order of preference.",
+                  "type": "boolean"
+                },
+                "cpu": {
+                  "description": "Target CPU utilization used in HorizontalPodAutoscaler.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "targetAverageUtilization": {
+                      "description": "K8s utilization setting for HorizontalPodAutoscaler target.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "deploymentLabels": {
+                  "description": "Labels that are added to Pilot deployment.\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "enabled": {
+                  "description": "Controls whether Pilot is enabled.",
+                  "type": "boolean"
+                },
+                "env": {
+                  "description": "Environment variables passed to the Pilot container.\n\nExamples:\nenv:\n\n\tENV_VAR_1: value1\n\tENV_VAR_2: value2",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "extraContainerArgs": {
+                  "description": "Additional container arguments for the Pilot container.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "hub": {
+                  "description": "Hub to pull the container image from. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Image name used for Pilot.\n\nThis can be set either to image name if hub is also set, or can be set to the full hub:name string.\n\nExamples: custom-pilot, docker.io/someuser:custom-pilot",
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "description": "Defines which IP family to use for single stack or the order of IP families for dual-stack.\nValid list items are \"IPv4\", \"IPv6\".\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ipFamilyPolicy": {
+                  "description": "Controls whether Services are configured to use IPv4, IPv6, or both. Valid options\nare PreferDualStack, RequireDualStack, and SingleStack.\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "string"
+                },
+                "istiodRemote": {
+                  "description": "Configuration for the istio-discovery chart when istiod is running in a remote cluster (e.g. \"remote control plane\").",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Indicates if this cluster/install should consume a \"remote\" istiod instance,",
+                      "type": "boolean"
+                    },
+                    "injectionCABundle": {
+                      "description": "injector ca bundle",
+                      "type": "string"
+                    },
+                    "injectionPath": {
+                      "description": "Path to use for the sidecar injector webhook service.",
+                      "type": "string"
+                    },
+                    "injectionURL": {
+                      "description": "URL to use for sidecar injector webhook.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "jwksResolverExtraRootCA": {
+                  "description": "Specifies an extra root certificate in PEM format. This certificate will be trusted\nby pilot when resolving JWKS URIs.",
+                  "type": "string"
+                },
+                "keepaliveMaxServerConnectionAge": {
+                  "description": "Maximum duration that a sidecar can be connected to a pilot.\n\nThis setting balances out load across pilot instances, but adds some resource overhead.\n\nExamples: 300s, 30m, 1h",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Target memory utilization used in HorizontalPodAutoscaler.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "targetAverageUtilization": {
+                      "description": "K8s utilization setting for HorizontalPodAutoscaler target.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "nodeSelector": {
+                  "description": "K8s node selector.\n\nSee https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "podAnnotations": {
+                  "description": "K8s annotations for pods.\n\nSee: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "podLabels": {
+                  "description": "Labels that are added to Pilot pods.\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "replicaCount": {
+                  "description": "Number of replicas in the Pilot Deployment.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "resources": {
+                  "description": "K8s resources settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "rollingMaxSurge": {
+                  "description": "K8s rolling update strategy\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "rollingMaxUnavailable": {
+                  "description": "The number of pods that can be unavailable during a rolling update (see\n`strategy.rollingUpdate.maxUnavailable` here:\nhttps://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec).\nMay be specified as a number of pods or as a percent of the total number\nof pods at the start of the update.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "seccompProfile": {
+                  "description": "The seccompProfile for the Pilot container.\n\nSee: https://kubernetes.io/docs/tutorials/security/seccomp/",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "serviceAccountAnnotations": {
+                  "description": "K8s annotations for the service account",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "serviceAnnotations": {
+                  "description": "K8s annotations for the Service.\n\nSee: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "tag": {
+                  "description": "The container image tag to pull. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "taint": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enable the untaint controller for new nodes. This aims to solve a race for CNI installation on\nnew nodes. For this to work, the newly added nodes need to have the istio CNI taint as they are\nadded to the cluster. This is usually done by configuring the cluster infra provider.",
+                      "type": "boolean"
+                    },
+                    "namespace": {
+                      "description": "The namespace of the CNI daemonset, incase it's not the same as istiod.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "tolerations": {
+                  "description": "The node tolerations to be applied to the Pilot deployment so that it can be\nscheduled to particular nodes with matching taints.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "array",
+                  "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                    "type": "object",
+                    "properties": {
+                      "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "value": {
+                        "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "topologySpreadConstraints": {
+                  "description": "The k8s topologySpreadConstraints for the Pilot pods.",
+                  "type": "array",
+                  "items": {
+                    "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                    "type": "object",
+                    "required": [
+                      "maxSkew",
+                      "topologyKey",
+                      "whenUnsatisfiable"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "maxSkew": {
+                        "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "minDomains": {
+                        "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "nodeAffinityPolicy": {
+                        "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                        "type": "string"
+                      },
+                      "topologyKey": {
+                        "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "traceSampling": {
+                  "description": "Trace sampling fraction.\n\nUsed to set the fraction of time that traces are sampled. Higher values are more accurate but add CPU overhead.\n\nAllowed values: 0.0 to 1.0",
+                  "type": "number"
+                },
+                "trustedZtunnelNamespace": {
+                  "description": "If set, `istiod` will allow connections from trusted node proxy ztunnels\nin the provided namespace.",
+                  "type": "string"
+                },
+                "variant": {
+                  "description": "The container image variant to pull. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                },
+                "volumeMounts": {
+                  "description": "Additional volumeMounts to add to the Pilot container.",
+                  "type": "array",
+                  "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                    "type": "object",
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "properties": {
+                      "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "This must match the Name of a Volume.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "recursiveReadOnly": {
+                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                        "type": "string"
+                      },
+                      "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "volumes": {
+                  "description": "Additional volumes to add to the Pilot Pod.",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "azureDisk": {
+                        "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "properties": {
+                          "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "azureFile": {
+                        "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "properties": {
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "description": "shareName is the azure share Name",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cephfs": {
+                        "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "monitors"
+                        ],
+                        "properties": {
+                          "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cinder": {
+                        "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "csi": {
+                        "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "downwardAPI": {
+                        "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "Items is a list of downward API volume file",
+                            "type": "array",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                  "type": "object",
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                  "type": "object",
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "emptyDir": {
+                        "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "object",
+                        "properties": {
+                          "medium": {
+                            "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      },
+                      "ephemeral": {
+                        "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                        "type": "object",
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                            "type": "object",
+                            "required": [
+                              "spec"
+                            ],
+                            "properties": {
+                              "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                "type": "object"
+                              },
+                              "spec": {
+                                "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                "type": "object",
+                                "properties": {
+                                  "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "dataSource": {
+                                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "dataSourceRef": {
+                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                    "type": "object",
+                                    "properties": {
+                                      "limits": {
+                                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      },
+                                      "requests": {
+                                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "selector": {
+                                    "description": "selector is a label query over volumes to consider for binding.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
+                                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "fc": {
+                        "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun is Optional: FC target lun number",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "flexVolume": {
+                        "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                            "type": "string"
+                          },
+                          "options": {
+                            "description": "options is Optional: this field holds extra command options if any.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "flocker": {
+                        "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                        "type": "object",
+                        "properties": {
+                          "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "gcePersistentDisk": {
+                        "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "object",
+                        "required": [
+                          "pdName"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "gitRepo": {
+                        "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                        "type": "object",
+                        "required": [
+                          "repository"
+                        ],
+                        "properties": {
+                          "directory": {
+                            "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                            "type": "string"
+                          },
+                          "repository": {
+                            "description": "repository is the URL",
+                            "type": "string"
+                          },
+                          "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "glusterfs": {
+                        "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                        "type": "object",
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "properties": {
+                          "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "hostPath": {
+                        "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "object",
+                        "required": [
+                          "path"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                        "type": "object",
+                        "properties": {
+                          "pullPolicy": {
+                            "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                            "type": "string"
+                          },
+                          "reference": {
+                            "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "iscsi": {
+                        "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+                        "type": "object",
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "object",
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "object",
+                        "required": [
+                          "claimName"
+                        ],
+                        "properties": {
+                          "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "photonPersistentDisk": {
+                        "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "pdID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "portworxVolume": {
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                            "type": "array",
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                              "type": "object",
+                              "properties": {
+                                "clusterTrustBundle": {
+                                  "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "type": "object",
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "description": "Relative path from the volume root to write the bundle.",
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "configMap": {
+                                  "description": "configMap information about the configMap data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "secret": {
+                                  "description": "secret information about the secret data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "quobyte": {
+                        "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "properties": {
+                          "group": {
+                            "description": "group to map volume access to\nDefault is no group",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                            "type": "string"
+                          },
+                          "user": {
+                            "description": "user to map volume access to\nDefaults to serivceaccount user",
+                            "type": "string"
+                          },
+                          "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "rbd": {
+                        "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+                        "type": "object",
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                            "type": "string"
+                          },
+                          "image": {
+                            "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "pool": {
+                            "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "scaleIO": {
+                        "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                            "type": "string"
+                          },
+                          "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "secret": {
+                        "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "storageos": {
+                        "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "vsphereVolume": {
+                        "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "volumePath"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "profile": {
+              "description": "Specifies which installation configuration profile to apply.",
+              "type": "string"
+            },
+            "revision": {
+              "description": "Identifies the revision this installation is associated with.",
+              "type": "string"
+            },
+            "sidecarInjectorWebhook": {
+              "description": "Configuration for the sidecar injector webhook.",
+              "type": "object",
+              "properties": {
+                "alwaysInjectSelector": {
+                  "description": "See NeverInjectSelector.",
+                  "type": "array",
+                  "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "type": "array",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                },
+                "defaultTemplates": {
+                  "description": "defaultTemplates: [\"sidecar\", \"hello\"]",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enableNamespacesByDefault": {
+                  "description": "Enables sidecar auto-injection in namespaces by default.",
+                  "type": "boolean"
+                },
+                "injectedAnnotations": {
+                  "description": "injectedAnnotations are additional annotations that will be added to the pod spec after injection\nThis is primarily to support PSP annotations.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "injectionURL": {
+                  "description": "Configure the injection url for sidecar injector webhook",
+                  "type": "string"
+                },
+                "neverInjectSelector": {
+                  "description": "Instructs Istio to not inject the sidecar on those pods, based on labels that are present in those pods.\n\nAnnotations in the pods have higher precedence than the label selectors.\nOrder of evaluation: Pod Annotations \u2192 NeverInjectSelector \u2192 AlwaysInjectSelector \u2192 Default Policy.\nSee https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#more-control-adding-exceptions",
+                  "type": "array",
+                  "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "type": "array",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                },
+                "reinvocationPolicy": {
+                  "description": "Setting this to `IfNeeded` will result in the sidecar injector being run again if additional mutations occur. Default: Never",
+                  "type": "string"
+                },
+                "rewriteAppHTTPProbe": {
+                  "description": "If true, webhook or istioctl injector will rewrite PodSpec for liveness health check to redirect request to sidecar. This makes liveness check work even when mTLS is enabled.",
+                  "type": "boolean"
+                },
+                "templates": {
+                  "description": "Templates defines a set of custom injection templates that can be used. For example, defining:\n\ntemplates:\n\n\thello: |\n\t  metadata:\n\t    labels:\n\t      hello: world\n\nThen starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod\nbeing injected with the hello=world labels.\nThis is intended for advanced configuration only; most users should use the built in template",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "telemetry": {
+              "description": "Controls whether telemetry is exported for Pilot.",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Controls whether telemetry is exported for Pilot.",
+                  "type": "boolean"
+                },
+                "v2": {
+                  "description": "Configuration for Telemetry v2.",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Controls whether pilot will configure telemetry v2.",
+                      "type": "boolean"
+                    },
+                    "prometheus": {
+                      "description": "Telemetry v2 settings for prometheus.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "description": "Controls whether stats envoyfilter would be enabled or not.",
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "stackdriver": {
+                      "description": "Telemetry v2 settings for stackdriver.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "version": {
+          "description": "Defines the version of Istio to install.\nMust be one of: v1.24-latest, v1.24.4, v1.24.3.",
+          "type": "string",
+          "enum": [
+            "v1.24-latest",
+            "v1.24.4",
+            "v1.24.3"
+          ]
+        }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "spec.values.global.istioNamespace must match spec.namespace",
+          "rule": "!has(self.values) || !has(self.values.global) || !has(self.values.global.istioNamespace) || self.values.global.istioNamespace == self.__namespace__"
+        }
+      ]
+    },
+    "status": {
+      "description": "IstioStatus defines the observed state of Istio",
+      "type": "object",
+      "properties": {
+        "activeRevisionName": {
+          "description": "The name of the active revision.",
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Represents the latest available observations of the object's current state.",
+          "type": "array",
+          "items": {
+            "description": "IstioCondition represents a specific observation of the IstioCondition object's state.",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Human-readable message indicating details about the last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Unique, single-word, CamelCase reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of this condition. Can be True, False or Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of this condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the most recent generation observed for this\nIstio object. It corresponds to the object's generation, which is\nupdated on mutation by the API Server. The information in the status\npertains to this particular generation of the object.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "revisions": {
+          "description": "Reports information about the underlying IstioRevisions.",
+          "type": "object",
+          "required": [
+            "inUse",
+            "ready",
+            "total"
+          ],
+          "properties": {
+            "inUse": {
+              "description": "Number of IstioRevisions that are currently in use.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "ready": {
+              "description": "Number of IstioRevisions that are Ready.",
+              "type": "integer",
+              "format": "int32"
+            },
+            "total": {
+              "description": "Total number of IstioRevisions currently associated with this Istio.",
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
+        "state": {
+          "description": "Reports the current state of the object.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "Istio",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/istiocni.json
+++ b/class_generator/schema/istiocni.json
@@ -1,0 +1,1225 @@
+{
+  "description": "IstioCNI represents a deployment of the Istio CNI component.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
+    "spec": {
+      "description": "IstioCNISpec defines the desired state of IstioCNI",
+      "type": "object",
+      "required": [
+        "namespace",
+        "version"
+      ],
+      "properties": {
+        "namespace": {
+          "description": "Namespace to which the Istio CNI component should be installed. Note that this field is immutable.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "profile": {
+          "description": "The built-in installation configuration profile to use.\nThe 'default' profile is always applied. On OpenShift, the 'openshift' profile is also applied on top of 'default'.\nMust be one of: ambient, default, demo, empty, openshift-ambient, openshift, preview, remote, stable.",
+          "type": "string",
+          "enum": [
+            "ambient",
+            "default",
+            "demo",
+            "empty",
+            "openshift-ambient",
+            "openshift",
+            "preview",
+            "remote",
+            "stable"
+          ]
+        },
+        "values": {
+          "description": "Defines the values to be passed to the Helm charts when installing Istio CNI.",
+          "type": "object",
+          "properties": {
+            "cni": {
+              "description": "Configuration for the Istio CNI plugin.",
+              "type": "object",
+              "properties": {
+                "affinity": {
+                  "description": "K8s affinity to set on the istio-cni Pods. Can be used to exclude istio-cni from being scheduled on specified nodes.",
+                  "type": "object",
+                  "properties": {
+                    "nodeAffinity": {
+                      "description": "Describes node affinity scheduling rules for the pod.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                            "type": "object",
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "A node selector term, associated with the corresponding weight.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                          "type": "object",
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                              "type": "array",
+                              "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      }
+                    },
+                    "podAffinity": {
+                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    },
+                    "podAntiAffinity": {
+                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ambient": {
+                  "description": "Configuration for Istio Ambient.",
+                  "type": "object",
+                  "properties": {
+                    "configDir": {
+                      "description": "The directory path containing the configuration files for Ambient. Defaults to /etc/ambient-config.",
+                      "type": "string"
+                    },
+                    "dnsCapture": {
+                      "description": "If enabled, and ambient is enabled, DNS redirection will be enabled.",
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "description": "Controls whether ambient redirection is enabled",
+                      "type": "boolean"
+                    },
+                    "ipv6": {
+                      "description": "UNSTABLE: If enabled, and ambient is enabled, enables ipv6 support",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "chained": {
+                  "description": "Configure the plugin as a chained CNI plugin. When true, the configuration is added to the CNI chain; when false,\nthe configuration is added as a standalone file in the CNI configuration directory.",
+                  "type": "boolean"
+                },
+                "cniBinDir": {
+                  "description": "The directory path within the cluster node's filesystem where the CNI binaries are to be installed. Typically /var/lib/cni/bin.",
+                  "type": "string"
+                },
+                "cniConfDir": {
+                  "description": "The directory path within the cluster node's filesystem where the CNI configuration files are to be installed. Typically /etc/cni/net.d.",
+                  "type": "string"
+                },
+                "cniConfFileName": {
+                  "description": "The name of the CNI plugin configuration file. Defaults to istio-cni.conf.",
+                  "type": "string"
+                },
+                "cniNetnsDir": {
+                  "description": "The directory path within the cluster node's filesystem where network namespaces are located.\nDefaults to '/var/run/netns', in minikube/docker/others can be '/var/run/docker/netns'.",
+                  "type": "string"
+                },
+                "excludeNamespaces": {
+                  "description": "List of namespaces that should be ignored by the CNI plugin.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "hub": {
+                  "description": "Hub to pull the container image from. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Image name to pull from. Image will be `Hub/Image:Tag-Variant`.\nIf Image contains a \"/\", it will replace the entire `image` in the pod.",
+                  "type": "string"
+                },
+                "logging": {
+                  "description": "Same as `global.logging.level`, but will override it if set",
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "description": "Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>\nThe control plane has different scopes depending on component, but can configure default log level across all components\nIf empty, default scope and level will be used as configured in code",
+                      "type": "string"
+                    }
+                  }
+                },
+                "podAnnotations": {
+                  "description": "Additional annotations to apply to the istio-cni Pods.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "privileged": {
+                  "description": "No longer used for CNI. See: https://github.com/istio/istio/issues/49004\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "boolean"
+                },
+                "provider": {
+                  "description": "Specifies the CNI provider. Can be either \"default\" or \"multus\". When set to \"multus\", an additional\nNetworkAttachmentDefinition resource is deployed to the cluster to allow the istio-cni plugin to be\ninvoked in a cluster using the Multus CNI plugin.",
+                  "type": "string"
+                },
+                "psp_cluster_role": {
+                  "description": "PodSecurityPolicy cluster role. No longer used anywhere.",
+                  "type": "string"
+                },
+                "pullPolicy": {
+                  "description": "Specifies the image pull policy. one of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.\n\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ]
+                },
+                "repair": {
+                  "description": "Configuration for the CNI Repair controller.",
+                  "type": "object",
+                  "properties": {
+                    "brokenPodLabelKey": {
+                      "description": "The label key to apply to a broken pod when the controller is in labelPods mode.",
+                      "type": "string"
+                    },
+                    "brokenPodLabelValue": {
+                      "description": "The label value to apply to a broken pod when the controller is in labelPods mode.",
+                      "type": "string"
+                    },
+                    "createEvents": {
+                      "description": "No longer used.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "string"
+                    },
+                    "deletePods": {
+                      "description": "The Repair controller has 3 modes (labelPods, deletePods, and repairPods). Pick which one meets your use cases. Note only one may be used.\nThe mode defines the action the controller will take when a pod is detected as broken.\nIf deletePods is true, the controller will delete the broken pod. The pod will then be rescheduled, hopefully onto a node that is fully ready.\nNote this gives the DaemonSet a relatively high privilege, as it can delete any Pod.",
+                      "type": "boolean"
+                    },
+                    "enabled": {
+                      "description": "Controls whether repair behavior is enabled.",
+                      "type": "boolean"
+                    },
+                    "hub": {
+                      "description": "Hub to pull the container image from. Image will be `Hub/Image:Tag-Variant`.",
+                      "type": "string"
+                    },
+                    "image": {
+                      "description": "Image name to pull from. Image will be `Hub/Image:Tag-Variant`.\nIf Image contains a \"/\", it will replace the entire `image` in the pod.",
+                      "type": "string"
+                    },
+                    "initContainerName": {
+                      "description": "The name of the init container to use for the repairPods mode.",
+                      "type": "string"
+                    },
+                    "labelPods": {
+                      "description": "The Repair controller has 3 modes (labelPods, deletePods, and repairPods). Pick which one meets your use cases. Note only one may be used.\nThe mode defines the action the controller will take when a pod is detected as broken.\nIf labelPods is true, the controller will label all broken pods with <brokenPodLabelKey>=<brokenPodLabelValue>.\nThis is only capable of identifying broken pods; the user is responsible for fixing them (generally, by deleting them).\nNote this gives the DaemonSet a relatively high privilege, as modifying pod metadata/status can have wider impacts.",
+                      "type": "boolean"
+                    },
+                    "repairPods": {
+                      "description": "The Repair controller has 3 modes (labelPods, deletePods, and repairPods). Pick which one meets your use cases. Note only one may be used.\nThe mode defines the action the controller will take when a pod is detected as broken.\nIf repairPods is true, the controller will dynamically repair any broken pod by setting up the pod networking configuration even after it has started.\nNote the pod will be crashlooping, so this may take a few minutes to become fully functional based on when the retry occurs.\nThis requires no RBAC privilege, but will require the CNI agent to run as a privileged pod.",
+                      "type": "boolean"
+                    },
+                    "tag": {
+                      "description": "The container image tag to pull. Image will be `Hub/Image:Tag-Variant`.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "resource_quotas": {
+                  "description": "The resource quotas configration for the CNI DaemonSet.",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Controls whether to create resource quotas or not for the CNI DaemonSet.",
+                      "type": "boolean"
+                    },
+                    "pods": {
+                      "description": "The hard limit on the number of pods in the namespace where the CNI DaemonSet is deployed.",
+                      "type": "integer",
+                      "format": "int64"
+                    }
+                  }
+                },
+                "resources": {
+                  "description": "The k8s resource requests and limits for the istio-cni Pods.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "rollingMaxUnavailable": {
+                  "description": "The number of pods that can be unavailable during a rolling update of the CNI DaemonSet (see\n`updateStrategy.rollingUpdate.maxUnavailable` here:\nhttps://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec).\nMay be specified as a number of pods or as a percent of the total number\nof pods at the start of the update.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "seccompProfile": {
+                  "description": "The Container seccompProfile\n\nSee: https://kubernetes.io/docs/tutorials/security/seccomp/",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "tag": {
+                  "description": "The container image tag to pull. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "variant": {
+                  "description": "The container image variant to pull. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                }
+              }
+            },
+            "global": {
+              "description": "Part of the global configuration applicable to the Istio CNI component.",
+              "type": "object",
+              "properties": {
+                "defaultResources": {
+                  "description": "See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "hub": {
+                  "description": "Specifies the docker hub for Istio images.",
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "Specifies the image pull policy for the Istio images. one of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.\n\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ]
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets for the control plane ServiceAccount, list of secrets in the same namespace\nto use for pulling any images in pods that reference this ServiceAccount.\nMust be set for any cluster configured with private docker registry.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "logAsJson": {
+                  "description": "Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.",
+                  "type": "boolean"
+                },
+                "logging": {
+                  "description": "Specifies the global logging level settings for the Istio control plane components.",
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "description": "Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>\nThe control plane has different scopes depending on component, but can configure default log level across all components\nIf empty, default scope and level will be used as configured in code",
+                      "type": "string"
+                    }
+                  }
+                },
+                "platform": {
+                  "description": "Platform in which Istio is deployed. Possible values are: \"openshift\" and \"gcp\"\nAn empty value means it is a vanilla Kubernetes distribution, therefore no special\ntreatment will be considered.",
+                  "type": "string"
+                },
+                "tag": {
+                  "description": "Specifies the tag for the Istio docker images.",
+                  "type": "string"
+                },
+                "variant": {
+                  "description": "The variant of the Istio container images to use. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "version": {
+          "description": "Defines the version of Istio to install.\nMust be one of: v1.24-latest, v1.24.4, v1.24.3.",
+          "type": "string",
+          "enum": [
+            "v1.24-latest",
+            "v1.24.4",
+            "v1.24.3"
+          ]
+        }
+      }
+    },
+    "status": {
+      "description": "IstioCNIStatus defines the observed state of IstioCNI",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of the object's current state.",
+          "type": "array",
+          "items": {
+            "description": "IstioCNICondition represents a specific observation of the IstioCNI object's state.",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Human-readable message indicating details about the last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Unique, single-word, CamelCase reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of this condition. Can be True, False or Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of this condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the most recent generation observed for this\nIstioCNI object. It corresponds to the object's generation, which is\nupdated on mutation by the API Server. The information in the status\npertains to this particular generation of the object.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "state": {
+          "description": "Reports the current state of the object.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "IstioCNI",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "x-kubernetes-validations": [
+    {
+      "message": "metadata.name must be 'default'",
+      "rule": "self.metadata.name == 'default'"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/istiocnilist.json
+++ b/class_generator/schema/istiocnilist.json
@@ -1,0 +1,37 @@
+{
+  "description": "IstioCNIList is a list of IstioCNI",
+  "type": "object",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "items": {
+      "description": "List of istiocnis. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": "array",
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioCNI"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "IstioCNIList",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/istiolist.json
+++ b/class_generator/schema/istiolist.json
@@ -1,0 +1,37 @@
+{
+  "description": "IstioList is a list of Istio",
+  "type": "object",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "items": {
+      "description": "List of istios. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": "array",
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.sailoperator.v1.Istio"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "IstioList",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/istiorevision.json
+++ b/class_generator/schema/istiorevision.json
@@ -1,0 +1,7143 @@
+{
+  "description": "IstioRevision represents a single revision of an Istio Service Mesh deployment.\nUsers shouldn't create IstioRevision objects directly. Instead, they should\ncreate an Istio object and allow the operator to create the underlying\nIstioRevision object(s).",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
+    "spec": {
+      "description": "IstioRevisionSpec defines the desired state of IstioRevision",
+      "type": "object",
+      "required": [
+        "namespace",
+        "version"
+      ],
+      "properties": {
+        "namespace": {
+          "description": "Namespace to which the Istio components should be installed.",
+          "type": "string",
+          "x-kubernetes-validations": [
+            {
+              "message": "Value is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
+        },
+        "values": {
+          "description": "Defines the values to be passed to the Helm charts when installing Istio.",
+          "type": "object",
+          "properties": {
+            "base": {
+              "description": "Configuration for the base component.",
+              "type": "object",
+              "properties": {
+                "excludedCRDs": {
+                  "description": "CRDs to exclude. Requires `enableCRDTemplates`",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "validationCABundle": {
+                  "description": "validation webhook CA bundle",
+                  "type": "string"
+                },
+                "validationURL": {
+                  "description": "URL to use for validating webhook.",
+                  "type": "string"
+                }
+              }
+            },
+            "compatibilityVersion": {
+              "description": "Specifies the compatibility version to use. When this is set, the control plane will\nbe configured with the same defaults as the specified version.",
+              "type": "string"
+            },
+            "defaultRevision": {
+              "description": "The name of the default revision in the cluster.",
+              "type": "string"
+            },
+            "experimental": {
+              "description": "Specifies experimental helm fields that could be removed or changed in the future",
+              "x-kubernetes-preserve-unknown-fields": true
+            },
+            "global": {
+              "description": "Global configuration for Istio components.",
+              "type": "object",
+              "properties": {
+                "arch": {
+                  "description": "Specifies pod scheduling arch(amd64, ppc64le, s390x, arm64) and weight as follows:\n\n\t0 - Never scheduled\n\t1 - Least preferred\n\t2 - No preference\n\t3 - Most preferred\n\nDeprecated: replaced by the affinity k8s settings which allows architecture nodeAffinity configuration of this behavior.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "amd64": {
+                      "description": "Sets pod scheduling weight for amd64 arch",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "arm64": {
+                      "description": "Sets pod scheduling weight for arm64 arch.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "ppc64le": {
+                      "description": "Sets pod scheduling weight for ppc64le arch.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "s390x": {
+                      "description": "Sets pod scheduling weight for s390x arch.",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "caAddress": {
+                  "description": "The address of the CA for CSR.",
+                  "type": "string"
+                },
+                "caName": {
+                  "description": "The name of the CA for workloads.\nFor example, when caName=GkeWorkloadCertificate, GKE workload certificates\nwill be used as the certificates for workloads.\nThe default value is \"\" and when caName=\"\", the CA will be configured by other\nmechanisms (e.g., environmental variable CA_PROVIDER).",
+                  "type": "string"
+                },
+                "certSigners": {
+                  "description": "List of certSigners to allow \"approve\" action in the ClusterRole",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "configCluster": {
+                  "description": "Controls whether a remote cluster is the config cluster for an external istiod",
+                  "type": "boolean"
+                },
+                "configValidation": {
+                  "description": "Controls whether the server-side validation is enabled.",
+                  "type": "boolean"
+                },
+                "defaultNodeSelector": {
+                  "description": "Default k8s node selector for all the Istio control plane components\n\nSee https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "defaultPodDisruptionBudget": {
+                  "description": "Specifies the default pod disruption budget configuration.",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Controls whether a PodDisruptionBudget with a default minAvailable value of 1 is created for each deployment.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "defaultResources": {
+                  "description": "Default k8s resources settings for all Istio control plane components.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "defaultTolerations": {
+                  "description": "Default node tolerations to be applied to all deployments so that all pods can be\nscheduled to nodes with matching taints. Each component can overwrite\nthese default values by adding its tolerations block in the relevant section below\nand setting the desired values.\nConfigure this field in case that all pods of Istio control plane are expected to\nbe scheduled to particular nodes with specified taints.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "array",
+                  "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                    "type": "object",
+                    "properties": {
+                      "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "value": {
+                        "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "externalIstiod": {
+                  "description": "Controls whether one external istiod is enabled.",
+                  "type": "boolean"
+                },
+                "hub": {
+                  "description": "Specifies the docker hub for Istio images.",
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "Specifies the image pull policy for the Istio images. one of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.\n\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ]
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets for the control plane ServiceAccount, list of secrets in the same namespace\nto use for pulling any images in pods that reference this ServiceAccount.\nMust be set for any cluster configured with private docker registry.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ipFamilies": {
+                  "description": "Defines which IP family to use for single stack or the order of IP families for dual-stack.\nValid list items are \"IPv4\", \"IPv6\".\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ipFamilyPolicy": {
+                  "description": "Controls whether Services are configured to use IPv4, IPv6, or both. Valid options\nare PreferDualStack, RequireDualStack, and SingleStack.\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "string"
+                },
+                "istioNamespace": {
+                  "description": "Specifies the default namespace for the Istio control plane components.",
+                  "type": "string"
+                },
+                "istiod": {
+                  "description": "Specifies the configution of istiod",
+                  "type": "object",
+                  "properties": {
+                    "enableAnalysis": {
+                      "description": "If enabled, istiod will perform config analysis",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "jwtPolicy": {
+                  "description": "Configure the policy for validating JWT.\nThis is deprecated and has no effect.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "string"
+                },
+                "logAsJson": {
+                  "description": "Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.",
+                  "type": "boolean"
+                },
+                "logging": {
+                  "description": "Specifies the global logging level settings for the Istio control plane components.",
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "description": "Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>\nThe control plane has different scopes depending on component, but can configure default log level across all components\nIf empty, default scope and level will be used as configured in code",
+                      "type": "string"
+                    }
+                  }
+                },
+                "meshID": {
+                  "description": "The Mesh Identifier. It should be unique within the scope where\nmeshes will interact with each other, but it is not required to be\nglobally/universally unique. For example, if any of the following are true,\nthen two meshes must have different Mesh IDs:\n- Meshes will have their telemetry aggregated in one place\n- Meshes will be federated together\n- Policy will be written referencing one mesh from the other\n\nIf an administrator expects that any of these conditions may become true in\nthe future, they should ensure their meshes have different Mesh IDs\nassigned.\n\nWithin a multicluster mesh, each cluster must be (manually or auto)\nconfigured to have the same Mesh ID value. If an existing cluster 'joins' a\nmulticluster mesh, it will need to be migrated to the new mesh ID. Details\nof migration TBD, and it may be a disruptive operation to change the Mesh\nID post-install.\n\nIf the mesh admin does not specify a value, Istio will use the value of the\nmesh's Trust Domain. The best practice is to select a proper Trust Domain\nvalue.",
+                  "type": "string"
+                },
+                "meshNetworks": {
+                  "description": "Configure the mesh networks to be used by the Split Horizon EDS.\n\nThe following example defines two networks with different endpoints association methods.\nFor `network1` all endpoints that their IP belongs to the provided CIDR range will be\nmapped to network1. The gateway for this network example is specified by its public IP\naddress and port.\nThe second network, `network2`, in this example is defined differently with all endpoints\nretrieved through the specified Multi-Cluster registry being mapped to network2. The\ngateway is also defined differently with the name of the gateway service on the remote\ncluster. The public IP for the gateway will be determined from that remote service (only\nLoadBalancer gateway service type is currently supported, for a NodePort type gateway service,\nit still need to be configured manually).\n\nmeshNetworks:\n\n\tnetwork1:\n\t  endpoints:\n\t  - fromCidr: \"192.168.0.1/24\"\n\t  gateways:\n\t  - address: 1.1.1.1\n\t    port: 80\n\tnetwork2:\n\t  endpoints:\n\t  - fromRegistry: reg1\n\t  gateways:\n\t  - registryServiceName: istio-ingressgateway.istio-system.svc.cluster.local\n\t    port: 443",
+                  "type": "object",
+                  "additionalProperties": {
+                    "description": "Network provides information about the endpoints in a routable L3\nnetwork. A single routable L3 network can have one or more service\nregistries. Note that the network has no relation to the locality of the\nendpoint. The endpoint locality will be obtained from the service\nregistry.",
+                    "type": "object",
+                    "properties": {
+                      "endpoints": {
+                        "description": "The list of endpoints in the network (obtained through the\nconstituent service registries or from CIDR ranges). All endpoints in\nthe network are directly accessible to one another.",
+                        "type": "array",
+                        "items": {
+                          "description": "NetworkEndpoints describes how the network associated with an endpoint\nshould be inferred. An endpoint will be assigned to a network based on\nthe following rules:\n\n1. Implicitly: If the registry explicitly provides information about\nthe network to which the endpoint belongs to. In some cases, its\npossible to indicate the network associated with the endpoint by\nadding the `ISTIO_META_NETWORK` environment variable to the sidecar.\n\n2. Explicitly:\n\n\ta. By matching the registry name with one of the \"fromRegistry\"\n\tin the mesh config. A \"fromRegistry\" can only be assigned to a\n\tsingle network.\n\n\tb. By matching the IP against one of the CIDR ranges in a mesh\n\tconfig network. The CIDR ranges must not overlap and be assigned to\n\ta single network.\n\n(2) will override (1) if both are present.",
+                          "type": "object",
+                          "properties": {
+                            "fromCidr": {
+                              "description": "A CIDR range for the set of endpoints in this network. The CIDR\nranges for endpoints from different networks must not overlap.",
+                              "type": "string"
+                            },
+                            "fromRegistry": {
+                              "description": "Add all endpoints from the specified registry into this network.\nThe names of the registries should correspond to the kubeconfig file name\ninside the secret that was used to configure the registry (Kubernetes\nmulticluster) or supplied by MCP server.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "At most one of [fromCidr fromRegistry] should be set",
+                              "rule": "(has(self.fromCidr)?1:0) + (has(self.fromRegistry)?1:0) <= 1"
+                            }
+                          ]
+                        }
+                      },
+                      "gateways": {
+                        "description": "Set of gateways associated with the network.",
+                        "type": "array",
+                        "items": {
+                          "description": "The gateway associated with this network. Traffic from remote networks\nwill arrive at the specified gateway:port. All incoming traffic must\nuse mTLS.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "IP address or externally resolvable DNS address associated with the gateway.",
+                              "type": "string"
+                            },
+                            "locality": {
+                              "description": "The locality associated with an explicitly specified gateway (i.e. ip)",
+                              "type": "string"
+                            },
+                            "port": {
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "registryServiceName": {
+                              "description": "A fully qualified domain name of the gateway service.  istiod will\nlookup the service from the service registries in the network and\nobtain the endpoint IPs of the gateway from the service\nregistry. Note that while the service name is a fully qualified\ndomain name, it need not be resolvable outside the orchestration\nplatform for the registry. e.g., this could be\nistio-ingressgateway.istio-system.svc.cluster.local.",
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "At most one of [registryServiceName address] should be set",
+                              "rule": "(has(self.registryServiceName)?1:0) + (has(self.address)?1:0) <= 1"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                },
+                "mountMtlsCerts": {
+                  "description": "Controls whether the in-cluster MTLS key and certs are loaded from the secret volume mounts.",
+                  "type": "boolean"
+                },
+                "multiCluster": {
+                  "description": "Specifies the Configuration for Istio mesh across multiple clusters through Istio gateways.",
+                  "type": "object",
+                  "properties": {
+                    "clusterName": {
+                      "description": "The name of the cluster this installation will run in. This is required for sidecar injection\nto properly label proxies",
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "Enables the connection between two kubernetes clusters via their respective ingressgateway services.\nUse if the pods in each cluster cannot directly talk to one another.",
+                      "type": "boolean"
+                    },
+                    "globalDomainSuffix": {
+                      "description": "The suffix for global service names.",
+                      "type": "string"
+                    },
+                    "includeEnvoyFilter": {
+                      "description": "Enable envoy filter to translate `globalDomainSuffix` to cluster local suffix for cross cluster communication.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "network": {
+                  "description": "Network defines the network this cluster belong to. This name\ncorresponds to the networks in the map of mesh networks.",
+                  "type": "string"
+                },
+                "omitSidecarInjectorConfigMap": {
+                  "description": "Controls whether the creation of the sidecar injector ConfigMap should be skipped.\nDefaults to false. When set to true, the sidecar injector ConfigMap will not be created.",
+                  "type": "boolean"
+                },
+                "operatorManageWebhooks": {
+                  "description": "Controls whether the WebhookConfiguration resource(s) should be created. The current behavior\nof Istiod is to manage its own webhook configurations.\nWhen this option is set to true, Istio Operator, instead of webhooks, manages the\nwebhook configurations. When this option is set as false, webhooks manage their\nown webhook configurations.",
+                  "type": "boolean"
+                },
+                "pilotCertProvider": {
+                  "description": "Configure the Pilot certificate provider.\nCurrently, four providers are supported: \"kubernetes\", \"istiod\", \"custom\" and \"none\".",
+                  "type": "string"
+                },
+                "platform": {
+                  "description": "Platform in which Istio is deployed. Possible values are: \"openshift\" and \"gcp\"\nAn empty value means it is a vanilla Kubernetes distribution, therefore no special\ntreatment will be considered.",
+                  "type": "string"
+                },
+                "podDNSSearchNamespaces": {
+                  "description": "Custom DNS config for the pod to resolve names of services in other\nclusters. Use this to add additional search domains, and other settings.\nsee https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#dns-config\nThis does not apply to gateway pods as they typically need a different\nset of DNS settings than the normal application pods (e.g. in multicluster scenarios).",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "priorityClassName": {
+                  "description": "Specifies the k8s priorityClassName for the istio control plane components.\n\nSee https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "string"
+                },
+                "proxy": {
+                  "description": "Specifies how proxies are configured within Istio.",
+                  "type": "object",
+                  "properties": {
+                    "autoInject": {
+                      "description": "Controls the 'policy' in the sidecar injector.",
+                      "type": "string"
+                    },
+                    "clusterDomain": {
+                      "description": "Domain for the cluster, default: \"cluster.local\".\n\nK8s allows this to be customized, see https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/",
+                      "type": "string"
+                    },
+                    "componentLogLevel": {
+                      "description": "Per Component log level for proxy, applies to gateways and sidecars.\n\nIf a component level is not set, then the global \"logLevel\" will be used. If left empty, \"misc:error\" is used.",
+                      "type": "string"
+                    },
+                    "enableCoreDump": {
+                      "description": "Enables core dumps for newly injected sidecars.\n\nIf set, newly injected sidecars will have core dumps enabled.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "boolean"
+                    },
+                    "excludeIPRanges": {
+                      "description": "Lists the excluded IP ranges of Istio egress traffic that the sidecar captures.",
+                      "type": "string"
+                    },
+                    "excludeInboundPorts": {
+                      "description": "Specifies the Istio ingress ports not to capture.",
+                      "type": "string"
+                    },
+                    "excludeOutboundPorts": {
+                      "description": "A comma separated list of outbound ports to be excluded from redirection to Envoy.",
+                      "type": "string"
+                    },
+                    "holdApplicationUntilProxyStarts": {
+                      "description": "Controls if sidecar is injected at the front of the container list and blocks the start of the other containers until the proxy is ready\n\nDeprecated: replaced by ProxyConfig setting which allows per-pod configuration of this behavior.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "boolean"
+                    },
+                    "image": {
+                      "description": "Image name or path for the proxy, default: \"proxyv2\".\n\nIf registry or tag are not specified, global.hub and global.tag are used.\n\nExamples: my-proxy (uses global.hub/tag), docker.io/myrepo/my-proxy:v1.0.0",
+                      "type": "string"
+                    },
+                    "includeIPRanges": {
+                      "description": "Lists the IP ranges of Istio egress traffic that the sidecar captures.\n\nExample: \"172.30.0.0/16,172.20.0.0/16\"\nThis would only capture egress traffic on those two IP Ranges, all other outbound traffic would # be allowed by the sidecar.\"",
+                      "type": "string"
+                    },
+                    "includeInboundPorts": {
+                      "description": "A comma separated list of inbound ports for which traffic is to be redirected to Envoy.\nThe wildcard character '*' can be used to configure redirection for all ports.",
+                      "type": "string"
+                    },
+                    "includeOutboundPorts": {
+                      "description": "A comma separated list of outbound ports for which traffic is to be redirected to Envoy, regardless of the destination IP.",
+                      "type": "string"
+                    },
+                    "lifecycle": {
+                      "description": "The k8s lifecycle hooks definition (pod.spec.containers.lifecycle) for the proxy container.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                      "type": "object",
+                      "properties": {
+                        "postStart": {
+                          "description": "PostStart is called immediately after a container is created. If the handler fails,\nthe container is terminated and restarted according to its restart policy.\nOther management of the container blocks until the hook completes.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                          "type": "object",
+                          "properties": {
+                            "exec": {
+                              "description": "Exec specifies a command to execute in the container.",
+                              "type": "object",
+                              "properties": {
+                                "command": {
+                                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "httpGet": {
+                              "description": "HTTPGet specifies an HTTP GET request to perform.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The header field value",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "path": {
+                                  "description": "Path to access on the HTTP server.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "sleep": {
+                              "description": "Sleep represents a duration that the container should sleep.",
+                              "type": "object",
+                              "required": [
+                                "seconds"
+                              ],
+                              "properties": {
+                                "seconds": {
+                                  "description": "Seconds is the number of seconds to sleep.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              }
+                            },
+                            "tcpSocket": {
+                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preStop": {
+                          "description": "PreStop is called immediately before a container is terminated due to an\nAPI request or management event such as liveness/startup probe failure,\npreemption, resource contention, etc. The handler is not called if the\ncontainer crashes or exits. The Pod's termination grace period countdown begins before the\nPreStop hook is executed. Regardless of the outcome of the handler, the\ncontainer will eventually terminate within the Pod's termination grace\nperiod (unless delayed by finalizers). Other management of the container blocks until the hook completes\nor until the termination grace period is reached.\nMore info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
+                          "type": "object",
+                          "properties": {
+                            "exec": {
+                              "description": "Exec specifies a command to execute in the container.",
+                              "type": "object",
+                              "properties": {
+                                "command": {
+                                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "httpGet": {
+                              "description": "HTTPGet specifies an HTTP GET request to perform.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The header field value",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "path": {
+                                  "description": "Path to access on the HTTP server.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "sleep": {
+                              "description": "Sleep represents a duration that the container should sleep.",
+                              "type": "object",
+                              "required": [
+                                "seconds"
+                              ],
+                              "properties": {
+                                "seconds": {
+                                  "description": "Seconds is the number of seconds to sleep.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              }
+                            },
+                            "tcpSocket": {
+                              "description": "Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept\nfor backward compatibility. There is no validation of this field and\nlifecycle hooks will fail at runtime when it is specified.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "logLevel": {
+                      "description": "Log level for proxy, applies to gateways and sidecars. If left empty, \"warning\" is used. Expected values are: trace\\|debug\\|info\\|warning\\|error\\|critical\\|off",
+                      "type": "string"
+                    },
+                    "outlierLogPath": {
+                      "description": "Path to the file to which the proxy will write outlier detection logs.\n\nExample: \"/dev/stdout\"\nThis would write the logs to standard output.",
+                      "type": "string"
+                    },
+                    "privileged": {
+                      "description": "Enables privileged securityContext for the istio-proxy container.\n\nSee https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+                      "type": "boolean"
+                    },
+                    "readinessFailureThreshold": {
+                      "description": "Sets the number of successive failed probes before indicating readiness failure.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "readinessInitialDelaySeconds": {
+                      "description": "Sets the initial delay for readiness probes in seconds.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "readinessPeriodSeconds": {
+                      "description": "Sets the interval between readiness probes in seconds.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "resources": {
+                      "description": "K8s resources settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "startupProbe": {
+                      "description": "Configures the startup probe for the istio-proxy container.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "description": "Enables or disables a startup probe.\nFor optimal startup times, changing this should be tied to the readiness probe values.\n\nIf the probe is enabled, it is recommended to have delay=0s,period=15s,failureThreshold=4.\nThis ensures the pod is marked ready immediately after the startup probe passes (which has a 1s poll interval),\nand doesn't spam the readiness endpoint too much\n\nIf the probe is disabled, it is recommended to have delay=1s,period=2s,failureThreshold=30.\nThis ensures the startup is reasonable fast (polling every 2s). 1s delay is used since the startup is not often ready instantly.",
+                          "type": "boolean"
+                        },
+                        "failureThreshold": {
+                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "statusPort": {
+                      "description": "Default port used for the Pilot agent's health checks.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "tracer": {
+                      "description": "Specify which tracer to use. One of: zipkin, lightstep, datadog, stackdriver.\nIf using stackdriver tracer outside GCP, set env GOOGLE_APPLICATION_CREDENTIALS to the GCP credential file.",
+                      "type": "string",
+                      "enum": [
+                        "zipkin",
+                        "lightstep",
+                        "datadog",
+                        "stackdriver",
+                        "openCensusAgent",
+                        "none"
+                      ]
+                    }
+                  }
+                },
+                "proxy_init": {
+                  "description": "Specifies the Configuration for proxy_init container which sets the pods' networking to intercept the inbound/outbound traffic.",
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "description": "Specifies the image for the proxy_init container.",
+                      "type": "string"
+                    },
+                    "resources": {
+                      "description": "K8s resources settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "remotePilotAddress": {
+                  "description": "Specifies the Istio control plane\u2019s pilot Pod IP address or remote cluster DNS resolvable hostname.",
+                  "type": "string"
+                },
+                "revision": {
+                  "description": "Configures the revision this control plane is a part of",
+                  "type": "string"
+                },
+                "sds": {
+                  "description": "Specifies the Configuration for the SecretDiscoveryService instead of using K8S secrets to mount the certificates.",
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "description": "Deprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                      "type": "object",
+                      "properties": {
+                        "aud": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "sts": {
+                  "description": "Specifies the configuration for Security Token Service.",
+                  "type": "object",
+                  "properties": {
+                    "servicePort": {
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "tag": {
+                  "description": "Specifies the tag for the Istio docker images.",
+                  "type": "string"
+                },
+                "tracer": {
+                  "description": "Specifies the Configuration for each of the supported tracers.",
+                  "type": "object",
+                  "properties": {
+                    "datadog": {
+                      "description": "Configuration for the datadog tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address in host:port format for reporting trace data to the Datadog agent.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "lightstep": {
+                      "description": "Configuration for the lightstep tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "accessToken": {
+                          "description": "Sets the lightstep access token.",
+                          "type": "string"
+                        },
+                        "address": {
+                          "description": "Sets the lightstep satellite pool address in host:port format for reporting trace data.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "stackdriver": {
+                      "description": "Configuration for the stackdriver tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "debug": {
+                          "description": "enables trace output to stdout.",
+                          "type": "boolean"
+                        },
+                        "maxNumberOfAnnotations": {
+                          "description": "The global default max number of annotation events per span.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "maxNumberOfAttributes": {
+                          "description": "The global default max number of attributes per span.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "maxNumberOfMessageEvents": {
+                          "description": "The global default max number of message events per span.",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "zipkin": {
+                      "description": "Configuration for the zipkin tracing service.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address of zipkin instance in host:port format for reporting trace data.\n\nExample: <zipkin-collector-service>.<zipkin-collector-namespace>:941",
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "variant": {
+                  "description": "The variant of the Istio container images to use. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                },
+                "waypoint": {
+                  "description": "Specifies how waypoints are configured within Istio.",
+                  "type": "object",
+                  "properties": {
+                    "affinity": {
+                      "description": "K8s affinity settings for waypoint pods.\n\nSee https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity",
+                      "type": "object",
+                      "properties": {
+                        "nodeAffinity": {
+                          "description": "Describes node affinity scheduling rules for the pod.",
+                          "type": "object",
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                              "type": "array",
+                              "items": {
+                                "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                                "type": "object",
+                                "required": [
+                                  "preference",
+                                  "weight"
+                                ],
+                                "properties": {
+                                  "preference": {
+                                    "description": "A node selector term, associated with the corresponding weight.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "A list of node selector requirements by node's labels.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchFields": {
+                                        "description": "A list of node selector requirements by node's fields.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "weight": {
+                                    "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                              "type": "object",
+                              "required": [
+                                "nodeSelectorTerms"
+                              ],
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "description": "Required. A list of node selector terms. The terms are ORed.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "A list of node selector requirements by node's labels.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchFields": {
+                                        "description": "A list of node selector requirements by node's fields.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "The label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              },
+                              "x-kubernetes-map-type": "atomic"
+                            }
+                          }
+                        },
+                        "podAffinity": {
+                          "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                          "type": "object",
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                              "type": "array",
+                              "items": {
+                                "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                "type": "object",
+                                "required": [
+                                  "podAffinityTerm",
+                                  "weight"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                    "type": "object",
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                              "type": "array",
+                              "items": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "podAntiAffinity": {
+                          "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                          "type": "object",
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                              "type": "array",
+                              "items": {
+                                "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                                "type": "object",
+                                "required": [
+                                  "podAffinityTerm",
+                                  "weight"
+                                ],
+                                "properties": {
+                                  "podAffinityTerm": {
+                                    "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                    "type": "object",
+                                    "required": [
+                                      "topologyKey"
+                                    ],
+                                    "properties": {
+                                      "labelSelector": {
+                                        "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "matchLabelKeys": {
+                                        "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "mismatchLabelKeys": {
+                                        "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "namespaceSelector": {
+                                        "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                        "type": "object",
+                                        "properties": {
+                                          "matchExpressions": {
+                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                            "type": "array",
+                                            "items": {
+                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "type": "object",
+                                              "required": [
+                                                "key",
+                                                "operator"
+                                              ],
+                                              "properties": {
+                                                "key": {
+                                                  "description": "key is the label key that the selector applies to.",
+                                                  "type": "string"
+                                                },
+                                                "operator": {
+                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "type": "string"
+                                                },
+                                                "values": {
+                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                  "type": "array",
+                                                  "items": {
+                                                    "type": "string"
+                                                  },
+                                                  "x-kubernetes-list-type": "atomic"
+                                                }
+                                              }
+                                            },
+                                            "x-kubernetes-list-type": "atomic"
+                                          },
+                                          "matchLabels": {
+                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                            "type": "object",
+                                            "additionalProperties": {
+                                              "type": "string"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-map-type": "atomic"
+                                      },
+                                      "namespaces": {
+                                        "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "topologyKey": {
+                                        "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                              "type": "array",
+                              "items": {
+                                "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "nodeSelector": {
+                      "description": "K8s node labels settings.\n\nSee https://kubernetes.io/docs/user-guide/node-selection/",
+                      "type": "object",
+                      "required": [
+                        "nodeSelectorTerms"
+                      ],
+                      "properties": {
+                        "nodeSelectorTerms": {
+                          "description": "Required. A list of node selector terms. The terms are ORed.",
+                          "type": "array",
+                          "items": {
+                            "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "A list of node selector requirements by node's labels.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchFields": {
+                                "description": "A list of node selector requirements by node's fields.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "The label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "resources": {
+                      "description": "K8s resource settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container",
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                          "type": "array",
+                          "items": {
+                            "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                                "type": "string"
+                              },
+                              "request": {
+                                "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "toleration": {
+                      "description": "K8s tolerations settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/",
+                      "type": "array",
+                      "items": {
+                        "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                        "type": "object",
+                        "properties": {
+                          "effect": {
+                            "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                            "type": "string"
+                          },
+                          "key": {
+                            "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                            "type": "string"
+                          },
+                          "tolerationSeconds": {
+                            "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "value": {
+                            "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "topologySpreadConstraints": {
+                      "description": "K8s topology spread constraints settings.\n\nSee https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/",
+                      "type": "array",
+                      "items": {
+                        "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                        "type": "object",
+                        "required": [
+                          "maxSkew",
+                          "topologyKey",
+                          "whenUnsatisfiable"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                "type": "array",
+                                "items": {
+                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "description": "key is the label key that the selector applies to.",
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "matchLabelKeys": {
+                            "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "maxSkew": {
+                            "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "minDomains": {
+                            "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "nodeAffinityPolicy": {
+                            "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                            "type": "string"
+                          },
+                          "nodeTaintsPolicy": {
+                            "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                            "type": "string"
+                          },
+                          "topologyKey": {
+                            "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                            "type": "string"
+                          },
+                          "whenUnsatisfiable": {
+                            "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "istiodRemote": {
+              "description": "Configuration for istiod-remote.\nDEPRECATED - istiod-remote chart is removed and replaced with\n`istio-discovery --set values.istiodRemote.enabled=true`\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Indicates if this cluster/install should consume a \"remote\" istiod instance,",
+                  "type": "boolean"
+                },
+                "injectionCABundle": {
+                  "description": "injector ca bundle",
+                  "type": "string"
+                },
+                "injectionPath": {
+                  "description": "Path to use for the sidecar injector webhook service.",
+                  "type": "string"
+                },
+                "injectionURL": {
+                  "description": "URL to use for sidecar injector webhook.",
+                  "type": "string"
+                }
+              }
+            },
+            "meshConfig": {
+              "description": "Defines runtime configuration of components, including Istiod and istio-agent behavior.\nSee https://istio.io/docs/reference/config/istio.mesh.v1alpha1/ for all available options.",
+              "type": "object",
+              "properties": {
+                "accessLogEncoding": {
+                  "description": "Encoding for the proxy access log (`TEXT` or `JSON`).\nDefault value is `TEXT`.",
+                  "type": "string",
+                  "enum": [
+                    "TEXT",
+                    "JSON"
+                  ]
+                },
+                "accessLogFile": {
+                  "description": "File address for the proxy access log (e.g. /dev/stdout).\nEmpty value disables access logging.",
+                  "type": "string"
+                },
+                "accessLogFormat": {
+                  "description": "Format for the proxy access log\nEmpty value results in proxy's default access log format",
+                  "type": "string"
+                },
+                "ca": {
+                  "description": "If specified, Istiod will authorize and forward the CSRs from the workloads to the specified external CA\nusing the Istio CA gRPC API.",
+                  "type": "object",
+                  "required": [
+                    "address"
+                  ],
+                  "properties": {
+                    "address": {
+                      "description": "REQUIRED. Address of the CA server implementing the Istio CA gRPC API.\nCan be IP address or a fully qualified DNS name with port\nEg: custom-ca.default.svc.cluster.local:8932, 192.168.23.2:9000",
+                      "type": "string"
+                    },
+                    "istiodSide": {
+                      "description": "Use istiodSide to specify CA Server integrate to Istiod side or Agent side\nDefault: true",
+                      "type": "boolean"
+                    },
+                    "requestTimeout": {
+                      "description": "timeout for forward CSR requests from Istiod to External CA\nDefault: 10s",
+                      "type": "string"
+                    },
+                    "tlsSettings": {
+                      "description": "Use the tlsSettings to specify the tls mode to use.\nRegarding tlsSettings:\n- DISABLE MODE is legitimate for the case Istiod is making the request via an Envoy sidecar.\nDISABLE MODE can also be used for testing\n- TLS MUTUAL MODE be on by default. If the CA certificates\n(cert bundle to verify the CA server's certificate) is omitted, Istiod will\nuse the system root certs to verify the CA server's certificate.",
+                      "type": "object",
+                      "properties": {
+                        "caCertificates": {
+                          "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                          "type": "string"
+                        },
+                        "caCrl": {
+                          "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                          "type": "string"
+                        },
+                        "clientCertificate": {
+                          "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                          "type": "string"
+                        },
+                        "credentialName": {
+                          "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                          "type": "string"
+                        },
+                        "insecureSkipVerify": {
+                          "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                          "type": "boolean"
+                        },
+                        "mode": {
+                          "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                          "type": "string",
+                          "enum": [
+                            "DISABLE",
+                            "SIMPLE",
+                            "MUTUAL",
+                            "ISTIO_MUTUAL"
+                          ]
+                        },
+                        "privateKey": {
+                          "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                          "type": "string"
+                        },
+                        "sni": {
+                          "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                          "type": "string"
+                        },
+                        "subjectAltNames": {
+                          "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "caCertificates": {
+                  "description": "The extra root certificates for workload-to-workload communication.\nThe plugin certificates (the 'cacerts' secret) or self-signed certificates (the 'istio-ca-secret' secret)\nare automatically added by Istiod.\nThe CA certificate that signs the workload certificates is automatically added by Istio Agent.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "certSigners": {
+                        "description": "when Istiod is acting as RA(registration authority)\nIf set, they are used for these signers. Otherwise, this trustAnchor is used for all signers.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "pem": {
+                        "description": "The PEM data of the certificate.",
+                        "type": "string"
+                      },
+                      "spiffeBundleUrl": {
+                        "description": "The SPIFFE bundle endpoint URL that complies to:\nhttps://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#the-spiffe-trust-domain-and-bundle\nThe endpoint should support authentication based on Web PKI:\nhttps://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#521-web-pki\nThe certificate is retrieved from the endpoint.",
+                        "type": "string"
+                      },
+                      "trustDomains": {
+                        "description": "Optional. Specify the list of trust domains to which this trustAnchor data belongs.\nIf set, they are used for these trust domains. Otherwise, this trustAnchor is used for default trust domain\nand its aliases.\nNote that we can have multiple trustAnchor data for a same trustDomain.\nIn that case, trustAnchors with a same trust domain will be merged and used together to verify peer certificates.\nIf neither certSigners nor trustDomains is set, this trustAnchor is used for all trust domains and all signers.\nIf only trustDomains is set, this trustAnchor is used for these trustDomains and all signers.\nIf only certSigners is set, this trustAnchor is used for these certSigners and all trust domains.\nIf both certSigners and trustDomains is set, this trustAnchor is only used for these signers and trust domains.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "At most one of [pem spiffeBundleUrl] should be set",
+                        "rule": "(has(self.pem)?1:0) + (has(self.spiffeBundleUrl)?1:0) <= 1"
+                      }
+                    ]
+                  }
+                },
+                "certificates": {
+                  "description": "Configure the provision of certificates.\n\nNote: Deprecated, please refer to Cert-Manager or other cert provisioning solutions to sign DNS certificates.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                  "type": "array",
+                  "items": {
+                    "description": "Certificate configures the provision of a certificate and its key.\nExample 1: key and cert stored in a secret\n```\n{ secretName: galley-cert\n\n\t  secretNamespace: istio-system\n\t  dnsNames:\n\t    - galley.istio-system.svc\n\t    - galley.mydomain.com\n\t}\n\n```\nExample 2: key and cert stored in a directory\n```\n{ dnsNames:\n  - pilot.istio-system\n  - pilot.istio-system.svc\n  - pilot.mydomain.com\n    }\n\n```",
+                    "type": "object",
+                    "properties": {
+                      "dnsNames": {
+                        "description": "The DNS names for the certificate. A certificate may contain\nmultiple DNS names.",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "secretName": {
+                        "description": "Name of the secret the certificate and its key will be stored into.\nIf it is empty, it will not be stored into a secret.\nInstead, the certificate and its key will be stored into a hard-coded directory.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "configSources": {
+                  "description": "ConfigSource describes a source of configuration data for networking\nrules, and other Istio configuration artifacts. Multiple data sources\ncan be configured for a single control plane.",
+                  "type": "array",
+                  "items": {
+                    "description": "ConfigSource describes information about a configuration store inside a\nmesh. A single control plane instance can interact with one or more data\nsources.",
+                    "type": "object",
+                    "properties": {
+                      "address": {
+                        "description": "Address of the server implementing the Istio Mesh Configuration\nprotocol (MCP). Can be IP address or a fully qualified DNS name.\nUse xds:// to specify a grpc-based xds backend, k8s:// to specify a k8s controller or\nfs:/// to specify a file-based backend with absolute path to the directory.",
+                        "type": "string"
+                      },
+                      "subscribedResources": {
+                        "description": "Describes the source of configuration, if nothing is specified default is MCP",
+                        "type": "array",
+                        "items": {
+                          "description": "Resource describes the source of configuration",
+                          "type": "string",
+                          "enum": [
+                            "SERVICE_REGISTRY"
+                          ]
+                        }
+                      },
+                      "tlsSettings": {
+                        "description": "Use the tlsSettings to specify the tls mode to use. If the MCP server\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                        "type": "object",
+                        "properties": {
+                          "caCertificates": {
+                            "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                            "type": "string"
+                          },
+                          "caCrl": {
+                            "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                            "type": "string"
+                          },
+                          "clientCertificate": {
+                            "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                            "type": "string"
+                          },
+                          "credentialName": {
+                            "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                            "type": "string"
+                          },
+                          "insecureSkipVerify": {
+                            "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                            "type": "boolean"
+                          },
+                          "mode": {
+                            "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                            "type": "string",
+                            "enum": [
+                              "DISABLE",
+                              "SIMPLE",
+                              "MUTUAL",
+                              "ISTIO_MUTUAL"
+                            ]
+                          },
+                          "privateKey": {
+                            "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                            "type": "string"
+                          },
+                          "sni": {
+                            "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                            "type": "string"
+                          },
+                          "subjectAltNames": {
+                            "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "connectTimeout": {
+                  "description": "Connection timeout used by Envoy. (MUST be >=1ms)\nDefault timeout is 10s.",
+                  "type": "string"
+                },
+                "defaultConfig": {
+                  "description": "Default proxy config used by gateway and sidecars.\nIn case of Kubernetes, the proxy config is applied once during the injection process,\nand remain constant for the duration of the pod. The rest of the mesh config can be changed\nat runtime and config gets distributed dynamically.\nOn Kubernetes, this can be overridden on individual pods with the `proxy.istio.io/config` annotation.",
+                  "type": "object",
+                  "properties": {
+                    "availabilityZone": {
+                      "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    },
+                    "binaryPath": {
+                      "description": "Path to the proxy binary",
+                      "type": "string"
+                    },
+                    "caCertificatesPem": {
+                      "description": "The PEM data of the extra root certificates for workload-to-workload communication.\nThis includes the certificates defined in MeshConfig and any other certificates that Istiod uses as CA.\nThe plugin certificates (the 'cacerts' secret), self-signed certificates (the 'istio-ca-secret' secret)\nare added automatically by Istiod.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "concurrency": {
+                      "description": "The number of worker threads to run.\nIf unset, which is recommended, this will be automatically determined based on CPU requests/limits.\nIf set to 0, all cores on the machine will be used, ignoring CPU requests or limits. This can lead to major performance\nissues if CPU limits are also set.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "configPath": {
+                      "description": "Path to the generated configuration file directory.\nProxy agent generates the actual configuration and stores it in this directory.",
+                      "type": "string"
+                    },
+                    "controlPlaneAuthPolicy": {
+                      "description": "AuthenticationPolicy defines how the proxy is authenticated when it connects to the control plane.\nDefault is set to `MUTUAL_TLS`.",
+                      "type": "string",
+                      "enum": [
+                        "NONE",
+                        "MUTUAL_TLS",
+                        "INHERIT"
+                      ]
+                    },
+                    "customConfigFile": {
+                      "description": "File path of custom proxy configuration, currently used by proxies\nin front of istiod.",
+                      "type": "string"
+                    },
+                    "discoveryAddress": {
+                      "description": "Address of the discovery service exposing xDS with mTLS connection.\nThe inject configuration may override this value.",
+                      "type": "string"
+                    },
+                    "discoveryRefreshDelay": {
+                      "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    },
+                    "drainDuration": {
+                      "description": "restart. MUST be >=1s (e.g., _1s/1m/1h_)\nDefault drain duration is `45s`.",
+                      "type": "string"
+                    },
+                    "envoyAccessLogService": {
+                      "description": "Address of the service to which access logs from Envoys should be\nsent. (e.g. `accesslog-service:15000`). See [Access Log\nService](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto)\nfor details about Envoy's gRPC Access Log Service API.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address of a remove service used for various purposes (access log\nreceiver, metrics receiver, etc.). Can be IP address or a fully\nqualified DNS name.",
+                          "type": "string"
+                        },
+                        "tcpKeepalive": {
+                          "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                              "type": "string"
+                            },
+                            "probes": {
+                              "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "time": {
+                              "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "tlsSettings": {
+                          "description": "Use the `tlsSettings` to specify the tls mode to use. If the remote service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                          "type": "object",
+                          "properties": {
+                            "caCertificates": {
+                              "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                              "type": "string"
+                            },
+                            "clientCertificate": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "credentialName": {
+                              "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                              "type": "string"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                              "type": "string",
+                              "enum": [
+                                "DISABLE",
+                                "SIMPLE",
+                                "MUTUAL",
+                                "ISTIO_MUTUAL"
+                              ]
+                            },
+                            "privateKey": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "sni": {
+                              "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                              "type": "string"
+                            },
+                            "subjectAltNames": {
+                              "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envoyMetricsService": {
+                      "description": "Address of the Envoy Metrics Service implementation (e.g. `metrics-service:15000`).\nSee [Metric Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto)\nfor details about Envoy's Metrics Service API.",
+                      "type": "object",
+                      "properties": {
+                        "address": {
+                          "description": "Address of a remove service used for various purposes (access log\nreceiver, metrics receiver, etc.). Can be IP address or a fully\nqualified DNS name.",
+                          "type": "string"
+                        },
+                        "tcpKeepalive": {
+                          "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                          "type": "object",
+                          "properties": {
+                            "interval": {
+                              "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                              "type": "string"
+                            },
+                            "probes": {
+                              "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "time": {
+                              "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "tlsSettings": {
+                          "description": "Use the `tlsSettings` to specify the tls mode to use. If the remote service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                          "type": "object",
+                          "properties": {
+                            "caCertificates": {
+                              "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                              "type": "string"
+                            },
+                            "clientCertificate": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "credentialName": {
+                              "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                              "type": "string"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                              "type": "string",
+                              "enum": [
+                                "DISABLE",
+                                "SIMPLE",
+                                "MUTUAL",
+                                "ISTIO_MUTUAL"
+                              ]
+                            },
+                            "privateKey": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "sni": {
+                              "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                              "type": "string"
+                            },
+                            "subjectAltNames": {
+                              "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "envoyMetricsServiceAddress": {
+                      "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    },
+                    "extraStatTags": {
+                      "description": "An additional list of tags to extract from the in-proxy Istio telemetry. These extra tags can be\nadded by configuring the telemetry extension. Each additional tag needs to be present in this list.\nExtra tags emitted by the telemetry extensions must be listed here so that they can be processed\nand exposed as Prometheus metrics.\nDeprecated: `istio.stats` is a native filter now, this field is no longer needed.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "gatewayTopology": {
+                      "description": "Topology encapsulates the configuration which describes where the proxy is\nlocated i.e. behind a (or N) trusted proxy (proxies) or directly exposed\nto the internet. This configuration only effects gateways and is applied\nto all the gateways in the cluster unless overridden via annotations of the\ngateway workloads.",
+                      "type": "object",
+                      "properties": {
+                        "forwardClientCertDetails": {
+                          "description": "Configures how the gateway proxy handles x-forwarded-client-cert (XFCC)\nheader in the incoming request.",
+                          "type": "string",
+                          "enum": [
+                            "UNDEFINED",
+                            "SANITIZE",
+                            "FORWARD_ONLY",
+                            "APPEND_FORWARD",
+                            "SANITIZE_SET",
+                            "ALWAYS_FORWARD_ONLY"
+                          ]
+                        },
+                        "numTrustedProxies": {
+                          "description": "Number of trusted proxies deployed in front of the Istio gateway proxy.\nWhen this option is set to value N greater than zero, the trusted client\naddress is assumed to be the Nth address from the right end of the\nX-Forwarded-For (XFF) header from the incoming request. If the\nX-Forwarded-For (XFF) header is missing or has fewer than N addresses, the\ngateway proxy falls back to using the immediate downstream connection's\nsource address as the trusted client address.\nNote that the gateway proxy will append the downstream connection's source\naddress to the X-Forwarded-For (XFF) address and set the\nX-Envoy-External-Address header to the trusted client address before\nforwarding it to the upstream services in the cluster.\nThe default value of numTrustedProxies is 0.\nSee [Envoy XFF](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-for)\nheader handling for more details.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "proxyProtocol": {
+                          "description": "Enables [PROXY protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) for\ndownstream connections on a gateway.",
+                          "type": "object"
+                        }
+                      }
+                    },
+                    "holdApplicationUntilProxyStarts": {
+                      "description": "Boolean flag for enabling/disabling the holdApplicationUntilProxyStarts behavior.\nThis feature adds hooks to delay application startup until the pod proxy\nis ready to accept traffic, mitigating some startup race conditions.\nDefault value is 'false'.",
+                      "type": "boolean"
+                    },
+                    "image": {
+                      "description": "Specifies the details of the proxy image.",
+                      "type": "object",
+                      "properties": {
+                        "imageType": {
+                          "description": "The image type of the image.\nIstio publishes default, debug, and distroless images.\nOther values are allowed if those image types (example: centos) are published to the specified hub.\nsupported values: default, debug, distroless.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "interceptionMode": {
+                      "description": "The mode used to redirect inbound traffic to Envoy.",
+                      "type": "string",
+                      "enum": [
+                        "REDIRECT",
+                        "TPROXY",
+                        "NONE"
+                      ]
+                    },
+                    "meshId": {
+                      "description": "The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)\nAll control planes running in the same service mesh should specify the same mesh ID.\nMesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.",
+                      "type": "string"
+                    },
+                    "privateKeyProvider": {
+                      "description": "Specifies the details of the Private Key Provider configuration for gateway and sidecar proxies.",
+                      "type": "object",
+                      "properties": {
+                        "cryptomb": {
+                          "description": "Use CryptoMb private key provider",
+                          "type": "object",
+                          "properties": {
+                            "fallback": {
+                              "description": "If the private key provider isn\u2019t available (eg. the required hardware capability doesn\u2019t existed)\nEnvoy will fallback to the BoringSSL default implementation when the fallback is true.\nThe default value is false.",
+                              "type": "boolean"
+                            },
+                            "pollDelay": {
+                              "description": "How long to wait until the per-thread processing queue should be processed. If the processing queue\ngets full (eight sign or decrypt requests are received) it is processed immediately.\nHowever, if the queue is not filled before the delay has expired, the requests already in the queue\nare processed, even if the queue is not full.\nIn effect, this value controls the balance between latency and throughput.\nThe duration needs to be set to a value greater than or equal to 1 millisecond.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "qat": {
+                          "description": "Use QAT private key provider",
+                          "type": "object",
+                          "properties": {
+                            "fallback": {
+                              "description": "If the private key provider isn\u2019t available (eg. the required hardware capability doesn\u2019t existed)\nEnvoy will fallback to the BoringSSL default implementation when the fallback is true.\nThe default value is false.",
+                              "type": "boolean"
+                            },
+                            "pollDelay": {
+                              "description": "How long to wait before polling the hardware accelerator after a request has been submitted there.\nHaving a small value leads to quicker answers from the hardware but causes more polling loop spins,\nleading to potentially larger CPU usage.\nThe duration needs to be set to a value greater than or equal to 1 millisecond.",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "At most one of [cryptomb qat] should be set",
+                          "rule": "(has(self.cryptomb)?1:0) + (has(self.qat)?1:0) <= 1"
+                        }
+                      ]
+                    },
+                    "proxyAdminPort": {
+                      "description": "Port on which Envoy should listen for administrative commands.\nDefault port is `15000`.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "proxyBootstrapTemplatePath": {
+                      "description": "Path to the proxy bootstrap template file",
+                      "type": "string"
+                    },
+                    "proxyHeaders": {
+                      "description": "Define the set of headers to add/modify for HTTP request/responses.\n\nTo enable an optional header, simply set the field. If no specific configuration is required, an empty object (`{}`) will enable it.\nNote: currently all headers are enabled by default.\n\nBelow shows an example of customizing the `server` header and disabling the `X-Envoy-Attempt-Count` header:\n\n```yaml\nproxyHeaders:\n\n\tserver:\n\t  value: \"my-custom-server\"\n\t# Explicitly enable Request IDs.\n\t# As this is the default, this has no effect.\n\trequestId: {}\n\tattemptCount:\n\t  disabled: true\n\n```\n\nSome headers are enabled by default, and require explicitly disabling. See below for an example of disabling all default-enabled headers:\n\n```yaml\nproxyHeaders:\n\n\tforwardedClientCert: SANITIZE\n\tserver:\n\t  disabled: true\n\trequestId:\n\t  disabled: true\n\tattemptCount:\n\t  disabled: true\n\tenvoyDebugHeaders:\n\t  disabled: true\n\tmetadataExchangeHeaders:\n\t  mode: IN_MESH\n\n```",
+                      "type": "object",
+                      "properties": {
+                        "attemptCount": {
+                          "description": "Controls the `X-Envoy-Attempt-Count` header.\nIf enabled, this header will be added on outbound request headers (including gateways) that have retries configured.\nIf disabled, this header will not be set. If it is already present, it will be preserved.\nThis header is enabled by default if not configured.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "envoyDebugHeaders": {
+                          "description": "Controls various `X-Envoy-*` headers, such as `X-Envoy-Overloaded` and `X-Envoy-Upstream-Service-Time`. If enabled,\nthese headers will be included.\nIf disabled, these headers will not be set. If they are already present, they will be preserved.\nSee the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/router/v3/router.proto#envoy-v3-api-field-extensions-filters-http-router-v3-router-suppress-envoy-headers) for more details.\nThese headers are enabled by default if not configured.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "forwardedClientCert": {
+                          "description": "Controls the `X-Forwarded-Client-Cert` header for inbound sidecar requests. To set this on gateways, use the `Topology` setting.\nTo disable the header, configure either `SANITIZE` (to always remove the header, if present) or `FORWARD_ONLY` (to leave the header as-is).\nBy default, `APPEND_FORWARD` will be used.",
+                          "type": "string",
+                          "enum": [
+                            "UNDEFINED",
+                            "SANITIZE",
+                            "FORWARD_ONLY",
+                            "APPEND_FORWARD",
+                            "SANITIZE_SET",
+                            "ALWAYS_FORWARD_ONLY"
+                          ]
+                        },
+                        "metadataExchangeHeaders": {
+                          "description": "Controls Istio metadata exchange headers `X-Envoy-Peer-Metadata` and `X-Envoy-Peer-Metadata-Id`.\nBy default, the behavior is unspecified.\nIf IN_MESH, these headers will not be appended to outbound requests from sidecars to services not in-mesh.",
+                          "type": "object",
+                          "properties": {
+                            "mode": {
+                              "type": "string",
+                              "enum": [
+                                "UNDEFINED",
+                                "IN_MESH"
+                              ]
+                            }
+                          }
+                        },
+                        "requestId": {
+                          "description": "Controls the `X-Request-Id` header. If enabled, a request ID is generated for each request if one is not already set.\nThis applies to all types of traffic (inbound, outbound, and gateways).\nIf disabled, no request ID will be generate for the request. If it is already present, it will be preserved.\nWarning: request IDs are a critical component to mesh tracing and logging, so disabling this is not recommended.\nThis header is enabled by default if not configured.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            }
+                          }
+                        },
+                        "server": {
+                          "description": "Controls the `server` header. If enabled, the `Server: istio-envoy` header is set in response headers for inbound traffic (including gateways).\nIf disabled, the `Server` header is not modified. If it is already present, it will be preserved.",
+                          "type": "object",
+                          "properties": {
+                            "disabled": {
+                              "type": "boolean"
+                            },
+                            "value": {
+                              "description": "If set, and the server header is enabled, this value will be set as the server header. By default, `istio-envoy` will be used.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "setCurrentClientCertDetails": {
+                          "description": "This field is valid only when forward_client_cert_details is APPEND_FORWARD or SANITIZE_SET\nand the client connection is mTLS. It specifies the fields in\nthe client certificate to be forwarded. Note that `Hash` is always set, and\n`By` is always set when the client certificate presents the URI type Subject Alternative Name value.",
+                          "type": "object",
+                          "properties": {
+                            "cert": {
+                              "description": "Whether to forward the entire client cert in URL encoded PEM format. This will appear in the\nXFCC header comma separated from other values with the value Cert=\"PEM\".\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "chain": {
+                              "description": "Whether to forward the entire client cert chain (including the leaf cert) in URL encoded PEM\nformat. This will appear in the XFCC header comma separated from other values with the value\nChain=\"PEM\".\nDefaults to false.",
+                              "type": "boolean"
+                            },
+                            "dns": {
+                              "description": "Whether to forward the DNS type Subject Alternative Names of the client cert.\nDefaults to true.",
+                              "type": "boolean"
+                            },
+                            "subject": {
+                              "description": "Whether to forward the subject of the client cert. Defaults to true.",
+                              "type": "boolean"
+                            },
+                            "uri": {
+                              "description": "Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to\ntrue.",
+                              "type": "boolean"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "proxyMetadata": {
+                      "description": "Additional environment variables for the proxy.\nNames starting with `ISTIO_META_` will be included in the generated bootstrap and sent to the XDS server.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "proxyStatsMatcher": {
+                      "description": "Proxy stats matcher defines configuration for reporting custom Envoy stats.\nTo reduce memory and CPU overhead from Envoy stats system, Istio proxies by\ndefault create and expose only a subset of Envoy stats. This option is to\ncontrol creation of additional Envoy stats with prefix, suffix, and regex\nexpressions match on the name of the stats. This replaces the stats\ninclusion annotations\n(`sidecar.istio.io/statsInclusionPrefixes`,\n`sidecar.istio.io/statsInclusionRegexps`, and\n`sidecar.istio.io/statsInclusionSuffixes`). For example, to enable stats\nfor circuit breakers, request retries, upstream connections, and request timeouts,\nyou can specify stats matcher as follows:\n```yaml\nproxyStatsMatcher:\n\n\tinclusionRegexps:\n\t  - .*outlier_detection.*\n\t  - .*upstream_rq_retry.*\n\t  - .*upstream_cx_.*\n\tinclusionSuffixes:\n\t  - upstream_rq_timeout\n\n```\nNote including more Envoy stats might increase number of time series\ncollected by prometheus significantly. Care needs to be taken on Prometheus\nresource provision and configuration to reduce cardinality.",
+                      "type": "object",
+                      "properties": {
+                        "inclusionPrefixes": {
+                          "description": "Proxy stats name prefix matcher for inclusion.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "inclusionRegexps": {
+                          "description": "Proxy stats name regexps matcher for inclusion.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "inclusionSuffixes": {
+                          "description": "Proxy stats name suffix matcher for inclusion.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "readinessProbe": {
+                      "description": "VM Health Checking readiness probe. This health check config exactly mirrors the\nkubernetes readiness probe configuration both in schema and logic.\nOnly one health check method of 3 can be set at a time.",
+                      "type": "object",
+                      "properties": {
+                        "exec": {
+                          "description": "Exec specifies a command to execute in the container.",
+                          "type": "object",
+                          "properties": {
+                            "command": {
+                              "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "failureThreshold": {
+                          "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "grpc": {
+                          "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                          "type": "object",
+                          "required": [
+                            "port"
+                          ],
+                          "properties": {
+                            "port": {
+                              "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "service": {
+                              "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "httpGet": {
+                          "description": "HTTPGet specifies an HTTP GET request to perform.",
+                          "type": "object",
+                          "required": [
+                            "port"
+                          ],
+                          "properties": {
+                            "host": {
+                              "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                              "type": "string"
+                            },
+                            "httpHeaders": {
+                              "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                              "type": "array",
+                              "items": {
+                                "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "value"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "description": "The header field value",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "path": {
+                              "description": "Path to access on the HTTP server.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            },
+                            "scheme": {
+                              "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "initialDelaySeconds": {
+                          "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "periodSeconds": {
+                          "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "successThreshold": {
+                          "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "tcpSocket": {
+                          "description": "TCPSocket specifies a connection to a TCP port.",
+                          "type": "object",
+                          "required": [
+                            "port"
+                          ],
+                          "properties": {
+                            "host": {
+                              "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                              "type": "string"
+                            },
+                            "port": {
+                              "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        },
+                        "terminationGracePeriodSeconds": {
+                          "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                          "type": "integer",
+                          "format": "int64"
+                        },
+                        "timeoutSeconds": {
+                          "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "runtimeValues": {
+                      "description": "Envoy [runtime configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime) to set during bootstrapping.\nThis enables setting experimental, unsafe, unsupported, and deprecated features that should be used with extreme caution.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "sds": {
+                      "description": "Secret Discovery Service(SDS) configuration to be used by the proxy.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "description": "True if SDS is enabled.",
+                          "type": "boolean"
+                        },
+                        "k8sSaJwtPath": {
+                          "description": "Path of k8s service account JWT path.",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "serviceCluster": {
+                      "description": "Service cluster defines the name for the `service_cluster` that is\nshared by all Envoy instances. This setting corresponds to\n`--service-cluster` flag in Envoy.  In a typical Envoy deployment, the\n`service-cluster` flag is used to identify the caller, for\nsource-based routing scenarios.\n\nSince Istio does not assign a local `service/service` version to each\nEnvoy instance, the name is same for all of them.  However, the\nsource/caller's identity (e.g., IP address) is encoded in the\n`--service-node` flag when launching Envoy.  When the RDS service\nreceives API calls from Envoy, it uses the value of the `service-node`\nflag to compute routes that are relative to the service instances\nlocated at that IP address.",
+                      "type": "string"
+                    },
+                    "statNameLength": {
+                      "description": "Maximum length of name field in Envoy's metrics. The length of the name field\nis determined by the length of a name field in a service and the set of labels that\ncomprise a particular version of the service. The default value is set to 189 characters.\nEnvoy's internal metrics take up 67 characters, for a total of 256 character name per metric.\nIncrease the value of this field if you find that the metrics from Envoys are truncated.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "statsdUdpAddress": {
+                      "description": "IP Address and Port of a statsd UDP listener (e.g. `10.75.241.127:9125`).",
+                      "type": "string"
+                    },
+                    "statusPort": {
+                      "description": "Port on which the agent should listen for administrative commands such as readiness probe.\nDefault is set to port `15020`.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "terminationDrainDuration": {
+                      "description": "The amount of time allowed for connections to complete on proxy shutdown.\nOn receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start gracefully draining,\ndiscouraging any new connections and allowing existing connections to complete. It then\nsleeps for the `terminationDrainDuration` and then kills any remaining active Envoy processes.\nIf not set, a default of `5s` will be applied.",
+                      "type": "string"
+                    },
+                    "tracing": {
+                      "description": "Tracing configuration to be used by the proxy.",
+                      "type": "object",
+                      "properties": {
+                        "customTags": {
+                          "description": "and gateways).\nThe key represents the name of the tag.\nEx:\n```yaml\ncustom_tags:\n\n\tnew_tag_name:\n\t  header:\n\t    name: custom-http-header-name\n\t    default_value: defaulted-value-from-custom-header\n\n```",
+                          "type": "object",
+                          "additionalProperties": {
+                            "description": "Configure custom tags that will be added to any active span.\nTags can be generated via literals, environment variables or an incoming request header.",
+                            "type": "object",
+                            "properties": {
+                              "environment": {
+                                "description": "The custom tag's value should be populated from an environmental\nvariable",
+                                "type": "object",
+                                "properties": {
+                                  "defaultValue": {
+                                    "description": "When the environment variable is not found,\nthe tag's value will be populated with this default value if specified,\notherwise the tag will not be populated.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "Name of the environment variable used to populate the tag's value",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "header": {
+                                "description": "The custom tag's value is populated by an http header from\nan incoming request.",
+                                "type": "object",
+                                "properties": {
+                                  "defaultValue": {
+                                    "description": "Default value to be used for the tag when the named HTTP header does not exist.\nThe tag will be skipped if no default value is provided.",
+                                    "type": "string"
+                                  },
+                                  "name": {
+                                    "description": "HTTP header name used to obtain the value from to populate the tag value.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "literal": {
+                                "description": "The custom tag's value is the specified literal.",
+                                "type": "object",
+                                "properties": {
+                                  "value": {
+                                    "description": "Static literal value used to populate the tag value.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "At most one of [literal environment header] should be set",
+                                "rule": "(has(self.literal)?1:0) + (has(self.environment)?1:0) + (has(self.header)?1:0) <= 1"
+                              }
+                            ]
+                          }
+                        },
+                        "datadog": {
+                          "description": "Use a Datadog tracer.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "Address of the Datadog Agent.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "lightstep": {
+                          "description": "Use a Lightstep tracer.\nNOTE: For Istio 1.15+, this configuration option will result\nin using OpenTelemetry-based Lightstep integration.",
+                          "type": "object",
+                          "properties": {
+                            "accessToken": {
+                              "description": "The Lightstep access token.",
+                              "type": "string"
+                            },
+                            "address": {
+                              "description": "Address of the Lightstep Satellite pool.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "maxPathTagLength": {
+                          "description": "Configures the maximum length of the request path to extract and include in the\nHttpUrl tag. Used to truncate length request paths to meet the needs of tracing\nbackend. If not set, then a length of 256 will be used.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "openCensusAgent": {
+                          "description": "Use an OpenCensus tracer exporting to an OpenCensus agent.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "gRPC address for the OpenCensus agent (e.g. dns://authority/host:port or\nunix:path). See [gRPC naming\ndocs](https://github.com/grpc/grpc/blob/master/doc/naming.md) for\ndetails.",
+                              "type": "string"
+                            },
+                            "context": {
+                              "description": "Specifies the set of context propagation headers used for distributed\ntracing. Default is `[\"W3C_TRACE_CONTEXT\"]`. If multiple values are specified,\nthe proxy will attempt to read each header for each request and will\nwrite all headers.",
+                              "type": "array",
+                              "items": {
+                                "description": "TraceContext selects the context propagation headers used for\ndistributed tracing.",
+                                "type": "string",
+                                "enum": [
+                                  "UNSPECIFIED",
+                                  "W3C_TRACE_CONTEXT",
+                                  "GRPC_BIN",
+                                  "CLOUD_TRACE_CONTEXT",
+                                  "B3"
+                                ]
+                              }
+                            }
+                          }
+                        },
+                        "sampling": {
+                          "description": "The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation,\nif not requested by the client or not forced. Default is 1.0.",
+                          "type": "number"
+                        },
+                        "stackdriver": {
+                          "description": "Use a Stackdriver tracer.",
+                          "type": "object",
+                          "properties": {
+                            "debug": {
+                              "description": "debug enables trace output to stdout.",
+                              "type": "boolean"
+                            },
+                            "maxNumberOfAnnotations": {
+                              "description": "The global default max number of annotation events per span.\ndefault is 200.",
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "maxNumberOfAttributes": {
+                              "description": "The global default max number of attributes per span.\ndefault is 200.",
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "maxNumberOfMessageEvents": {
+                              "description": "The global default max number of message events per span.\ndefault is 200.",
+                              "type": "integer",
+                              "format": "int64"
+                            }
+                          }
+                        },
+                        "tlsSettings": {
+                          "description": "Use the tlsSettings to specify the tls mode to use. If the remote tracing service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                          "type": "object",
+                          "properties": {
+                            "caCertificates": {
+                              "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                              "type": "string"
+                            },
+                            "clientCertificate": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "credentialName": {
+                              "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                              "type": "string"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                              "type": "string",
+                              "enum": [
+                                "DISABLE",
+                                "SIMPLE",
+                                "MUTUAL",
+                                "ISTIO_MUTUAL"
+                              ]
+                            },
+                            "privateKey": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "sni": {
+                              "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                              "type": "string"
+                            },
+                            "subjectAltNames": {
+                              "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "zipkin": {
+                          "description": "Use a Zipkin tracer.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "Address of the Zipkin service (e.g. _zipkin:9411_).",
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "At most one of [zipkin lightstep datadog stackdriver openCensusAgent] should be set",
+                          "rule": "(has(self.zipkin)?1:0) + (has(self.lightstep)?1:0) + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0) + (has(self.openCensusAgent)?1:0) <= 1"
+                        }
+                      ]
+                    },
+                    "tracingServiceName": {
+                      "description": "Used by Envoy proxies to assign the values for the service names in trace\nspans.",
+                      "type": "string",
+                      "enum": [
+                        "APP_LABEL_AND_NAMESPACE",
+                        "CANONICAL_NAME_ONLY",
+                        "CANONICAL_NAME_AND_NAMESPACE"
+                      ]
+                    },
+                    "zipkinAddress": {
+                      "description": "Address of the Zipkin service (e.g. _zipkin:9411_).\nDEPRECATED: Use [tracing][istio.mesh.v1alpha1.ProxyConfig.tracing] instead.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "At most one of [serviceCluster tracingServiceName] should be set",
+                      "rule": "(has(self.serviceCluster)?1:0) + (has(self.tracingServiceName)?1:0) <= 1"
+                    }
+                  ]
+                },
+                "defaultDestinationRuleExportTo": {
+                  "description": "The default value for the `DestinationRule.exportTo` field. Has the same\nsyntax as `defaultServiceExportTo`.\n\nIf not set the system will use \"*\" as the default value which implies that\ndestination rules are exported to all namespaces",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "defaultHttpRetryPolicy": {
+                  "description": "Configure the default HTTP retry policy.\nThe default number of retry attempts is set at 2 for these errors:\n\n\t\"connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes\".\n\nSetting the number of attempts to 0 disables retry policy globally.\nThis setting can be overridden on a per-host basis using the Virtual Service\nAPI.\nAll settings in the retry policy except `perTryTimeout` can currently be\nconfigured globally via this field.",
+                  "type": "object",
+                  "properties": {
+                    "attempts": {
+                      "description": "Number of retries to be allowed for a given request. The interval\nbetween retries will be determined automatically (25ms+). When request\n`timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)\nor `per_try_timeout` is configured, the actual number of retries attempted also depends on\nthe specified request `timeout` and `per_try_timeout` values. MUST be >= 0. If `0`, retries will be disabled.\nThe maximum possible number of requests made will be 1 + `attempts`.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "perTryTimeout": {
+                      "description": "Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST be >=1ms.\nDefault is same value as request\n`timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute),\nwhich means no timeout.",
+                      "type": "string"
+                    },
+                    "retryOn": {
+                      "description": "Specifies the conditions under which retry takes place.\nOne or more policies can be specified using a \u2018,\u2019 delimited list.\nSee the [retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on)\nand [gRPC retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on) for more details.\n\nIn addition to the policies specified above, a list of HTTP status codes can be passed, such as `retryOn: \"503,reset\"`.\nNote these status codes refer to the actual responses received from the destination.\nFor example, if a connection is reset, Istio will translate this to 503 for it's response.\nHowever, the destination did not return a 503 error, so this would not match `\"503\"` (it would, however, match `\"reset\"`).\n\nIf not specified, this defaults to `connect-failure,refused-stream,unavailable,cancelled,503`.",
+                      "type": "string"
+                    },
+                    "retryRemoteLocalities": {
+                      "description": "Flag to specify whether the retries should retry to other localities.\nSee the [retry plugin configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_connection_management#retry-plugin-configuration) for more details.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "defaultProviders": {
+                  "description": "Specifies extension providers to use by default in Istio configuration resources.",
+                  "type": "object",
+                  "properties": {
+                    "accessLogging": {
+                      "description": "Name of the default provider(s) for access logging.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "metrics": {
+                      "description": "Name of the default provider(s) for metrics.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "tracing": {
+                      "description": "Name of the default provider(s) for tracing.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "defaultServiceExportTo": {
+                  "description": "The default value for the ServiceEntry.exportTo field and services\nimported through container registry integrations, e.g. this applies to\nKubernetes Service resources. The value is a list of namespace names and\nreserved namespace aliases. The allowed namespace aliases are:\n```\n* - All Namespaces\n. - Current Namespace\n~ - No Namespace\n```\nIf not set the system will use \"*\" as the default value which implies that\nservices are exported to all namespaces.\n\n`All namespaces` is a reasonable default for implementations that don't\nneed to restrict access or visibility of services across namespace\nboundaries. If that requirement is present it is generally good practice to\nmake the default `Current namespace` so that services are only visible\nwithin their own namespaces by default. Operators can then expand the\nvisibility of services to other namespaces as needed. Use of `No Namespace`\nis expected to be rare but can have utility for deployments where\ndependency management needs to be precise even within the scope of a single\nnamespace.\n\nFor further discussion see the reference documentation for `ServiceEntry`,\n`Sidecar`, and `Gateway`.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "defaultVirtualServiceExportTo": {
+                  "description": "The default value for the VirtualService.exportTo field. Has the same\nsyntax as `defaultServiceExportTo`.\n\nIf not set the system will use \"*\" as the default value which implies that\nvirtual services are exported to all namespaces",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "disableEnvoyListenerLog": {
+                  "description": "This flag disables Envoy Listener logs.\nSee [Listener Access Log](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-access-log)\nIstio Enables Envoy's listener access logs on \"NoRoute\" response flag.\nDefault value is `false`.",
+                  "type": "boolean"
+                },
+                "discoverySelectors": {
+                  "description": "A list of Kubernetes selectors that specify the set of namespaces that Istio considers when\ncomputing configuration updates for sidecars. This can be used to reduce Istio's computational load\nby limiting the number of entities (including services, pods, and endpoints) that are watched and processed.\nIf omitted, Istio will use the default behavior of processing all namespaces in the cluster.\nElements in the list are disjunctive (OR semantics), i.e. a namespace will be included if it matches any selector.\nThe following example selects any namespace that matches either below:\n1. The namespace has both of these labels: `env: prod` and `region: us-east1`\n2. The namespace has label `app` equal to `cassandra` or `spark`.\n```yaml\ndiscoverySelectors:\n  - matchLabels:\n    env: prod\n    region: us-east1\n  - matchExpressions:\n  - key: app\n    operator: In\n    values:\n  - cassandra\n  - spark\n\n```\nRefer to the [Kubernetes selector docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)\nfor additional detail on selector semantics.",
+                  "type": "array",
+                  "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "type": "array",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                },
+                "dnsRefreshRate": {
+                  "description": "Configures DNS refresh rate for Envoy clusters of type `STRICT_DNS`\nDefault refresh rate is `60s`.",
+                  "type": "string"
+                },
+                "enableAutoMtls": {
+                  "description": "This flag is used to enable mutual `TLS` automatically for service to service communication\nwithin the mesh, default true.\nIf set to true, and a given service does not have a corresponding `DestinationRule` configured,\nor its `DestinationRule` does not have ClientTLSSettings specified, Istio configures client side\nTLS configuration appropriately. More specifically,\nIf the upstream authentication policy is in `STRICT` mode, use Istio provisioned certificate\nfor mutual `TLS` to connect to upstream.\nIf upstream service is in plain text mode, use plain text.\nIf the upstream authentication policy is in PERMISSIVE mode, Istio configures clients to use\nmutual `TLS` when server sides are capable of accepting mutual `TLS` traffic.\nIf service `DestinationRule` exists and has `ClientTLSSettings` specified, that is always used instead.",
+                  "type": "boolean"
+                },
+                "enableEnvoyAccessLogService": {
+                  "description": "This flag enables Envoy's gRPC Access Log Service.\nSee [Access Log Service](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/grpc/v3/als.proto)\nfor details about Envoy's gRPC Access Log Service API.\nDefault value is `false`.",
+                  "type": "boolean"
+                },
+                "enablePrometheusMerge": {
+                  "description": "If enabled, Istio agent will merge metrics exposed by the application with metrics from Envoy\nand Istio agent. The sidecar injection will replace `prometheus.io` annotations present on the pod\nand redirect them towards Istio agent, which will then merge metrics of from the application with Istio metrics.\nThis relies on the annotations `prometheus.io/scrape`, `prometheus.io/port`, and\n`prometheus.io/path` annotations.\nIf you are running a separately managed Envoy with an Istio sidecar, this may cause issues, as the metrics will collide.\nIn this case, it is recommended to disable aggregation on that deployment with the\n`prometheus.istio.io/merge-metrics: \"false\"` annotation.\nIf not specified, this will be enabled by default.",
+                  "type": "boolean"
+                },
+                "enableTracing": {
+                  "description": "Flag to control generation of trace spans and request IDs.\nRequires a trace span collector defined in the proxy configuration.",
+                  "type": "boolean"
+                },
+                "extensionProviders": {
+                  "description": "Defines a list of extension providers that extend Istio's functionality. For example, the AuthorizationPolicy\ncan be used with an extension provider to delegate the authorization decision to a custom authorization system.",
+                  "type": "array",
+                  "maxItems": 1000,
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "datadog": {
+                        "description": "Configures a Datadog tracing provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the Datadog agent.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"datadog.default.svc.cluster.local\" or \"bar/datadog.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyExtAuthzGrpc": {
+                        "description": "Configures an external authorizer that implements the Envoy ext_authz filter authorization check service using the gRPC API.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "failOpen": {
+                            "description": "If true, the HTTP request or TCP connection will be allowed even if the communication with the authorization service has failed,\nor if the authorization service has returned a HTTP 5xx error.\nDefault is false. For HTTP request, it will be rejected with 403 (HTTP Forbidden). For TCP connection, it will be closed immediately.",
+                            "type": "boolean"
+                          },
+                          "includeRequestBodyInCheck": {
+                            "description": "If set, the client request body will be included in the authorization request sent to the authorization service.",
+                            "type": "object",
+                            "properties": {
+                              "allowPartialMessage": {
+                                "description": "When this field is true, ext-authz filter will buffer the message until maxRequestBytes is reached.\nThe authorization request will be dispatched and no 413 HTTP error will be returned by the filter.\nA \"x-envoy-auth-partial-body: false|true\" metadata header will be added to the authorization request message\nindicating if the body data is partial.",
+                                "type": "boolean"
+                              },
+                              "maxRequestBytes": {
+                                "description": "Sets the maximum size of a message body that the ext-authz filter will hold in memory.\nIf maxRequestBytes is reached, and allowPartialMessage is false, Envoy will return a 413 (Payload Too Large).\nOtherwise the request will be sent to the provider with a partial message.\nNote that this setting will have precedence over the failOpen field, the 413 will be returned even when the\nfailOpen is set to true.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "packAsBytes": {
+                                "description": "If true, the body sent to the external authorization service in the gRPC authorization request is set with raw bytes\nin the [raw_body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153).\nOtherwise, it will be filled with UTF-8 string in the [body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147).\nThis field only works with the envoyExtAuthzGrpc provider and has no effect for the envoyExtAuthzHttp provider.",
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ext_authz gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"my-ext-authz.foo.svc.cluster.local\" or \"bar/my-ext-authz.example.com\".",
+                            "type": "string"
+                          },
+                          "statusOnError": {
+                            "description": "Sets the HTTP status that is returned to the client when there is a network error to the authorization service.\nThe default status is \"403\" (HTTP Forbidden).",
+                            "type": "string"
+                          },
+                          "timeout": {
+                            "description": "The maximum duration that the proxy will wait for a response from the provider, this is the timeout for a specific request (default timeout: 600s).\nWhen this timeout condition is met, the proxy marks the communication to the authorization service as failure.\nIn this situation, the response sent back to the client will depend on the configured `failOpen` field.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyExtAuthzHttp": {
+                        "description": "Configures an external authorizer that implements the Envoy ext_authz filter authorization check service using the HTTP API.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "failOpen": {
+                            "description": "If true, the user request will be allowed even if the communication with the authorization service has failed,\nor if the authorization service has returned a HTTP 5xx error.\nDefault is false and the request will be rejected with \"Forbidden\" response.",
+                            "type": "boolean"
+                          },
+                          "headersToDownstreamOnAllow": {
+                            "description": "List of headers from the authorization service that should be forwarded to downstream when the authorization\ncheck result is allowed (HTTP code 200).\nIf not specified, the original response will not be modified and forwarded to downstream as-is.\nNote, any existing headers will be overridden.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "headersToDownstreamOnDeny": {
+                            "description": "List of headers from the authorization service that should be forwarded to downstream when the authorization\ncheck result is not allowed (HTTP code other than 200).\nIf not specified, all the authorization response headers, except *Authority (Host)* will be in the response to\nthe downstream.\nWhen a header is included in this list, *Path*, *Status*, *Content-Length*, *WWWAuthenticate* and *Location* are\nautomatically added.\nNote, the body from the authorization service is always included in the response to downstream.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "headersToUpstreamOnAllow": {
+                            "description": "List of headers from the authorization service that should be added or overridden in the original request and\nforwarded to the upstream when the authorization check result is allowed (HTTP code 200).\nIf not specified, the original request will not be modified and forwarded to backend as-is.\nNote, any existing headers will be overridden.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "includeAdditionalHeadersInCheck": {
+                            "description": "Set of additional fixed headers that should be included in the authorization request sent to the authorization service.\nKey is the header name and value is the header value.\nNote that client request of the same key or headers specified in includeRequestHeadersInCheck will be overridden.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "includeHeadersInCheck": {
+                            "description": "DEPRECATED. Use includeRequestHeadersInCheck instead.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "includeRequestBodyInCheck": {
+                            "description": "If set, the client request body will be included in the authorization request sent to the authorization service.",
+                            "type": "object",
+                            "properties": {
+                              "allowPartialMessage": {
+                                "description": "When this field is true, ext-authz filter will buffer the message until maxRequestBytes is reached.\nThe authorization request will be dispatched and no 413 HTTP error will be returned by the filter.\nA \"x-envoy-auth-partial-body: false|true\" metadata header will be added to the authorization request message\nindicating if the body data is partial.",
+                                "type": "boolean"
+                              },
+                              "maxRequestBytes": {
+                                "description": "Sets the maximum size of a message body that the ext-authz filter will hold in memory.\nIf maxRequestBytes is reached, and allowPartialMessage is false, Envoy will return a 413 (Payload Too Large).\nOtherwise the request will be sent to the provider with a partial message.\nNote that this setting will have precedence over the failOpen field, the 413 will be returned even when the\nfailOpen is set to true.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "packAsBytes": {
+                                "description": "If true, the body sent to the external authorization service in the gRPC authorization request is set with raw bytes\nin the [raw_body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153).\nOtherwise, it will be filled with UTF-8 string in the [body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147).\nThis field only works with the envoyExtAuthzGrpc provider and has no effect for the envoyExtAuthzHttp provider.",
+                                "type": "boolean"
+                              }
+                            }
+                          },
+                          "includeRequestHeadersInCheck": {
+                            "description": "List of client request headers that should be included in the authorization request sent to the authorization service.\nNote that in addition to the headers specified here following headers are included by default:\n1. *Host*, *Method*, *Path* and *Content-Length* are automatically sent.\n2. *Content-Length* will be set to 0 and the request will not have a message body. However, the authorization\nrequest can include the buffered client request body (controlled by includeRequestBodyInCheck setting),\nconsequently the value of Content-Length of the authorization request reflects the size of its payload size.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "pathPrefix": {
+                            "description": "Sets a prefix to the value of authorization request header *Path*.\nFor example, setting this to \"/check\" for an original user request at path \"/admin\" will cause the\nauthorization check request to be sent to the authorization service at the path \"/check/admin\" instead of \"/admin\".",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ext_authz HTTP authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"my-ext-authz.foo.svc.cluster.local\" or \"bar/my-ext-authz.example.com\".",
+                            "type": "string"
+                          },
+                          "statusOnError": {
+                            "description": "Sets the HTTP status that is returned to the client when there is a network error to the authorization service.\nThe default status is \"403\" (HTTP Forbidden).",
+                            "type": "string"
+                          },
+                          "timeout": {
+                            "description": "The maximum duration that the proxy will wait for a response from the provider (default timeout: 600s).\nWhen this timeout condition is met, the proxy marks the communication to the authorization service as failure.\nIn this situation, the response sent back to the client will depend on the configured `failOpen` field.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyFileAccessLog": {
+                        "description": "Configures an Envoy File Access Log provider.",
+                        "type": "object",
+                        "properties": {
+                          "logFormat": {
+                            "description": "Optional. Allows overriding of the default access log format.",
+                            "type": "object",
+                            "properties": {
+                              "labels": {
+                                "description": "JSON structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)\ncan be used as values for fields within the Struct. Values are rendered\nas strings, numbers, or boolean values, as appropriate\n(see: [format dictionaries](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries)). Nested JSON is\nsupported for some command operators (e.g. `FILTER_STATE` or `DYNAMIC_METADATA`).\nUse `labels: {}` for default envoy JSON log format.\n\nExample:\n```\nlabels:\n\n\tstatus: \"%RESPONSE_CODE%\"\n\tmessage: \"%LOCAL_REPLY_BODY%\"\n\n```",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "text": {
+                                "description": "Textual format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be\nused in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)\nprovides more information.\n\nNOTE: Istio will insert a newline ('\\n') on all formats (if missing).\n\nExample: `text: \"%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\"`",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "At most one of [text labels] should be set",
+                                "rule": "(has(self.text)?1:0) + (has(self.labels)?1:0) <= 1"
+                              }
+                            ]
+                          },
+                          "path": {
+                            "description": "Path to a local file to write the access log entries.\nThis may be used to write to streams, via `/dev/stderr` and `/dev/stdout`\nIf unspecified, defaults to `/dev/stdout`.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyHttpAls": {
+                        "description": "Configures an Envoy Access Logging Service provider for HTTP traffic.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "additionalRequestHeadersToLog": {
+                            "description": "Optional. Additional request headers to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalResponseHeadersToLog": {
+                            "description": "Optional. Additional response headers to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalResponseTrailersToLog": {
+                            "description": "Optional. Additional response trailers to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "filterStateObjectsToLog": {
+                            "description": "Optional. Additional filter state objects to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "logName": {
+                            "description": "Optional. The friendly name of the access log.\nDefaults:\n-  \"http_envoy_accesslog\"\n-  \"listener_envoy_accesslog\"",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyOtelAls": {
+                        "description": "Configures an Envoy Open Telemetry Access Logging Service provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "logFormat": {
+                            "description": "Optional. Format for the proxy access log\nEmpty value results in proxy's default access log format, following Envoy access logging formatting.",
+                            "type": "object",
+                            "properties": {
+                              "labels": {
+                                "description": "Optional. Additional attributes that describe the specific event occurrence.\nStructured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)\ncan be used as values for fields within the Struct. Values are rendered\nas strings, numbers, or boolean values, as appropriate\n(see: [format dictionaries](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries)). Nested JSON is\nsupported for some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).\nAlias to `attributes` field in [Open Telemetry](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/open_telemetry/v3/logs_service.proto)\n\nExample:\n```\nlabels:\n\n\tstatus: \"%RESPONSE_CODE%\"\n\tmessage: \"%LOCAL_REPLY_BODY%\"\n\n```",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "text": {
+                                "description": "Textual format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be\nused in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)\nprovides more information.\nAlias to `body` field in [Open Telemetry](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/open_telemetry/v3/logs_service.proto)\nExample: `text: \"%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\"`",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "logName": {
+                            "description": "Optional. The friendly name of the access log.\nDefaults:\n- \"otel_envoy_accesslog\"",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "envoyTcpAls": {
+                        "description": "Configures an Envoy Access Logging Service provider for TCP traffic.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "filterStateObjectsToLog": {
+                            "description": "Optional. Additional filter state objects to log.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "logName": {
+                            "description": "Optional. The friendly name of the access log.\nDefaults:\n- \"tcp_envoy_accesslog\"\n- \"listener_envoy_accesslog\"",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "lightstep": {
+                        "description": "Configures a Lightstep tracing provider.\nDeprecated: For Istio 1.15+, please use an OpenTelemetryTracingProvider instead, more details can be found at https://github.com/istio/istio/issues/40027\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "accessToken": {
+                            "description": "The Lightstep access token.",
+                            "type": "string"
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the Lightstep collector.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"lightstep.default.svc.cluster.local\" or \"bar/lightstep.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "REQUIRED. A unique name identifying the extension provider.",
+                        "type": "string"
+                      },
+                      "opencensus": {
+                        "description": "Configures an OpenCensusAgent tracing provider.\nDeprecated: OpenCensus is deprecated, more details can be found at https://opentelemetry.io/blog/2023/sunsetting-opencensus/\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "context": {
+                            "description": "Specifies the set of context propagation headers used for distributed\ntracing. Default is `[\"W3C_TRACE_CONTEXT\"]`. If multiple values are specified,\nthe proxy will attempt to read each header for each request and will\nwrite all headers.",
+                            "type": "array",
+                            "items": {
+                              "description": "TraceContext selects the context propagation headers used for\ndistributed tracing.",
+                              "type": "string",
+                              "enum": [
+                                "UNSPECIFIED",
+                                "W3C_TRACE_CONTEXT",
+                                "GRPC_BIN",
+                                "CLOUD_TRACE_CONTEXT",
+                                "B3"
+                              ]
+                            }
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the OpenCensusAgent.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"ocagent.default.svc.cluster.local\" or \"bar/ocagent.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "opentelemetry": {
+                        "description": "Configures an OpenTelemetry tracing provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "dynatraceSampler": {
+                            "description": "The Dynatrace adaptive traffic management (ATM) sampler.\n\nExample configuration:\n\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: \"{your-environment-id}.live.dynatrace.com\"\n    http:\n    path: \"/api/v2/otlp/v1/traces\"\n    timeout: 10s\n    headers:\n  - name: \"Authorization\"\n    value: \"Api-Token dt0c01.\"\n    resourceDetectors:\n    dynatrace: {}\n    dynatraceSampler:\n    tenant: \"{your-environment-id}\"\n    clusterId: 1234",
+                            "type": "object",
+                            "required": [
+                              "clusterId",
+                              "tenant"
+                            ],
+                            "properties": {
+                              "clusterId": {
+                                "description": "REQUIRED. The identifier of the cluster in the Dynatrace platform.\nThe cluster here is Dynatrace-specific concept and not related to the cluster concept in Istio/Envoy.\n\nThe value can be obtained from the Istio deployment page in Dynatrace.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "httpService": {
+                                "description": "Optional. Dynatrace HTTP API to obtain sampling configuration.\n\nWhen not provided, the Dynatrace Sampler will re-use the configuration from the OpenTelemetryTracingProvider HTTP Exporter\n(`service`, `port` and `http`), including the access token.",
+                                "type": "object",
+                                "required": [
+                                  "http",
+                                  "port",
+                                  "service"
+                                ],
+                                "properties": {
+                                  "http": {
+                                    "description": "REQUIRED. Specifies sampling configuration URI.",
+                                    "type": "object",
+                                    "required": [
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "headers": {
+                                        "description": "Optional. Allows specifying custom HTTP headers that will be added\nto each HTTP request sent.",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "required": [
+                                            "name",
+                                            "value"
+                                          ],
+                                          "properties": {
+                                            "name": {
+                                              "description": "REQUIRED. The HTTP header name.",
+                                              "type": "string"
+                                            },
+                                            "value": {
+                                              "description": "REQUIRED. The HTTP header value.",
+                                              "type": "string"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "path": {
+                                        "description": "REQUIRED. Specifies the path on the service.",
+                                        "type": "string"
+                                      },
+                                      "timeout": {
+                                        "description": "Optional. Specifies the timeout for the HTTP request.\nIf not specified, the default is 3s.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "port": {
+                                    "description": "REQUIRED. Specifies the port of the service.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "service": {
+                                    "description": "REQUIRED. Specifies the Dynatrace environment to obtain the sampling configuration.\nThe format is `<Hostname>`, where `<Hostname>` is the fully qualified Dynatrace environment\nhost name defined in the ServiceEntry.\n\nExample: \"{your-environment-id}.live.dynatrace.com\".",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "rootSpansPerMinute": {
+                                "description": "Optional. Number of sampled spans per minute to be used\nwhen the adaptive value cannot be obtained from the Dynatrace API.\n\nA default value of `1000` is used when:\n\n- `rootSpansPerMinute` is unset\n- `rootSpansPerMinute` is set to 0",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "tenant": {
+                                "description": "REQUIRED. The Dynatrace customer's tenant identifier.\n\nThe value can be obtained from the Istio deployment page in Dynatrace.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "grpc": {
+                            "description": "Optional. Specifies the configuration for exporting OTLP traces via GRPC.\nWhen empty, traces will check whether HTTP is set.\nIf not, traces will use default GRPC configurations.\n\nThe following example shows how to configure the OpenTelemetry ExtensionProvider to export via GRPC:\n\n1. Add/change the OpenTelemetry extension provider in `MeshConfig`\n```yaml\n  - name: opentelemetry\n    opentelemetry:\n    port: 8090\n    service: tracing.example.com\n    grpc:\n    timeout: 10s\n    initialMetadata:\n  - name: \"Authentication\"\n    value: \"token-xxxxx\"\n\n```\n\n2. Deploy a `ServiceEntry` for the observability back-end\n```yaml\napiVersion: networking.istio.io/v1alpha3\nkind: ServiceEntry\nmetadata:\n\n\tname: tracing-grpc\n\nspec:\n\n\thosts:\n\t- tracing.example.com\n\tports:\n\t- number: 8090\n\t  name: grpc-port\n\t  protocol: GRPC\n\tresolution: DNS\n\tlocation: MESH_EXTERNAL\n\n```",
+                            "type": "object",
+                            "properties": {
+                              "initialMetadata": {
+                                "description": "Optional. Additional metadata to include in streams initiated to the GrpcService. This can be used for\nscenarios in which additional ad hoc authorization headers (e.g. \"x-foo-bar: baz-key\") are to\nbe injected.",
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "REQUIRED. The HTTP header name.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "REQUIRED. The HTTP header value.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "timeout": {
+                                "description": "Optional. Specifies the timeout for the GRPC request.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "http": {
+                            "description": "Optional. Specifies the configuration for exporting OTLP traces via HTTP.\nWhen empty, traces will be exported via gRPC.\n\nThe following example shows how to configure the OpenTelemetry ExtensionProvider to export via HTTP:\n\n1. Add/change the OpenTelemetry extension provider in `MeshConfig`\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: my.olly-backend.com\n    http:\n    path: \"/api/otlp/traces\"\n    timeout: 10s\n    headers:\n  - name: \"my-custom-header\"\n    value: \"some value\"\n\n```\n\n2. Deploy a `ServiceEntry` for the observability back-end\n```yaml\napiVersion: networking.istio.io/v1alpha3\nkind: ServiceEntry\nmetadata:\n\n\tname: my-olly-backend\n\nspec:\n\n\thosts:\n\t- my.olly-backend.com\n\tports:\n\t- number: 443\n\t  name: https-port\n\t  protocol: HTTPS\n\tresolution: DNS\n\tlocation: MESH_EXTERNAL\n\n---\napiVersion: networking.istio.io/v1alpha3\nkind: DestinationRule\nmetadata:\n\n\tname: my-olly-backend\n\nspec:\n\n\thost: my.olly-backend.com\n\ttrafficPolicy:\n\t  portLevelSettings:\n\t  - port:\n\t      number: 443\n\t    tls:\n\t      mode: SIMPLE\n\n```",
+                            "type": "object",
+                            "required": [
+                              "path"
+                            ],
+                            "properties": {
+                              "headers": {
+                                "description": "Optional. Allows specifying custom HTTP headers that will be added\nto each HTTP request sent.",
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "name",
+                                    "value"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "description": "REQUIRED. The HTTP header name.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "description": "REQUIRED. The HTTP header value.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "path": {
+                                "description": "REQUIRED. Specifies the path on the service.",
+                                "type": "string"
+                              },
+                              "timeout": {
+                                "description": "Optional. Specifies the timeout for the HTTP request.\nIf not specified, the default is 3s.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "resourceDetectors": {
+                            "description": "Optional. Specifies [Resource Detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/)\nto be used by the OpenTelemetry Tracer. When multiple resources are provided, they are merged\naccording to the OpenTelemetry [Resource specification](https://opentelemetry.io/docs/specs/otel/resource/sdk/#merge).\n\nThe following example shows how to configure the Environment Resource Detector, that will\nread the attributes from the environment variable `OTEL_RESOURCE_ATTRIBUTES`:\n\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: my.olly-backend.com\n    resourceDetectors:\n    environment: {}\n\n```",
+                            "type": "object",
+                            "properties": {
+                              "dynatrace": {
+                                "description": "Dynatrace Resource Detector.\nThe resource detector reads from the Dynatrace enrichment files\nand adds host/process related attributes to the OpenTelemetry resource.\n\nSee: [Enrich ingested data with Dynatrace-specific dimensions](https://docs.dynatrace.com/docs/shortlink/enrichment-files)",
+                                "type": "object"
+                              },
+                              "environment": {
+                                "description": "OpenTelemetry Environment Resource Detector.\nThe resource detector reads attributes from the environment variable `OTEL_RESOURCE_ATTRIBUTES`\nand adds them to the OpenTelemetry resource.\n\nSee: [Resource specification](https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable)",
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the OpenTelemetry endpoint that will receive OTLP traces.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"otlp.default.svc.cluster.local\" or \"bar/otlp.example.com\".",
+                            "type": "string"
+                          }
+                        },
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "At most one of [dynatraceSampler] should be set",
+                            "rule": "(has(self.dynatraceSampler)?1:0) <= 1"
+                          }
+                        ]
+                      },
+                      "prometheus": {
+                        "description": "Configures a Prometheus metrics provider.",
+                        "type": "object"
+                      },
+                      "skywalking": {
+                        "description": "Configures a Apache SkyWalking provider.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "accessToken": {
+                            "description": "Optional. The SkyWalking OAP access token.",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service for the SkyWalking receiver.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"skywalking.default.svc.cluster.local\" or \"bar/skywalking.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "stackdriver": {
+                        "description": "Configures a Stackdriver provider.",
+                        "type": "object",
+                        "properties": {
+                          "debug": {
+                            "description": "debug enables trace output to stdout.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "boolean"
+                          },
+                          "logging": {
+                            "description": "Optional. Controls Stackdriver logging behavior.",
+                            "type": "object",
+                            "properties": {
+                              "labels": {
+                                "description": "Collection of tag names and tag expressions to include in the log\nentry. Conflicts are resolved by the tag name by overriding previously\nsupplied values.\n\nExample:\n\n\tlabels:\n\t  path: request.url_path\n\t  foo: request.headers['x-foo']",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "maxNumberOfAnnotations": {
+                            "description": "The global default max number of annotation events per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "maxNumberOfAttributes": {
+                            "description": "The global default max number of attributes per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "maxNumberOfMessageEvents": {
+                            "description": "The global default max number of message events per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          }
+                        }
+                      },
+                      "zipkin": {
+                        "description": "Configures a tracing provider that uses the Zipkin API.",
+                        "type": "object",
+                        "required": [
+                          "port",
+                          "service"
+                        ],
+                        "properties": {
+                          "enable64bitTraceId": {
+                            "description": "Optional. A 128 bit trace id will be used in Istio.\nIf true, will result in a 64 bit trace id being used.",
+                            "type": "boolean"
+                          },
+                          "maxTagLength": {
+                            "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "path": {
+                            "description": "Optional. Specifies the endpoint of Zipkin API.\nThe default value is \"/api/v2/spans\".",
+                            "type": "string"
+                          },
+                          "port": {
+                            "description": "REQUIRED. Specifies the port of the service.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "service": {
+                            "description": "REQUIRED. Specifies the service that the Zipkin API.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"zipkin.default.svc.cluster.local\" or \"bar/zipkin.example.com\".",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "At most one of [envoyExtAuthzHttp envoyExtAuthzGrpc zipkin lightstep datadog stackdriver opencensus skywalking opentelemetry prometheus envoyFileAccessLog envoyHttpAls envoyTcpAls envoyOtelAls] should be set",
+                        "rule": "(has(self.envoyExtAuthzHttp)?1:0) + (has(self.envoyExtAuthzGrpc)?1:0) + (has(self.zipkin)?1:0) + (has(self.lightstep)?1:0) + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0) + (has(self.opencensus)?1:0) + (has(self.skywalking)?1:0) + (has(self.opentelemetry)?1:0) + (has(self.prometheus)?1:0) + (has(self.envoyFileAccessLog)?1:0) + (has(self.envoyHttpAls)?1:0) + (has(self.envoyTcpAls)?1:0) + (has(self.envoyOtelAls)?1:0) <= 1"
+                      }
+                    ]
+                  }
+                },
+                "h2UpgradePolicy": {
+                  "description": "Specify if http1.1 connections should be upgraded to http2 by default.\nif sidecar is installed on all pods in the mesh, then this should be set to `UPGRADE`.\nIf one or more services or namespaces do not have sidecar(s), then this should be set to `DO_NOT_UPGRADE`.\nIt can be enabled by destination using the `destinationRule.trafficPolicy.connectionPool.http.h2UpgradePolicy` override.",
+                  "type": "string",
+                  "enum": [
+                    "DO_NOT_UPGRADE",
+                    "UPGRADE"
+                  ]
+                },
+                "inboundClusterStatName": {
+                  "description": "Name to be used while emitting statistics for inbound clusters. The same pattern is used while computing stat prefix for\nnetwork filters like TCP and Redis.\nBy default, Istio emits statistics with the pattern `inbound|<port>|<port-name>|<service-FQDN>`.\nFor example `inbound|7443|grpc-reviews|reviews.prod.svc.cluster.local`. This can be used to override that pattern.\n\nA Pattern can be composed of various pre-defined variables. The following variables are supported.\n\n- `%SERVICE%` - Will be substituted with short hostname of the service.\n- `%SERVICE_NAME%` - Will be substituted with name of the service.\n- `%SERVICE_FQDN%` - Will be substituted with FQDN of the service.\n- `%SERVICE_PORT%` - Will be substituted with port of the service.\n- `%TARGET_PORT%`  - Will be substituted with the target port of the service.\n- `%SERVICE_PORT_NAME%` - Will be substituted with port name of the service.\n\nFollowing are some examples of supported patterns for reviews:\n\n- `%SERVICE_FQDN%_%SERVICE_PORT%` will use reviews.prod.svc.cluster.local_7443 as the stats name.\n- `%SERVICE%` will use reviews.prod as the stats name.",
+                  "type": "string"
+                },
+                "inboundTrafficPolicy": {
+                  "description": "Set the default behavior of the sidecar for handling inbound\ntraffic to the application.  If your application listens on\nlocalhost, you will need to set this to `LOCALHOST`.",
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "PASSTHROUGH",
+                        "LOCALHOST"
+                      ]
+                    }
+                  }
+                },
+                "ingressClass": {
+                  "description": "Class of ingress resources to be processed by Istio ingress\ncontroller. This corresponds to the value of\n`kubernetes.io/ingress.class` annotation.",
+                  "type": "string"
+                },
+                "ingressControllerMode": {
+                  "description": "Defines whether to use Istio ingress controller for annotated or all ingress resources.\nDefault mode is `STRICT`.",
+                  "type": "string",
+                  "enum": [
+                    "UNSPECIFIED",
+                    "OFF",
+                    "DEFAULT",
+                    "STRICT"
+                  ]
+                },
+                "ingressSelector": {
+                  "description": "Defines which gateway deployment to use as the Ingress controller. This field corresponds to\nthe Gateway.selector field, and will be set as `istio: INGRESS_SELECTOR`.\nBy default, `ingressgateway` is used, which will select the default IngressGateway as it has the\n`istio: ingressgateway` labels.\nIt is recommended that this is the same value as ingressService.",
+                  "type": "string"
+                },
+                "ingressService": {
+                  "description": "Name of the Kubernetes service used for the istio ingress controller.\nIf no ingress controller is specified, the default value `istio-ingressgateway` is used.",
+                  "type": "string"
+                },
+                "localityLbSetting": {
+                  "description": "Locality based load balancing distribution or failover settings.\nIf unspecified, locality based load balancing will be enabled by default.\nHowever, this requires outlierDetection to actually take effect for a particular\nservice, see https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/",
+                  "type": "object",
+                  "properties": {
+                    "distribute": {
+                      "description": "Optional: only one of distribute, failover or failoverPriority can be set.\nExplicitly specify loadbalancing weight across different zones and geographical locations.\nRefer to [Locality weighted load balancing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight)\nIf empty, the locality weight is set according to the endpoints number within it.",
+                      "type": "array",
+                      "items": {
+                        "description": "Describes how traffic originating in the 'from' zone or sub-zone is\ndistributed over a set of 'to' zones. Syntax for specifying a zone is\n{region}/{zone}/{sub-zone} and terminal wildcards are allowed on any\nsegment of the specification. Examples:\n\n`*` - matches all localities\n\n`us-west/*` - all zones and sub-zones within the us-west region\n\n`us-west/zone-1/*` - all sub-zones within us-west/zone-1",
+                        "type": "object",
+                        "properties": {
+                          "from": {
+                            "description": "Originating locality, '/' separated, e.g. 'region/zone/sub_zone'.",
+                            "type": "string"
+                          },
+                          "to": {
+                            "description": "Map of upstream localities to traffic distribution weights. The sum of\nall weights should be 100. Any locality not present will\nreceive no traffic.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable locality load balancing. This is DestinationRule-level and will override mesh-wide settings in entirety.\ne.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh-wide settings is.",
+                      "type": "boolean"
+                    },
+                    "failover": {
+                      "description": "Optional: only one of distribute, failover or failoverPriority can be set.\nExplicitly specify the region traffic will land on when endpoints in local region becomes unhealthy.\nShould be used together with OutlierDetection to detect unhealthy endpoints.\nNote: if no OutlierDetection specified, this will not take effect.",
+                      "type": "array",
+                      "items": {
+                        "description": "Specify the traffic failover policy across regions. Since zone and sub-zone\nfailover is supported by default this only needs to be specified for\nregions when the operator needs to constrain traffic failover so that\nthe default behavior of failing over to any endpoint globally does not\napply. This is useful when failing over traffic across regions would not\nimprove service health or may need to be restricted for other reasons\nlike regulatory controls.",
+                        "type": "object",
+                        "properties": {
+                          "from": {
+                            "description": "Originating region.",
+                            "type": "string"
+                          },
+                          "to": {
+                            "description": "Destination region the traffic will fail over to when endpoints in\nthe 'from' region becomes unhealthy.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "failoverPriority": {
+                      "description": "failoverPriority is an ordered list of labels used to sort endpoints to do priority based load balancing.\nThis is to support traffic failover across different groups of endpoints.\nTwo kinds of labels can be specified:\n\n  - Specify only label keys `[key1, key2, key3]`, istio would compare the label values of client with endpoints.\n    Suppose there are total N label keys `[key1, key2, key3, ...keyN]` specified:\n\n    1. Endpoints matching all N labels with the client proxy have priority P(0) i.e. the highest priority.\n    2. Endpoints matching the first N-1 labels with the client proxy have priority P(1) i.e. second highest priority.\n    3. By extension of this logic, endpoints matching only the first label with the client proxy has priority P(N-1) i.e. second lowest priority.\n    4. All the other endpoints have priority P(N) i.e. lowest priority.\n\n  - Specify labels with key and value `[key1=value1, key2=value2, key3=value3]`, istio would compare the labels with endpoints.\n    Suppose there are total N labels `[key1=value1, key2=value2, key3=value3, ...keyN=valueN]` specified:\n\n    1. Endpoints matching all N labels have priority P(0) i.e. the highest priority.\n    2. Endpoints matching the first N-1 labels have priority P(1) i.e. second highest priority.\n    3. By extension of this logic, endpoints matching only the first label has priority P(N-1) i.e. second lowest priority.\n    4. All the other endpoints have priority P(N) i.e. lowest priority.\n\nNote: For a label to be considered for match, the previous labels must match, i.e. nth label would be considered matched only if first n-1 labels match.\n\nIt can be any label specified on both client and server workloads.\nThe following labels which have special semantic meaning are also supported:\n\n  - `topology.istio.io/network` is used to match the network metadata of an endpoint, which can be specified by pod/namespace label `topology.istio.io/network`, sidecar env `ISTIO_META_NETWORK` or MeshNetworks.\n  - `topology.istio.io/cluster` is used to match the clusterID of an endpoint, which can be specified by pod label `topology.istio.io/cluster` or pod env `ISTIO_META_CLUSTER_ID`.\n  - `topology.kubernetes.io/region` is used to match the region metadata of an endpoint, which maps to Kubernetes node label `topology.kubernetes.io/region` or the deprecated label `failure-domain.beta.kubernetes.io/region`.\n  - `topology.kubernetes.io/zone` is used to match the zone metadata of an endpoint, which maps to Kubernetes node label `topology.kubernetes.io/zone` or the deprecated label `failure-domain.beta.kubernetes.io/zone`.\n  - `topology.istio.io/subzone` is used to match the subzone metadata of an endpoint, which maps to Istio node label `topology.istio.io/subzone`.\n  - `kubernetes.io/hostname` is used to match the current node of an endpoint, which maps to Kubernetes node label `kubernetes.io/hostname`.\n\nThe below topology config indicates the following priority levels:\n\n```yaml\nfailoverPriority:\n- \"topology.istio.io/network\"\n- \"topology.kubernetes.io/region\"\n- \"topology.kubernetes.io/zone\"\n- \"topology.istio.io/subzone\"\n```\n\n1. endpoints match same [network, region, zone, subzone] label with the client proxy have the highest priority.\n2. endpoints have same [network, region, zone] label but different [subzone] label with the client proxy have the second highest priority.\n3. endpoints have same [network, region] label but different [zone] label with the client proxy have the third highest priority.\n4. endpoints have same [network] but different [region] labels with the client proxy have the fourth highest priority.\n5. all the other endpoints have the same lowest priority.\n\nSuppose a service associated endpoints reside in multi clusters, the below example represents:\n1. endpoints in `clusterA` and has `version=v1` label have P(0) priority.\n2. endpoints not in `clusterA` but has `version=v1` label have P(1) priority.\n2. all the other endpoints have P(2) priority.\n\n```yaml\nfailoverPriority:\n- \"version=v1\"\n- \"topology.istio.io/cluster=clusterA\"\n```\n\nOptional: only one of distribute, failover or failoverPriority can be set.\nAnd it should be used together with `OutlierDetection` to detect unhealthy endpoints, otherwise has no effect.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "meshMTLS": {
+                  "description": "The below configuration parameters can be used to specify TLSConfig for mesh traffic.\nFor example, a user could enable min TLS version for ISTIO_MUTUAL traffic and specify a curve for non ISTIO_MUTUAL traffic like below:\n```yaml\nmeshConfig:\n\n\tmeshMTLS:\n\t  minProtocolVersion: TLSV1_3\n\ttlsDefaults:\n\t  Note: applicable only for non ISTIO_MUTUAL scenarios\n\t  ecdhCurves:\n\t    - P-256\n\t    - P-512\n\n```\nConfiguration of mTLS for traffic between workloads with ISTIO_MUTUAL TLS traffic.\n\nNote: Mesh mTLS does not respect ECDH curves.",
+                  "type": "object",
+                  "properties": {
+                    "cipherSuites": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified cipher list when negotiating TLS 1.0-1.2.\nIf not specified, the following cipher suites will be used:\n```\nECDHE-ECDSA-AES256-GCM-SHA384\nECDHE-RSA-AES256-GCM-SHA384\nECDHE-ECDSA-AES128-GCM-SHA256\nECDHE-RSA-AES128-GCM-SHA256\nAES256-GCM-SHA384\nAES128-GCM-SHA256\n```",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "ecdhCurves": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified ECDH curves for the DH key exchange.\nIf not specified, the default curves enforced by Envoy will be used. For details about the default curves, refer to\n[Ecdh Curves](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "minProtocolVersion": {
+                      "description": "Optional: the minimum TLS protocol version. The default minimum\nTLS version will be TLS 1.2. As servers may not be Envoy and be\nset to TLS 1.2 (e.g., workloads using mTLS without sidecars), the\nminimum TLS version for clients may also be TLS 1.2.\nIn the current Istio implementation, the maximum TLS protocol version\nis TLS 1.3.",
+                      "type": "string",
+                      "enum": [
+                        "TLS_AUTO",
+                        "TLSV1_2",
+                        "TLSV1_3"
+                      ]
+                    }
+                  }
+                },
+                "outboundClusterStatName": {
+                  "description": "Name to be used while emitting statistics for outbound clusters. The same pattern is used while computing stat prefix for\nnetwork filters like TCP and Redis.\nBy default, Istio emits statistics with the pattern `outbound|<port>|<subsetname>|<service-FQDN>`.\nFor example `outbound|8080|v2|reviews.prod.svc.cluster.local`. This can be used to override that pattern.\n\nA Pattern can be composed of various pre-defined variables. The following variables are supported.\n\n- `%SERVICE%` - Will be substituted with short hostname of the service.\n- `%SERVICE_NAME%` - Will be substituted with name of the service.\n- `%SERVICE_FQDN%` - Will be substituted with FQDN of the service.\n- `%SERVICE_PORT%` - Will be substituted with port of the service.\n- `%SERVICE_PORT_NAME%` - Will be substituted with port name of the service.\n- `%SUBSET_NAME%` - Will be substituted with subset.\n\nFollowing are some examples of supported patterns for reviews:\n\n- `%SERVICE_FQDN%_%SERVICE_PORT%` will use `reviews.prod.svc.cluster.local_7443` as the stats name.\n- `%SERVICE%` will use reviews.prod as the stats name.",
+                  "type": "string"
+                },
+                "outboundTrafficPolicy": {
+                  "description": "Set the default behavior of the sidecar for handling outbound\ntraffic from the application.\n\nCan be overridden at a Sidecar level by setting the `OutboundTrafficPolicy` in the\n[Sidecar API](https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy).\n\nDefault mode is `ALLOW_ANY`, which means outbound traffic to unknown destinations will be allowed.",
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "REGISTRY_ONLY",
+                        "ALLOW_ANY"
+                      ]
+                    }
+                  }
+                },
+                "pathNormalization": {
+                  "description": "ProxyPathNormalization configures how URL paths in incoming and outgoing HTTP requests are\nnormalized by the sidecars and gateways.\nThe normalized paths will be used in all aspects through the requests' lifetime on the\nsidecars and gateways, which includes routing decisions in outbound direction (client proxy),\nauthorization policy match and enforcement in inbound direction (server proxy), and the URL\npath proxied to the upstream service.\nIf not set, the NormalizationType.DEFAULT configuration will be used.",
+                  "type": "object",
+                  "properties": {
+                    "normalization": {
+                      "type": "string",
+                      "enum": [
+                        "DEFAULT",
+                        "NONE",
+                        "BASE",
+                        "MERGE_SLASHES",
+                        "DECODE_AND_MERGE_SLASHES"
+                      ]
+                    }
+                  }
+                },
+                "protocolDetectionTimeout": {
+                  "description": "Automatic protocol detection uses a set of heuristics to\ndetermine whether the connection is using TLS or not (on the\nserver side), as well as the application protocol being used\n(e.g., http vs tcp). These heuristics rely on the client sending\nthe first bits of data. For server first protocols like MySQL,\nMongoDB, etc. Envoy will timeout on the protocol detection after\nthe specified period, defaulting to non mTLS plain TCP\ntraffic. Set this field to tweak the period that Envoy will wait\nfor the client to send the first bits of data. (MUST be >=1ms or\n0s to disable). Default detection timeout is 0s (no timeout).\n\nSetting a timeout is not recommended nor safe. Even high timeouts (>5s) will be hit\noccasionally, and when they occur the result is typically broken traffic that may not\nrecover on its own. Exceptionally high values might solve this, but injecting 60s delays\nonto new connections is generally not tenable anyways.",
+                  "type": "string"
+                },
+                "proxyHttpPort": {
+                  "description": "Port on which Envoy should listen for HTTP PROXY requests if set.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "proxyInboundListenPort": {
+                  "description": "Port on which Envoy should listen for all inbound traffic to the pod/vm will be captured to.\nDefault port is 15006.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "proxyListenPort": {
+                  "description": "Port on which Envoy should listen for all outbound traffic to other services.\nDefault port is 15001.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "rootNamespace": {
+                  "description": "The namespace to treat as the administrative root namespace for\nIstio configuration. When processing a leaf namespace Istio will search for\ndeclarations in that namespace first and if none are found it will\nsearch in the root namespace. Any matching declaration found in the root\nnamespace is processed as if it were declared in the leaf namespace.\n\nThe precise semantics of this processing are documented on each resource\ntype.",
+                  "type": "string"
+                },
+                "serviceSettings": {
+                  "description": "Settings to be applied to select services.",
+                  "type": "array",
+                  "items": {
+                    "description": "Settings to be applied to select services.\n\nFor example, the following configures all services in namespace \"foo\" as well as the\n\"bar\" service in namespace \"baz\" to be considered cluster-local:\n\n```yaml\nserviceSettings:\n  - settings:\n    clusterLocal: true\n    hosts:\n  - \"*.foo.svc.cluster.local\"\n  - \"bar.baz.svc.cluster.local\"\n\n```",
+                    "type": "object",
+                    "properties": {
+                      "hosts": {
+                        "description": "The services to which the Settings should be applied. Services are selected using the hostname\nmatching rules used by DestinationRule.\n\nFor example: foo.bar.svc.cluster.local, *.baz.svc.cluster.local",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "settings": {
+                        "description": "The settings to apply to the selected services.",
+                        "type": "object",
+                        "properties": {
+                          "clusterLocal": {
+                            "description": "If true, specifies that the client and service endpoints must reside in the same cluster.\nBy default, in multi-cluster deployments, the Istio control plane assumes all service\nendpoints to be reachable from any client in any of the clusters which are part of the\nmesh. This configuration option limits the set of service endpoints visible to a client\nto be cluster scoped.\n\nThere are some common scenarios when this can be useful:\n\n  - A service (or group of services) is inherently local to the cluster and has local storage\n    for that cluster. For example, the kube-system namespace (e.g. the Kube API Server).\n  - A mesh administrator wants to slowly migrate services to Istio. They might start by first\n    having services cluster-local and then slowly transition them to mesh-wide. They could do\n    this service-by-service (e.g. mysvc.myns.svc.cluster.local) or as a group\n    (e.g. *.myns.svc.cluster.local).\n\nBy default Istio will consider kubernetes.default.svc (i.e. the API Server) as well as all\nservices in the kube-system namespace to be cluster-local, unless explicitly overridden here.",
+                            "type": "boolean"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "tcpKeepalive": {
+                  "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                  "type": "object",
+                  "properties": {
+                    "interval": {
+                      "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                      "type": "string"
+                    },
+                    "probes": {
+                      "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "time": {
+                      "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                      "type": "string"
+                    }
+                  }
+                },
+                "tlsDefaults": {
+                  "description": "Configuration of TLS for all traffic except for ISTIO_MUTUAL mode.\nCurrently, this supports configuration of ecdhCurves and cipherSuites only.\nFor ISTIO_MUTUAL TLS settings, use meshMTLS configuration.",
+                  "type": "object",
+                  "properties": {
+                    "cipherSuites": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified cipher list when negotiating TLS 1.0-1.2.\nIf not specified, the following cipher suites will be used:\n```\nECDHE-ECDSA-AES256-GCM-SHA384\nECDHE-RSA-AES256-GCM-SHA384\nECDHE-ECDSA-AES128-GCM-SHA256\nECDHE-RSA-AES128-GCM-SHA256\nAES256-GCM-SHA384\nAES128-GCM-SHA256\n```",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "ecdhCurves": {
+                      "description": "Optional: If specified, the TLS connection will only support the specified ECDH curves for the DH key exchange.\nIf not specified, the default curves enforced by Envoy will be used. For details about the default curves, refer to\n[Ecdh Curves](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "minProtocolVersion": {
+                      "description": "Optional: the minimum TLS protocol version. The default minimum\nTLS version will be TLS 1.2. As servers may not be Envoy and be\nset to TLS 1.2 (e.g., workloads using mTLS without sidecars), the\nminimum TLS version for clients may also be TLS 1.2.\nIn the current Istio implementation, the maximum TLS protocol version\nis TLS 1.3.",
+                      "type": "string",
+                      "enum": [
+                        "TLS_AUTO",
+                        "TLSV1_2",
+                        "TLSV1_3"
+                      ]
+                    }
+                  }
+                },
+                "trustDomain": {
+                  "description": "The trust domain corresponds to the trust root of a system.\nRefer to [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)",
+                  "type": "string"
+                },
+                "trustDomainAliases": {
+                  "description": "The trust domain aliases represent the aliases of `trustDomain`.\nFor example, if we have\n```yaml\ntrustDomain: td1\ntrustDomainAliases: [\"td2\", \"td3\"]\n```\nAny service with the identity `td1/ns/foo/sa/a-service-account`, `td2/ns/foo/sa/a-service-account`,\nor `td3/ns/foo/sa/a-service-account` will be treated the same in the Istio mesh.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "verifyCertificateAtClient": {
+                  "description": "`VerifyCertificateAtClient` sets the mesh global default for peer certificate validation\nat the client-side proxy when `SIMPLE` TLS or `MUTUAL` TLS (non `ISTIO_MUTUAL`) origination\nmodes are used. This setting can be overridden at the host level via DestinationRule API.\nBy default, `VerifyCertificateAtClient` is `true`.\n\n`CaCertificates`: If set, proxy verifies CA signature based on given CaCertificates. If unset,\nand VerifyCertificateAtClient is true, proxy uses default System CA bundle. If unset and\n`VerifyCertificateAtClient` is false, proxy will not verify the CA.\n\n`SubjectAltNames`: If set, proxy verifies subject alt names are present in the SAN. If unset,\nand `VerifyCertificateAtClient` is true, proxy uses host in destination rule to verify the SANs.\nIf unset, and `VerifyCertificateAtClient` is false, proxy does not verify SANs.\n\nFor SAN, client-side proxy will exact match host in `DestinationRule` as well as one level\nwildcard if the specified host in DestinationRule doesn't contain a wildcard.\nFor example, if the host in `DestinationRule` is `x.y.com`, client-side proxy will\nmatch either `x.y.com` or `*.y.com` for the SAN in the presented server certificate.\nFor wildcard host name in DestinationRule, client-side proxy will do a suffix match. For example,\nif host is `*.x.y.com`, client-side proxy will verify the presented server certificate SAN matches\n\u201c.x.y.com` suffix.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                  "type": "boolean"
+                }
+              }
+            },
+            "pilot": {
+              "description": "Configuration for the Pilot component.",
+              "type": "object",
+              "properties": {
+                "affinity": {
+                  "description": "K8s affinity to set on the Pilot Pods.",
+                  "type": "object",
+                  "properties": {
+                    "nodeAffinity": {
+                      "description": "Describes node affinity scheduling rules for the pod.",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node matches the corresponding matchExpressions; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "An empty preferred scheduling term matches all objects with implicit weight 0\n(i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+                            "type": "object",
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "A node selector term, associated with the corresponding weight.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "weight": {
+                                "description": "Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to an update), the system\nmay or may not try to eventually evict the pod from its node.",
+                          "type": "object",
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "description": "Required. A list of node selector terms. The terms are ORed.",
+                              "type": "array",
+                              "items": {
+                                "description": "A null or empty node selector term matches no objects. The requirements of\nthem are ANDed.\nThe TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "A list of node selector requirements by node's labels.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "description": "A list of node selector requirements by node's fields.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A node selector requirement is a selector that contains values, a key, and an operator\nthat relates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "The label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "Represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "An array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. If the operator is Gt or Lt, the values\narray must have a single element, which will be interpreted as an integer.\nThis array is replaced during a strategic merge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      }
+                    },
+                    "podAffinity": {
+                      "description": "Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    },
+                    "podAntiAffinity": {
+                      "description": "Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "The scheduler will prefer to schedule pods to nodes that satisfy\nthe anti-affinity expressions specified by this field, but it may choose\na node that violates one or more of the expressions. The node that is\nmost preferred is the one with the greatest sum of weights, i.e.\nfor each node that meets all of the scheduling requirements (resource\nrequest, requiredDuringScheduling anti-affinity expressions, etc.),\ncompute a sum by iterating through the elements of this field and adding\n\"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the\nnode(s) with the highest sum are the most preferred.",
+                          "type": "array",
+                          "items": {
+                            "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+                            "type": "object",
+                            "required": [
+                              "podAffinityTerm",
+                              "weight"
+                            ],
+                            "properties": {
+                              "podAffinityTerm": {
+                                "description": "Required. A pod affinity term, associated with the corresponding weight.",
+                                "type": "object",
+                                "required": [
+                                  "topologyKey"
+                                ],
+                                "properties": {
+                                  "labelSelector": {
+                                    "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "matchLabelKeys": {
+                                    "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "mismatchLabelKeys": {
+                                    "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "namespaceSelector": {
+                                    "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "namespaces": {
+                                    "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "topologyKey": {
+                                    "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "description": "weight associated with matching the corresponding podAffinityTerm,\nin the range 1-100.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "If the anti-affinity requirements specified by this field are not met at\nscheduling time, the pod will not be scheduled onto the node.\nIf the anti-affinity requirements specified by this field cease to be met\nat some point during pod execution (e.g. due to a pod label update), the\nsystem may or may not try to eventually evict the pod from its node.\nWhen there are multiple elements, the lists of nodes corresponding to each\npodAffinityTerm are intersected, i.e. all terms must be satisfied.",
+                          "type": "array",
+                          "items": {
+                            "description": "Defines a set of pods (namely those matching the labelSelector\nrelative to the given namespace(s)) that this pod should be\nco-located (affinity) or not co-located (anti-affinity) with,\nwhere co-located is defined as running on a node whose value of\nthe label with key <topologyKey> matches that of any node on which\na pod of the set of pods is running",
+                            "type": "object",
+                            "required": [
+                              "topologyKey"
+                            ],
+                            "properties": {
+                              "labelSelector": {
+                                "description": "A label query over a set of resources, in this case pods.\nIf it's null, this PodAffinityTerm matches with no Pods.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "matchLabelKeys": {
+                                "description": "MatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both matchLabelKeys and labelSelector.\nAlso, matchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "mismatchLabelKeys": {
+                                "description": "MismatchLabelKeys is a set of pod label keys to select which pods will\nbe taken into consideration. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`\nto select the group of existing pods which pods will be taken into consideration\nfor the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming\npod labels will be ignored. The default value is empty.\nThe same key is forbidden to exist in both mismatchLabelKeys and labelSelector.\nAlso, mismatchLabelKeys cannot be set when labelSelector isn't set.\nThis is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "namespaceSelector": {
+                                "description": "A label query over the set of namespaces that the term applies to.\nThe term is applied to the union of the namespaces selected by this field\nand the ones listed in the namespaces field.\nnull selector and null or empty namespaces list means \"this pod's namespace\".\nAn empty selector ({}) matches all namespaces.",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "description": "key is the label key that the selector applies to.",
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchLabels": {
+                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-map-type": "atomic"
+                              },
+                              "namespaces": {
+                                "description": "namespaces specifies a static list of namespace names that the term applies to.\nThe term is applied to the union of the namespaces listed in this field\nand the ones selected by namespaceSelector.\nnull or empty namespaces list and null namespaceSelector means \"this pod's namespace\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "topologyKey": {
+                                "description": "This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching\nthe labelSelector in the specified namespaces, where co-located is defined as running on a node\nwhose value of the label with key topologyKey matches that of any node on which any of the\nselected pods is running.\nEmpty topologyKey is not allowed.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    }
+                  }
+                },
+                "autoscaleBehavior": {
+                  "description": "See https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior",
+                  "type": "object",
+                  "properties": {
+                    "scaleDown": {
+                      "description": "scaleDown is scaling policy for scaling Down.\nIf not set, the default value is to allow to scale down to minReplicas pods, with a\n300 second stabilization window (i.e., the highest recommendation for\nthe last 300sec is used).",
+                      "type": "object",
+                      "properties": {
+                        "policies": {
+                          "description": "policies is a list of potential scaling polices which can be used during scaling.\nAt least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
+                          "type": "array",
+                          "items": {
+                            "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                            "type": "object",
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "periodSeconds": {
+                                "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "type": {
+                                "description": "type is used to specify the scaling policy.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    },
+                    "scaleUp": {
+                      "description": "scaleUp is scaling policy for scaling Up.\nIf not set, the default value is the higher of:\n  * increase no more than 4 pods per 60 seconds\n  * double the number of pods per 60 seconds\nNo stabilization is used.",
+                      "type": "object",
+                      "properties": {
+                        "policies": {
+                          "description": "policies is a list of potential scaling polices which can be used during scaling.\nAt least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid",
+                          "type": "array",
+                          "items": {
+                            "description": "HPAScalingPolicy is a single policy which must hold true for a specified past interval.",
+                            "type": "object",
+                            "required": [
+                              "periodSeconds",
+                              "type",
+                              "value"
+                            ],
+                            "properties": {
+                              "periodSeconds": {
+                                "description": "periodSeconds specifies the window of time for which the policy should hold true.\nPeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "type": {
+                                "description": "type is used to specify the scaling policy.",
+                                "type": "string"
+                              },
+                              "value": {
+                                "description": "value contains the amount of change which is permitted by the policy.\nIt must be greater than zero",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "selectPolicy": {
+                          "description": "selectPolicy is used to specify which policy should be used.\nIf not set, the default value Max is used.",
+                          "type": "string"
+                        },
+                        "stabilizationWindowSeconds": {
+                          "description": "stabilizationWindowSeconds is the number of seconds for which past recommendations should be\nconsidered while scaling up or scaling down.\nStabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).\nIf not set, use the default values:\n- For scale up: 0 (i.e. no stabilization is done).\n- For scale down: 300 (i.e. the stabilization window is 300 seconds long).",
+                          "type": "integer",
+                          "format": "int32"
+                        }
+                      }
+                    }
+                  }
+                },
+                "autoscaleEnabled": {
+                  "description": "Controls whether a HorizontalPodAutoscaler is installed for Pilot.",
+                  "type": "boolean"
+                },
+                "autoscaleMax": {
+                  "description": "Maximum number of replicas in the HorizontalPodAutoscaler for Pilot.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "autoscaleMin": {
+                  "description": "Minimum number of replicas in the HorizontalPodAutoscaler for Pilot.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "cni": {
+                  "description": "Configures whether to use an existing CNI installation for workloads",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Controls whether CNI should be used.",
+                      "type": "boolean"
+                    },
+                    "provider": {
+                      "description": "Specifies the CNI provider. Can be either \"default\" or \"multus\". When set to \"multus\", an annotation\n`k8s.v1.cni.cncf.io/networks` is set on injected pods to point to a NetworkAttachmentDefinition",
+                      "type": "string"
+                    }
+                  }
+                },
+                "configMap": {
+                  "description": "Configuration settings passed to Pilot as a ConfigMap.\n\nThis controls whether the mesh config map, generated from values.yaml is generated.\nIf false, pilot wil use default values or user-supplied values, in that order of preference.",
+                  "type": "boolean"
+                },
+                "cpu": {
+                  "description": "Target CPU utilization used in HorizontalPodAutoscaler.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "targetAverageUtilization": {
+                      "description": "K8s utilization setting for HorizontalPodAutoscaler target.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "deploymentLabels": {
+                  "description": "Labels that are added to Pilot deployment.\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "enabled": {
+                  "description": "Controls whether Pilot is enabled.",
+                  "type": "boolean"
+                },
+                "env": {
+                  "description": "Environment variables passed to the Pilot container.\n\nExamples:\nenv:\n\n\tENV_VAR_1: value1\n\tENV_VAR_2: value2",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "extraContainerArgs": {
+                  "description": "Additional container arguments for the Pilot container.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "hub": {
+                  "description": "Hub to pull the container image from. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Image name used for Pilot.\n\nThis can be set either to image name if hub is also set, or can be set to the full hub:name string.\n\nExamples: custom-pilot, docker.io/someuser:custom-pilot",
+                  "type": "string"
+                },
+                "ipFamilies": {
+                  "description": "Defines which IP family to use for single stack or the order of IP families for dual-stack.\nValid list items are \"IPv4\", \"IPv6\".\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "ipFamilyPolicy": {
+                  "description": "Controls whether Services are configured to use IPv4, IPv6, or both. Valid options\nare PreferDualStack, RequireDualStack, and SingleStack.\nMore info: https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services",
+                  "type": "string"
+                },
+                "istiodRemote": {
+                  "description": "Configuration for the istio-discovery chart when istiod is running in a remote cluster (e.g. \"remote control plane\").",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Indicates if this cluster/install should consume a \"remote\" istiod instance,",
+                      "type": "boolean"
+                    },
+                    "injectionCABundle": {
+                      "description": "injector ca bundle",
+                      "type": "string"
+                    },
+                    "injectionPath": {
+                      "description": "Path to use for the sidecar injector webhook service.",
+                      "type": "string"
+                    },
+                    "injectionURL": {
+                      "description": "URL to use for sidecar injector webhook.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "jwksResolverExtraRootCA": {
+                  "description": "Specifies an extra root certificate in PEM format. This certificate will be trusted\nby pilot when resolving JWKS URIs.",
+                  "type": "string"
+                },
+                "keepaliveMaxServerConnectionAge": {
+                  "description": "Maximum duration that a sidecar can be connected to a pilot.\n\nThis setting balances out load across pilot instances, but adds some resource overhead.\n\nExamples: 300s, 30m, 1h",
+                  "type": "string"
+                },
+                "memory": {
+                  "description": "Target memory utilization used in HorizontalPodAutoscaler.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "targetAverageUtilization": {
+                      "description": "K8s utilization setting for HorizontalPodAutoscaler target.\n\nSee https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/",
+                      "type": "integer",
+                      "format": "int32"
+                    }
+                  }
+                },
+                "nodeSelector": {
+                  "description": "K8s node selector.\n\nSee https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "podAnnotations": {
+                  "description": "K8s annotations for pods.\n\nSee: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "podLabels": {
+                  "description": "Labels that are added to Pilot pods.\n\nSee https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "replicaCount": {
+                  "description": "Number of replicas in the Pilot Deployment.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "resources": {
+                  "description": "K8s resources settings.\n\nSee https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "rollingMaxSurge": {
+                  "description": "K8s rolling update strategy\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "rollingMaxUnavailable": {
+                  "description": "The number of pods that can be unavailable during a rolling update (see\n`strategy.rollingUpdate.maxUnavailable` here:\nhttps://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/#DeploymentSpec).\nMay be specified as a number of pods or as a percent of the total number\nof pods at the start of the update.\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "x-kubernetes-int-or-string": true
+                },
+                "seccompProfile": {
+                  "description": "The seccompProfile for the Pilot container.\n\nSee: https://kubernetes.io/docs/tutorials/security/seccomp/",
+                  "type": "object",
+                  "required": [
+                    "type"
+                  ],
+                  "properties": {
+                    "localhostProfile": {
+                      "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                      "type": "string"
+                    },
+                    "type": {
+                      "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "serviceAccountAnnotations": {
+                  "description": "K8s annotations for the service account",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "serviceAnnotations": {
+                  "description": "K8s annotations for the Service.\n\nSee: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "tag": {
+                  "description": "The container image tag to pull. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "taint": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Enable the untaint controller for new nodes. This aims to solve a race for CNI installation on\nnew nodes. For this to work, the newly added nodes need to have the istio CNI taint as they are\nadded to the cluster. This is usually done by configuring the cluster infra provider.",
+                      "type": "boolean"
+                    },
+                    "namespace": {
+                      "description": "The namespace of the CNI daemonset, incase it's not the same as istiod.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "tolerations": {
+                  "description": "The node tolerations to be applied to the Pilot deployment so that it can be\nscheduled to particular nodes with matching taints.\nMore info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "array",
+                  "items": {
+                    "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+                    "type": "object",
+                    "properties": {
+                      "effect": {
+                        "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                        "type": "string"
+                      },
+                      "key": {
+                        "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                        "type": "string"
+                      },
+                      "operator": {
+                        "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                        "type": "string"
+                      },
+                      "tolerationSeconds": {
+                        "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                        "type": "integer",
+                        "format": "int64"
+                      },
+                      "value": {
+                        "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "topologySpreadConstraints": {
+                  "description": "The k8s topologySpreadConstraints for the Pilot pods.",
+                  "type": "array",
+                  "items": {
+                    "description": "TopologySpreadConstraint specifies how to spread matching pods among the given topology.",
+                    "type": "object",
+                    "required": [
+                      "maxSkew",
+                      "topologyKey",
+                      "whenUnsatisfiable"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "description": "LabelSelector is used to find matching pods.\nPods that match this label selector are counted to determine the number of pods\nin their corresponding topology domain.",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "matchLabelKeys": {
+                        "description": "MatchLabelKeys is a set of pod label keys to select the pods over which\nspreading will be calculated. The keys are used to lookup values from the\nincoming pod labels, those key-value labels are ANDed with labelSelector\nto select the group of existing pods over which spreading will be calculated\nfor the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.\nMatchLabelKeys cannot be set when LabelSelector isn't set.\nKeys that don't exist in the incoming pod labels will\nbe ignored. A null or empty list means only match against labelSelector.\n\nThis is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).",
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "maxSkew": {
+                        "description": "MaxSkew describes the degree to which pods may be unevenly distributed.\nWhen `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference\nbetween the number of matching pods in the target topology and the global minimum.\nThe global minimum is the minimum number of matching pods in an eligible domain\nor zero if the number of eligible domains is less than MinDomains.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 2/2/1:\nIn this case, the global minimum is 1.\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |   P   |\n- if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;\nscheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)\nviolate MaxSkew(1).\n- if MaxSkew is 2, incoming pod can be scheduled onto any zone.\nWhen `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence\nto topologies that satisfy it.\nIt's a required field. Default value is 1 and 0 is not allowed.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "minDomains": {
+                        "description": "MinDomains indicates a minimum number of eligible domains.\nWhen the number of eligible domains with matching topology keys is less than minDomains,\nPod Topology Spread treats \"global minimum\" as 0, and then the calculation of Skew is performed.\nAnd when the number of eligible domains with matching topology keys equals or greater than minDomains,\nthis value has no effect on scheduling.\nAs a result, when the number of eligible domains is less than minDomains,\nscheduler won't schedule more than maxSkew Pods to those domains.\nIf value is nil, the constraint behaves as if MinDomains is equal to 1.\nValid values are integers greater than 0.\nWhen value is not nil, WhenUnsatisfiable must be DoNotSchedule.\n\nFor example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same\nlabelSelector spread as 2/2/2:\n| zone1 | zone2 | zone3 |\n|  P P  |  P P  |  P P  |\nThe number of domains is less than 5(MinDomains), so \"global minimum\" is treated as 0.\nIn this situation, new pod with the same labelSelector cannot be scheduled,\nbecause computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,\nit will violate MaxSkew.",
+                        "type": "integer",
+                        "format": "int32"
+                      },
+                      "nodeAffinityPolicy": {
+                        "description": "NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector\nwhen calculating pod topology spread skew. Options are:\n- Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.\n- Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.\n\nIf this value is nil, the behavior is equivalent to the Honor policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                        "type": "string"
+                      },
+                      "nodeTaintsPolicy": {
+                        "description": "NodeTaintsPolicy indicates how we will treat node taints when calculating\npod topology spread skew. Options are:\n- Honor: nodes without taints, along with tainted nodes for which the incoming pod\nhas a toleration, are included.\n- Ignore: node taints are ignored. All nodes are included.\n\nIf this value is nil, the behavior is equivalent to the Ignore policy.\nThis is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.",
+                        "type": "string"
+                      },
+                      "topologyKey": {
+                        "description": "TopologyKey is the key of node labels. Nodes that have a label with this key\nand identical values are considered to be in the same topology.\nWe consider each <key, value> as a \"bucket\", and try to put balanced number\nof pods into each bucket.\nWe define a domain as a particular instance of a topology.\nAlso, we define an eligible domain as a domain whose nodes meet the requirements of\nnodeAffinityPolicy and nodeTaintsPolicy.\ne.g. If TopologyKey is \"kubernetes.io/hostname\", each Node is a domain of that topology.\nAnd, if TopologyKey is \"topology.kubernetes.io/zone\", each zone is a domain of that topology.\nIt's a required field.",
+                        "type": "string"
+                      },
+                      "whenUnsatisfiable": {
+                        "description": "WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy\nthe spread constraint.\n- DoNotSchedule (default) tells the scheduler not to schedule it.\n- ScheduleAnyway tells the scheduler to schedule the pod in any location,\n  but giving higher precedence to topologies that would help reduce the\n  skew.\nA constraint is considered \"Unsatisfiable\" for an incoming pod\nif and only if every possible node assignment for that pod would violate\n\"MaxSkew\" on some topology.\nFor example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same\nlabelSelector spread as 3/1/1:\n| zone1 | zone2 | zone3 |\n| P P P |   P   |   P   |\nIf WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled\nto zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies\nMaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler\nwon't make it *more* imbalanced.\nIt's a required field.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "traceSampling": {
+                  "description": "Trace sampling fraction.\n\nUsed to set the fraction of time that traces are sampled. Higher values are more accurate but add CPU overhead.\n\nAllowed values: 0.0 to 1.0",
+                  "type": "number"
+                },
+                "trustedZtunnelNamespace": {
+                  "description": "If set, `istiod` will allow connections from trusted node proxy ztunnels\nin the provided namespace.",
+                  "type": "string"
+                },
+                "variant": {
+                  "description": "The container image variant to pull. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                },
+                "volumeMounts": {
+                  "description": "Additional volumeMounts to add to the Pilot container.",
+                  "type": "array",
+                  "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                    "type": "object",
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "properties": {
+                      "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "This must match the Name of a Volume.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "recursiveReadOnly": {
+                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                        "type": "string"
+                      },
+                      "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "volumes": {
+                  "description": "Additional volumes to add to the Pilot Pod.",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "azureDisk": {
+                        "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "properties": {
+                          "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "azureFile": {
+                        "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "properties": {
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "description": "shareName is the azure share Name",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cephfs": {
+                        "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "monitors"
+                        ],
+                        "properties": {
+                          "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cinder": {
+                        "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "csi": {
+                        "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "downwardAPI": {
+                        "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "Items is a list of downward API volume file",
+                            "type": "array",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                  "type": "object",
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                  "type": "object",
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "emptyDir": {
+                        "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "object",
+                        "properties": {
+                          "medium": {
+                            "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      },
+                      "ephemeral": {
+                        "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                        "type": "object",
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                            "type": "object",
+                            "required": [
+                              "spec"
+                            ],
+                            "properties": {
+                              "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                "type": "object"
+                              },
+                              "spec": {
+                                "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                "type": "object",
+                                "properties": {
+                                  "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "dataSource": {
+                                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "dataSourceRef": {
+                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                    "type": "object",
+                                    "properties": {
+                                      "limits": {
+                                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      },
+                                      "requests": {
+                                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "selector": {
+                                    "description": "selector is a label query over volumes to consider for binding.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
+                                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "fc": {
+                        "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun is Optional: FC target lun number",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "flexVolume": {
+                        "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                            "type": "string"
+                          },
+                          "options": {
+                            "description": "options is Optional: this field holds extra command options if any.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "flocker": {
+                        "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                        "type": "object",
+                        "properties": {
+                          "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "gcePersistentDisk": {
+                        "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "object",
+                        "required": [
+                          "pdName"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "gitRepo": {
+                        "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                        "type": "object",
+                        "required": [
+                          "repository"
+                        ],
+                        "properties": {
+                          "directory": {
+                            "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                            "type": "string"
+                          },
+                          "repository": {
+                            "description": "repository is the URL",
+                            "type": "string"
+                          },
+                          "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "glusterfs": {
+                        "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                        "type": "object",
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "properties": {
+                          "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "hostPath": {
+                        "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "object",
+                        "required": [
+                          "path"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                        "type": "object",
+                        "properties": {
+                          "pullPolicy": {
+                            "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                            "type": "string"
+                          },
+                          "reference": {
+                            "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "iscsi": {
+                        "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+                        "type": "object",
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "object",
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "object",
+                        "required": [
+                          "claimName"
+                        ],
+                        "properties": {
+                          "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "photonPersistentDisk": {
+                        "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "pdID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "portworxVolume": {
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                            "type": "array",
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                              "type": "object",
+                              "properties": {
+                                "clusterTrustBundle": {
+                                  "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "type": "object",
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "description": "Relative path from the volume root to write the bundle.",
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "configMap": {
+                                  "description": "configMap information about the configMap data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "secret": {
+                                  "description": "secret information about the secret data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "quobyte": {
+                        "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "properties": {
+                          "group": {
+                            "description": "group to map volume access to\nDefault is no group",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                            "type": "string"
+                          },
+                          "user": {
+                            "description": "user to map volume access to\nDefaults to serivceaccount user",
+                            "type": "string"
+                          },
+                          "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "rbd": {
+                        "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+                        "type": "object",
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                            "type": "string"
+                          },
+                          "image": {
+                            "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "pool": {
+                            "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "scaleIO": {
+                        "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                            "type": "string"
+                          },
+                          "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "secret": {
+                        "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "storageos": {
+                        "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "vsphereVolume": {
+                        "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "volumePath"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "profile": {
+              "description": "Specifies which installation configuration profile to apply.",
+              "type": "string"
+            },
+            "revision": {
+              "description": "Identifies the revision this installation is associated with.",
+              "type": "string"
+            },
+            "sidecarInjectorWebhook": {
+              "description": "Configuration for the sidecar injector webhook.",
+              "type": "object",
+              "properties": {
+                "alwaysInjectSelector": {
+                  "description": "See NeverInjectSelector.",
+                  "type": "array",
+                  "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "type": "array",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                },
+                "defaultTemplates": {
+                  "description": "defaultTemplates: [\"sidecar\", \"hello\"]",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "enableNamespacesByDefault": {
+                  "description": "Enables sidecar auto-injection in namespaces by default.",
+                  "type": "boolean"
+                },
+                "injectedAnnotations": {
+                  "description": "injectedAnnotations are additional annotations that will be added to the pod spec after injection\nThis is primarily to support PSP annotations.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "injectionURL": {
+                  "description": "Configure the injection url for sidecar injector webhook",
+                  "type": "string"
+                },
+                "neverInjectSelector": {
+                  "description": "Instructs Istio to not inject the sidecar on those pods, based on labels that are present in those pods.\n\nAnnotations in the pods have higher precedence than the label selectors.\nOrder of evaluation: Pod Annotations \u2192 NeverInjectSelector \u2192 AlwaysInjectSelector \u2192 Default Policy.\nSee https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#more-control-adding-exceptions",
+                  "type": "array",
+                  "items": {
+                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                    "type": "object",
+                    "properties": {
+                      "matchExpressions": {
+                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                        "type": "array",
+                        "items": {
+                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                          "type": "object",
+                          "required": [
+                            "key",
+                            "operator"
+                          ],
+                          "properties": {
+                            "key": {
+                              "description": "key is the label key that the selector applies to.",
+                              "type": "string"
+                            },
+                            "operator": {
+                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                              "type": "string"
+                            },
+                            "values": {
+                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        },
+                        "x-kubernetes-list-type": "atomic"
+                      },
+                      "matchLabels": {
+                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "x-kubernetes-map-type": "atomic"
+                  }
+                },
+                "reinvocationPolicy": {
+                  "description": "Setting this to `IfNeeded` will result in the sidecar injector being run again if additional mutations occur. Default: Never",
+                  "type": "string"
+                },
+                "rewriteAppHTTPProbe": {
+                  "description": "If true, webhook or istioctl injector will rewrite PodSpec for liveness health check to redirect request to sidecar. This makes liveness check work even when mTLS is enabled.",
+                  "type": "boolean"
+                },
+                "templates": {
+                  "description": "Templates defines a set of custom injection templates that can be used. For example, defining:\n\ntemplates:\n\n\thello: |\n\t  metadata:\n\t    labels:\n\t      hello: world\n\nThen starting a pod with the `inject.istio.io/templates: hello` annotation, will result in the pod\nbeing injected with the hello=world labels.\nThis is intended for advanced configuration only; most users should use the built in template",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "telemetry": {
+              "description": "Controls whether telemetry is exported for Pilot.",
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Controls whether telemetry is exported for Pilot.",
+                  "type": "boolean"
+                },
+                "v2": {
+                  "description": "Configuration for Telemetry v2.",
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "description": "Controls whether pilot will configure telemetry v2.",
+                      "type": "boolean"
+                    },
+                    "prometheus": {
+                      "description": "Telemetry v2 settings for prometheus.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "description": "Controls whether stats envoyfilter would be enabled or not.",
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "stackdriver": {
+                      "description": "Telemetry v2 settings for stackdriver.",
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "version": {
+          "description": "Defines the version of Istio to install.\nMust be one of: v1.24.4, v1.24.3.",
+          "type": "string",
+          "enum": [
+            "v1.24.4",
+            "v1.24.3"
+          ]
+        }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "spec.values.global.istioNamespace must match spec.namespace",
+          "rule": "self.values.global.istioNamespace == self.__namespace__"
+        }
+      ]
+    },
+    "status": {
+      "description": "IstioRevisionStatus defines the observed state of IstioRevision",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of the object's current state.",
+          "type": "array",
+          "items": {
+            "description": "IstioRevisionCondition represents a specific observation of the IstioRevision object's state.",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Human-readable message indicating details about the last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Unique, single-word, CamelCase reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of this condition. Can be True, False or Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of this condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the most recent generation observed for this\nIstioRevision object. It corresponds to the object's generation, which is\nupdated on mutation by the API Server. The information in the status\npertains to this particular generation of the object.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "state": {
+          "description": "Reports the current state of the object.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "IstioRevision",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "x-kubernetes-validations": [
+    {
+      "message": "spec.values.revision must match metadata.name",
+      "rule": "self.metadata.name == 'default' ? (!has(self.spec.values.revision) || size(self.spec.values.revision) == 0) : self.spec.values.revision == self.metadata.name"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/istiorevisionlist.json
+++ b/class_generator/schema/istiorevisionlist.json
@@ -1,0 +1,37 @@
+{
+  "description": "IstioRevisionList is a list of IstioRevision",
+  "type": "object",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "items": {
+      "description": "List of istiorevisions. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": "array",
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioRevision"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "IstioRevisionList",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/istiorevisiontag.json
+++ b/class_generator/schema/istiorevisiontag.json
@@ -1,0 +1,116 @@
+{
+  "description": "IstioRevisionTag references an Istio or IstioRevision object and serves as an alias for sidecar injection. It can be used to manage stable revision tags without having to use istioctl or helm directly. See https://istio.io/latest/docs/setup/upgrade/canary/#stable-revision-labels for more information on the concept.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
+    "spec": {
+      "description": "IstioRevisionTagSpec defines the desired state of IstioRevisionTag",
+      "type": "object",
+      "required": [
+        "targetRef"
+      ],
+      "properties": {
+        "targetRef": {
+          "description": "IstioRevisionTagTargetReference can reference either Istio or IstioRevision objects in the cluster. In the case of referencing an Istio object, the Sail Operator will automatically update the reference to the Istio object's Active Revision.",
+          "type": "object",
+          "required": [
+            "kind",
+            "name"
+          ],
+          "properties": {
+            "kind": {
+              "description": "Kind is the kind of the target resource.",
+              "type": "string",
+              "maxLength": 253,
+              "minLength": 1
+            },
+            "name": {
+              "description": "Name is the name of the target resource.",
+              "type": "string",
+              "maxLength": 253,
+              "minLength": 1
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "description": "IstioRevisionStatus defines the observed state of IstioRevision",
+      "type": "object",
+      "required": [
+        "istioRevision",
+        "istiodNamespace"
+      ],
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of the object's current state.",
+          "type": "array",
+          "items": {
+            "description": "IstioRevisionCondition represents a specific observation of the IstioRevision object's state.",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Human-readable message indicating details about the last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Unique, single-word, CamelCase reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of this condition. Can be True, False or Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of this condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "istioRevision": {
+          "description": "IstioRevision stores the name of the referenced IstioRevision",
+          "type": "string"
+        },
+        "istiodNamespace": {
+          "description": "IstiodNamespace stores the namespace of the corresponding Istiod instance",
+          "type": "string"
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the most recent generation observed for this\nIstioRevisionTag object. It corresponds to the object's generation, which is\nupdated on mutation by the API Server. The information in the status\npertains to this particular generation of the object.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "state": {
+          "description": "Reports the current state of the object.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "IstioRevisionTag",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/istiorevisiontaglist.json
+++ b/class_generator/schema/istiorevisiontaglist.json
@@ -1,0 +1,37 @@
+{
+  "description": "IstioRevisionTagList is a list of IstioRevisionTag",
+  "type": "object",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "items": {
+      "description": "List of istiorevisiontags. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": "array",
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.sailoperator.v1.IstioRevisionTag"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "IstioRevisionTagList",
+      "version": "v1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/kserve.json
+++ b/class_generator/schema/kserve.json
@@ -21,7 +21,6 @@
         "defaultDeploymentMode": {
           "description": "Configures the default deployment mode for Kserve. This can be set to 'Serverless' or 'RawDeployment'.\nThe value specified in this field will be used to set the default deployment mode in the 'inferenceservice-config' configmap for Kserve.\nThis field is optional. If no default deployment mode is specified, Kserve will use Serverless mode.",
           "type": "string",
-          "pattern": "^(Serverless|RawDeployment)$",
           "enum": [
             "Serverless",
             "RawDeployment"
@@ -69,9 +68,8 @@
           }
         },
         "rawDeploymentServiceConfig": {
-          "description": "Configures the type of service that is created for InferenceServices using RawDeployment.\nThe values for RawDeploymentServiceConfig can be \"Headless\" or \"Headed\".\nHeadless : sets \"ServiceClusterIPNone = true\" in the 'inferenceservice-config' configmap for Kserve.\nHeaded : sets \"ServiceClusterIPNone = false\" in the 'inferenceservice-config' configmap for Kserve.",
+          "description": "Configures the type of service that is created for InferenceServices using RawDeployment.\nThe values for RawDeploymentServiceConfig can be \"Headless\" (default value) or \"Headed\".\nHeadless: to set \"ServiceClusterIPNone = true\" in the 'inferenceservice-config' configmap for Kserve.\nHeaded: to set \"ServiceClusterIPNone = false\" in the 'inferenceservice-config' configmap for Kserve.",
           "type": "string",
-          "pattern": "^(Headless|Headed)$",
           "enum": [
             "Headless",
             "Headed"

--- a/class_generator/schema/lmevaljob.json
+++ b/class_generator/schema/lmevaljob.json
@@ -34,6 +34,21 @@
           "description": "Batch size for the evaluation. This is used by the models that run and are loaded\nlocally and not apply for the commercial APIs.",
           "type": "string"
         },
+        "chatTemplate": {
+          "description": "ChatTemplate defines whether to apply the default or specified chat template to prompts. This is required for chat-completions models.",
+          "type": "object",
+          "required": [
+            "enabled"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            }
+          }
+        },
         "genArgs": {
           "description": "Map to `--gen_kwargs` parameter for the underlying library.",
           "type": "array",
@@ -3882,6 +3897,10 @@
           "description": "Suspend keeps the job but without pods. This is intended to be used by the Kueue integration",
           "type": "boolean"
         },
+        "systemInstruction": {
+          "description": "SystemInstruction will set the system instruction for all prompts passed to the evaluated model",
+          "type": "string"
+        },
         "taskList": {
           "description": "Evaluation task list",
           "type": "object",
@@ -3890,7 +3909,50 @@
               "description": "Custom Unitxt artifacts that can be used in a TaskRecipe",
               "type": "object",
               "properties": {
+                "metrics": {
+                  "description": "The Unitxt custom metrics",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the custom artifact",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of the custom artifact. It could be a JSON string or plain text\ndepending on the artifact type",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
                 "systemPrompts": {
+                  "description": "The Unitxt custom System Prompts",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "name",
+                      "value"
+                    ],
+                    "properties": {
+                      "name": {
+                        "description": "Name of the custom artifact",
+                        "type": "string"
+                      },
+                      "value": {
+                        "description": "Value of the custom artifact. It could be a JSON string or plain text\ndepending on the artifact type",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "tasks": {
+                  "description": "The Unitxt custom tasks",
                   "type": "array",
                   "items": {
                     "type": "object",
@@ -3911,6 +3973,7 @@
                   }
                 },
                 "templates": {
+                  "description": "The Unitxt custom templates",
                   "type": "array",
                   "items": {
                     "type": "object",
@@ -4013,7 +4076,17 @@
                     "description": "Metrics",
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "description": "Unitxt metric id",
+                          "type": "string"
+                        },
+                        "ref": {
+                          "description": "The name of the custom metric in the custom field. Its value is a JSON string\nfor a custom Unitxt metric. Use the documentation here: https://www.unitxt.ai/en/latest/docs/adding_metric.html#adding-a-new-instance-metric\nto compose a custom metric, store it as a JSON file by calling the\nadd_to_catalog API: https://www.unitxt.ai/en/latest/docs/saving_and_loading_from_catalog.html#adding-assets-to-the-catalog,\nand use the JSON content as the value here.",
+                          "type": "string"
+                        }
+                      }
                     }
                   },
                   "numDemos": {
@@ -4036,7 +4109,17 @@
                   },
                   "task": {
                     "description": "The Unitxt Task",
-                    "type": "string"
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "Unitxt task id",
+                        "type": "string"
+                      },
+                      "ref": {
+                        "description": "The name of the custom task in the custom field. Its value is a JSON string\nfor a custom Unitxt task. Use the documentation here: https://www.unitxt.ai/en/latest/docs/adding_task.html\nto compose a custom task, store it as a JSON file by calling the\nadd_to_catalog API: https://www.unitxt.ai/en/latest/docs/saving_and_loading_from_catalog.html#adding-assets-to-the-catalog,\nand use the JSON content as the value here.",
+                        "type": "string"
+                      }
+                    }
                   },
                   "template": {
                     "description": "The Unitxt template",

--- a/class_generator/schema/manualapprovalgate.json
+++ b/class_generator/schema/manualapprovalgate.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/manualapprovalgatelist.json
+++ b/class_generator/schema/manualapprovalgatelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/mariadb.json
+++ b/class_generator/schema/mariadb.json
@@ -29,6 +29,167 @@
               "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
               "type": "boolean"
             },
+            "nodeAffinity": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+              "type": "object",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                    "type": "object",
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "properties": {
+                      "preference": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "weight": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                  "type": "object",
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "type": "array",
+                      "items": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                }
+              }
+            },
             "podAntiAffinity": {
               "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
               "type": "object",
@@ -51,14 +212,13 @@
                         ],
                         "properties": {
                           "labelSelector": {
-                            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                             "type": "object",
                             "properties": {
                               "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "type": "array",
                                 "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                   "type": "object",
                                   "required": [
                                     "key",
@@ -66,15 +226,13 @@
                                   ],
                                   "properties": {
                                     "key": {
-                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                       "type": "string"
                                     },
                                     "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -86,14 +244,12 @@
                                 "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object",
                                 "additionalProperties": {
                                   "type": "string"
                                 }
                               }
-                            },
-                            "x-kubernetes-map-type": "atomic"
+                            }
                           },
                           "topologyKey": {
                             "type": "string"
@@ -118,14 +274,13 @@
                     ],
                     "properties": {
                       "labelSelector": {
-                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                         "type": "object",
                         "properties": {
                           "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                             "type": "array",
                             "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                               "type": "object",
                               "required": [
                                 "key",
@@ -133,15 +288,13 @@
                               ],
                               "properties": {
                                 "key": {
-                                  "description": "key is the label key that the selector applies to.",
                                   "type": "string"
                                 },
                                 "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                   "type": "string"
                                 },
                                 "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
@@ -153,14 +306,12 @@
                             "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object",
                             "additionalProperties": {
                               "type": "string"
                             }
                           }
-                        },
-                        "x-kubernetes-map-type": "atomic"
+                        }
                       },
                       "topologyKey": {
                         "type": "string"
@@ -205,6 +356,167 @@
                       "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
                       "type": "boolean"
                     },
+                    "nodeAffinity": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "type": "array",
+                          "items": {
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                            "type": "object",
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                          "type": "object",
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "type": "array",
+                              "items": {
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "podAntiAffinity": {
                       "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
                       "type": "object",
@@ -227,14 +539,13 @@
                                 ],
                                 "properties": {
                                   "labelSelector": {
-                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                     "type": "object",
                                     "properties": {
                                       "matchExpressions": {
-                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "type": "array",
                                         "items": {
-                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                           "type": "object",
                                           "required": [
                                             "key",
@@ -242,15 +553,13 @@
                                           ],
                                           "properties": {
                                             "key": {
-                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
-                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                               "type": "string"
                                             },
                                             "values": {
-                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -262,14 +571,12 @@
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
-                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object",
                                         "additionalProperties": {
                                           "type": "string"
                                         }
                                       }
-                                    },
-                                    "x-kubernetes-map-type": "atomic"
+                                    }
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -294,14 +601,13 @@
                             ],
                             "properties": {
                               "labelSelector": {
-                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                 "type": "object",
                                 "properties": {
                                   "matchExpressions": {
-                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "type": "array",
                                     "items": {
-                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                       "type": "object",
                                       "required": [
                                         "key",
@@ -309,15 +615,13 @@
                                       ],
                                       "properties": {
                                         "key": {
-                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
-                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                           "type": "string"
                                         },
                                         "values": {
-                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -329,14 +633,12 @@
                                     "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
-                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
                                     }
                                   }
-                                },
-                                "x-kubernetes-map-type": "atomic"
+                                }
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -404,10 +706,8 @@
               "description": "S3 defines the configuration to restore backups from a S3 compatible storage. It has priority over Volume.",
               "type": "object",
               "required": [
-                "accessKeyIdSecretKeyRef",
                 "bucket",
-                "endpoint",
-                "secretAccessKeySecretKeyRef"
+                "endpoint"
               ],
               "properties": {
                 "accessKeyIdSecretKeyRef": {
@@ -502,6 +802,182 @@
                 }
               }
             },
+            "stagingStorage": {
+              "description": "StagingStorage defines the temporary storage used to keep external backups (i.e. S3) while they are being processed.\nIt defaults to an emptyDir volume, meaning that the backups will be temporarily stored in the node where the Restore Job is scheduled.",
+              "type": "object",
+              "properties": {
+                "persistentVolumeClaim": {
+                  "description": "PersistentVolumeClaim is a Kubernetes PVC specification.",
+                  "type": "object",
+                  "properties": {
+                    "accessModes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "resources": {
+                      "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+                      "type": "object",
+                      "properties": {
+                        "limits": {
+                          "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
+                    },
+                    "selector": {
+                      "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                      "type": "object",
+                      "properties": {
+                        "matchExpressions": {
+                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                          "type": "array",
+                          "items": {
+                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                            "type": "object",
+                            "required": [
+                              "key",
+                              "operator"
+                            ],
+                            "properties": {
+                              "key": {
+                                "description": "key is the label key that the selector applies to.",
+                                "type": "string"
+                              },
+                              "operator": {
+                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                "type": "string"
+                              },
+                              "values": {
+                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "matchLabels": {
+                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-map-type": "atomic"
+                    },
+                    "storageClassName": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "volume": {
+                  "description": "Volume is a Kubernetes volume specification.",
+                  "type": "object",
+                  "properties": {
+                    "csi": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#csivolumesource-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "driver"
+                      ],
+                      "properties": {
+                        "driver": {
+                          "type": "string"
+                        },
+                        "fsType": {
+                          "type": "string"
+                        },
+                        "nodePublishSecretRef": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "volumeAttributes": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "emptyDir": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#emptydirvolumesource-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "medium": {
+                          "description": "StorageMedium defines ways that storage can be allocated to a volume.",
+                          "type": "string"
+                        },
+                        "sizeLimit": {
+                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
+                    },
+                    "nfs": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nfsvolumesource-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "path",
+                        "server"
+                      ],
+                      "properties": {
+                        "path": {
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "server": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "persistentVolumeClaim": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#persistentvolumeclaimvolumesource-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "claimName"
+                      ],
+                      "properties": {
+                        "claimName": {
+                          "type": "string"
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
             "targetRecoveryTime": {
               "description": "TargetRecoveryTime is a RFC3339 (1970-01-01T00:00:00Z) date and time that defines the point in time recovery objective.\nIt is used to determine the closest restoration source in time.",
               "type": "string",
@@ -512,37 +988,31 @@
               "type": "object",
               "properties": {
                 "csi": {
-                  "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#csivolumesource-v1-core.",
                   "type": "object",
                   "required": [
                     "driver"
                   ],
                   "properties": {
                     "driver": {
-                      "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
                       "type": "string"
                     },
                     "fsType": {
-                      "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
                       "type": "string"
                     },
                     "nodePublishSecretRef": {
-                      "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
                       "type": "object",
                       "properties": {
                         "name": {
-                          "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                           "type": "string"
                         }
-                      },
-                      "x-kubernetes-map-type": "atomic"
+                      }
                     },
                     "readOnly": {
-                      "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
                       "type": "boolean"
                     },
                     "volumeAttributes": {
-                      "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
                       "type": "object",
                       "additionalProperties": {
                         "type": "string"
@@ -551,22 +1021,21 @@
                   }
                 },
                 "emptyDir": {
-                  "description": "Represents an empty directory for a pod.\nEmpty directory volumes support ownership management and SELinux relabeling.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#emptydirvolumesource-v1-core.",
                   "type": "object",
                   "properties": {
                     "medium": {
-                      "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                      "description": "StorageMedium defines ways that storage can be allocated to a volume.",
                       "type": "string"
                     },
                     "sizeLimit": {
-                      "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                       "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                       "x-kubernetes-int-or-string": true
                     }
                   }
                 },
                 "nfs": {
-                  "description": "Represents an NFS mount that lasts the lifetime of a pod.\nNFS volumes do not support ownership management or SELinux relabeling.",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nfsvolumesource-v1-core.",
                   "type": "object",
                   "required": [
                     "path",
@@ -574,32 +1043,27 @@
                   ],
                   "properties": {
                     "path": {
-                      "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                       "type": "string"
                     },
                     "readOnly": {
-                      "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                       "type": "boolean"
                     },
                     "server": {
-                      "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                       "type": "string"
                     }
                   }
                 },
                 "persistentVolumeClaim": {
-                  "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace.\nThis volume finds the bound PV and mounts that volume for the pod. A\nPersistentVolumeClaimVolumeSource is, essentially, a wrapper around another\ntype of volume that is owned by someone else (the system).",
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#persistentvolumeclaimvolumesource-v1-core.",
                   "type": "object",
                   "required": [
                     "claimName"
                   ],
                   "properties": {
                     "claimName": {
-                      "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                       "type": "string"
                     },
                     "readOnly": {
-                      "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
                       "type": "boolean"
                     }
                   }
@@ -1065,6 +1529,21 @@
                       "type": "integer",
                       "format": "int32"
                     },
+                    "tcpSocket": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
+                    },
                     "timeoutSeconds": {
                       "type": "integer",
                       "format": "int32"
@@ -1072,7 +1551,12 @@
                   }
                 },
                 "port": {
-                  "description": "Port where the agent will be listening for connections.",
+                  "description": "Port where the agent will be listening for API connections.",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "probePort": {
+                  "description": "Port where the agent will be listening for probe connections.",
                   "type": "integer",
                   "format": "int32"
                 },
@@ -1130,6 +1614,21 @@
                     "successThreshold": {
                       "type": "integer",
                       "format": "int32"
+                    },
+                    "tcpSocket": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
                     },
                     "timeoutSeconds": {
                       "type": "integer",
@@ -1206,6 +1705,82 @@
                     "runAsUser": {
                       "type": "integer",
                       "format": "int64"
+                    }
+                  }
+                },
+                "startupProbe": {
+                  "description": "StartupProbe to be used in the Container.",
+                  "type": "object",
+                  "properties": {
+                    "exec": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#execaction-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "command": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    },
+                    "failureThreshold": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "httpGet": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#httpgetaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "initialDelaySeconds": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "periodSeconds": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "successThreshold": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "tcpSocket": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
+                    },
+                    "timeoutSeconds": {
+                      "type": "integer",
+                      "format": "int32"
                     }
                   }
                 },
@@ -1557,6 +2132,21 @@
                       "type": "integer",
                       "format": "int32"
                     },
+                    "tcpSocket": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
+                    },
                     "timeoutSeconds": {
                       "type": "integer",
                       "format": "int32"
@@ -1617,6 +2207,21 @@
                     "successThreshold": {
                       "type": "integer",
                       "format": "int32"
+                    },
+                    "tcpSocket": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
                     },
                     "timeoutSeconds": {
                       "type": "integer",
@@ -1693,6 +2298,82 @@
                     "runAsUser": {
                       "type": "integer",
                       "format": "int64"
+                    }
+                  }
+                },
+                "startupProbe": {
+                  "description": "StartupProbe to be used in the Container.",
+                  "type": "object",
+                  "properties": {
+                    "exec": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#execaction-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "command": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        }
+                      }
+                    },
+                    "failureThreshold": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "httpGet": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#httpgetaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "path": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        },
+                        "scheme": {
+                          "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "initialDelaySeconds": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "periodSeconds": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "successThreshold": {
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "tcpSocket": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+                      "type": "object",
+                      "required": [
+                        "port"
+                      ],
+                      "properties": {
+                        "host": {
+                          "type": "string"
+                        },
+                        "port": {
+                          "x-kubernetes-int-or-string": true
+                        }
+                      }
+                    },
+                    "timeoutSeconds": {
+                      "type": "integer",
+                      "format": "int32"
                     }
                   }
                 },
@@ -1977,6 +2658,80 @@
                   "type": "string"
                 }
               },
+              "env": {
+                "description": "Env represents the environment variables to be injected in a container.",
+                "type": "array",
+                "items": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvarsource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvarsource-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#configmapkeyselector-v1-core.",
+                          "type": "object",
+                          "required": [
+                            "key"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "fieldRef": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectfieldselector-v1-core.",
+                          "type": "object",
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "properties": {
+                            "apiVersion": {
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "secretKeyRef": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretkeyselector-v1-core.",
+                          "type": "object",
+                          "required": [
+                            "key"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
               "image": {
                 "description": "Image name to be used by the container. The supported format is `<image>:<tag>`.",
                 "type": "string"
@@ -2100,6 +2855,21 @@
             "successThreshold": {
               "type": "integer",
               "format": "int32"
+            },
+            "tcpSocket": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                }
+              }
             },
             "timeoutSeconds": {
               "type": "integer",
@@ -2685,6 +3455,167 @@
                           "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
                           "type": "boolean"
                         },
+                        "nodeAffinity": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+                          "type": "object",
+                          "properties": {
+                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                              "type": "array",
+                              "items": {
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                                "type": "object",
+                                "required": [
+                                  "preference",
+                                  "weight"
+                                ],
+                                "properties": {
+                                  "preference": {
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchFields": {
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    }
+                                  },
+                                  "weight": {
+                                    "type": "integer",
+                                    "format": "int32"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            },
+                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                              "type": "object",
+                              "required": [
+                                "nodeSelectorTerms"
+                              ],
+                              "properties": {
+                                "nodeSelectorTerms": {
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchFields": {
+                                        "type": "array",
+                                        "items": {
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            }
+                          }
+                        },
                         "podAntiAffinity": {
                           "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
                           "type": "object",
@@ -2707,14 +3638,13 @@
                                     ],
                                     "properties": {
                                       "labelSelector": {
-                                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                         "type": "object",
                                         "properties": {
                                           "matchExpressions": {
-                                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                             "type": "array",
                                             "items": {
-                                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                               "type": "object",
                                               "required": [
                                                 "key",
@@ -2722,15 +3652,13 @@
                                               ],
                                               "properties": {
                                                 "key": {
-                                                  "description": "key is the label key that the selector applies to.",
                                                   "type": "string"
                                                 },
                                                 "operator": {
-                                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                  "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                                   "type": "string"
                                                 },
                                                 "values": {
-                                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                                   "type": "array",
                                                   "items": {
                                                     "type": "string"
@@ -2742,14 +3670,12 @@
                                             "x-kubernetes-list-type": "atomic"
                                           },
                                           "matchLabels": {
-                                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                             "type": "object",
                                             "additionalProperties": {
                                               "type": "string"
                                             }
                                           }
-                                        },
-                                        "x-kubernetes-map-type": "atomic"
+                                        }
                                       },
                                       "topologyKey": {
                                         "type": "string"
@@ -2774,14 +3700,13 @@
                                 ],
                                 "properties": {
                                   "labelSelector": {
-                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                     "type": "object",
                                     "properties": {
                                       "matchExpressions": {
-                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "type": "array",
                                         "items": {
-                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                           "type": "object",
                                           "required": [
                                             "key",
@@ -2789,15 +3714,13 @@
                                           ],
                                           "properties": {
                                             "key": {
-                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
-                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                               "type": "string"
                                             },
                                             "values": {
-                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -2809,14 +3732,12 @@
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
-                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object",
                                         "additionalProperties": {
                                           "type": "string"
                                         }
                                       }
-                                    },
-                                    "x-kubernetes-map-type": "atomic"
+                                    }
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -3240,6 +4161,124 @@
                 }
               }
             },
+            "tls": {
+              "description": "TLS defines the PKI to be used with MaxScale.",
+              "type": "object",
+              "properties": {
+                "adminCASecretRef": {
+                  "description": "AdminCASecretRef is a reference to a Secret containing the admin certificate authority keypair. It is used to establish trust and issue certificates for the MaxScale's administrative REST API and GUI.\nOne of:\n- Secret containing both the 'ca.crt' and 'ca.key' keys. This allows you to bring your own CA to Kubernetes to issue certificates.\n- Secret containing only the 'ca.crt' in order to establish trust. In this case, either adminCertSecretRef or adminCertIssuerRef fields must be provided.\nIf not provided, a self-signed CA will be provisioned to issue the server certificate.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "adminCertIssuerRef": {
+                  "description": "AdminCertIssuerRef is a reference to a cert-manager issuer object used to issue the MaxScale's administrative REST API and GUI certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with adminCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via adminCASecretRef.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "group": {
+                      "description": "Group of the resource being referred to.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource being referred to.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource being referred to.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "adminCertSecretRef": {
+                  "description": "AdminCertSecretRef is a reference to a TLS Secret used by the MaxScale's administrative REST API and GUI.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "enabled": {
+                  "description": "Enabled indicates whether TLS is enabled, determining if certificates should be issued and mounted to the MaxScale instance.\nIt is enabled by default when the referred MariaDB instance (via mariaDbRef) has TLS enabled and enforced.",
+                  "type": "boolean"
+                },
+                "listenerCASecretRef": {
+                  "description": "ListenerCASecretRef is a reference to a Secret containing the listener certificate authority keypair. It is used to establish trust and issue certificates for the MaxScale's listeners.\nOne of:\n- Secret containing both the 'ca.crt' and 'ca.key' keys. This allows you to bring your own CA to Kubernetes to issue certificates.\n- Secret containing only the 'ca.crt' in order to establish trust. In this case, either listenerCertSecretRef or listenerCertIssuerRef fields must be provided.\nIf not provided, a self-signed CA will be provisioned to issue the listener certificate.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "listenerCertIssuerRef": {
+                  "description": "ListenerCertIssuerRef is a reference to a cert-manager issuer object used to issue the MaxScale's listeners certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with listenerCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via listenerCASecretRef.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "group": {
+                      "description": "Group of the resource being referred to.",
+                      "type": "string"
+                    },
+                    "kind": {
+                      "description": "Kind of the resource being referred to.",
+                      "type": "string"
+                    },
+                    "name": {
+                      "description": "Name of the resource being referred to.",
+                      "type": "string"
+                    }
+                  }
+                },
+                "listenerCertSecretRef": {
+                  "description": "ListenerCertSecretRef is a reference to a TLS Secret used by the MaxScale's listeners.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "replicationSSLEnabled": {
+                  "description": "ReplicationSSLEnabled specifies whether the replication SSL is enabled. If enabled, the SSL options will be added to the server configuration.\nIt is enabled by default when the referred MariaDB instance (via mariaDbRef) has replication enabled.\nIf the MariaDB servers are manually provided by the user via the 'servers' field, this must be set by the user as well.",
+                  "type": "boolean"
+                },
+                "serverCASecretRef": {
+                  "description": "ServerCASecretRef is a reference to a Secret containing the MariaDB server CA certificates. It is used to establish trust with MariaDB servers.\nThe Secret should contain a 'ca.crt' key in order to establish trust.\nIf not provided, and the reference to a MariaDB resource is set (mariaDbRef), it will be defaulted to the referred MariaDB CA bundle.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "serverCertSecretRef": {
+                  "description": "ServerCertSecretRef is a reference to a TLS Secret used by MaxScale to connect to the MariaDB servers.\nIf not provided, and the reference to a MariaDB resource is set (mariaDbRef), it will be defaulted to the referred MariaDB client certificate (clientCertSecretRef).",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "verifyPeerCertificate": {
+                  "description": "VerifyPeerCertificate specifies whether the peer certificate's signature should be validated against the CA.\nIt is disabled by default.",
+                  "type": "boolean"
+                },
+                "verifyPeerHost": {
+                  "description": "VerifyPeerHost specifies whether the peer certificate's SANs should match the peer host.\nIt is disabled by default.",
+                  "type": "boolean"
+                }
+              }
+            },
             "updateStrategy": {
               "description": "UpdateStrategy defines the update strategy for the StatefulSet object.",
               "type": "object",
@@ -3299,6 +4338,167 @@
                       "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
                       "type": "boolean"
                     },
+                    "nodeAffinity": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "type": "array",
+                          "items": {
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                            "type": "object",
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                          "type": "object",
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "type": "array",
+                              "items": {
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "podAntiAffinity": {
                       "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
                       "type": "object",
@@ -3321,14 +4521,13 @@
                                 ],
                                 "properties": {
                                   "labelSelector": {
-                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                     "type": "object",
                                     "properties": {
                                       "matchExpressions": {
-                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "type": "array",
                                         "items": {
-                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                           "type": "object",
                                           "required": [
                                             "key",
@@ -3336,15 +4535,13 @@
                                           ],
                                           "properties": {
                                             "key": {
-                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
-                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                               "type": "string"
                                             },
                                             "values": {
-                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -3356,14 +4553,12 @@
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
-                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object",
                                         "additionalProperties": {
                                           "type": "string"
                                         }
                                       }
-                                    },
-                                    "x-kubernetes-map-type": "atomic"
+                                    }
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -3388,14 +4583,13 @@
                             ],
                             "properties": {
                               "labelSelector": {
-                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                 "type": "object",
                                 "properties": {
                                   "matchExpressions": {
-                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "type": "array",
                                     "items": {
-                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                       "type": "object",
                                       "required": [
                                         "key",
@@ -3403,15 +4597,13 @@
                                       ],
                                       "properties": {
                                         "key": {
-                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
-                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                           "type": "string"
                                         },
                                         "values": {
-                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -3423,14 +4615,12 @@
                                     "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
-                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
                                     }
                                   }
-                                },
-                                "x-kubernetes-map-type": "atomic"
+                                }
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -4187,6 +5377,21 @@
               "type": "integer",
               "format": "int32"
             },
+            "tcpSocket": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
             "timeoutSeconds": {
               "type": "integer",
               "format": "int32"
@@ -4643,6 +5848,80 @@
                   "type": "string"
                 }
               },
+              "env": {
+                "description": "Env represents the environment variables to be injected in a container.",
+                "type": "array",
+                "items": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvarsource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "description": "Name of the environment variable. Must be a C_IDENTIFIER.",
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    },
+                    "valueFrom": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#envvarsource-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "configMapKeyRef": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#configmapkeyselector-v1-core.",
+                          "type": "object",
+                          "required": [
+                            "key"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "fieldRef": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#objectfieldselector-v1-core.",
+                          "type": "object",
+                          "required": [
+                            "fieldPath"
+                          ],
+                          "properties": {
+                            "apiVersion": {
+                              "type": "string"
+                            },
+                            "fieldPath": {
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        },
+                        "secretKeyRef": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretkeyselector-v1-core.",
+                          "type": "object",
+                          "required": [
+                            "key"
+                          ],
+                          "properties": {
+                            "key": {
+                              "type": "string"
+                            },
+                            "name": {
+                              "type": "string"
+                            }
+                          },
+                          "x-kubernetes-map-type": "atomic"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
               "image": {
                 "description": "Image name to be used by the container. The supported format is `<image>:<tag>`.",
                 "type": "string"
@@ -4709,6 +5988,82 @@
                   }
                 }
               }
+            }
+          }
+        },
+        "startupProbe": {
+          "description": "StartupProbe to be used in the Container.",
+          "type": "object",
+          "properties": {
+            "exec": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#execaction-v1-core.",
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                }
+              }
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "httpGet": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#httpgetaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                  "type": "string"
+                }
+              }
+            },
+            "initialDelaySeconds": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "successThreshold": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "tcpSocket": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "format": "int32"
             }
           }
         },
@@ -4849,6 +6204,102 @@
         "timeZone": {
           "description": "TimeZone sets the default timezone. If not provided, it defaults to SYSTEM and the timezone data is not loaded.",
           "type": "string"
+        },
+        "tls": {
+          "description": "TLS defines the PKI to be used with MariaDB.",
+          "type": "object",
+          "properties": {
+            "clientCASecretRef": {
+              "description": "ClientCASecretRef is a reference to a Secret containing the client certificate authority keypair. It is used to establish trust and issue client certificates.\nOne of:\n- Secret containing both the 'ca.crt' and 'ca.key' keys. This allows you to bring your own CA to Kubernetes to issue certificates.\n- Secret containing only the 'ca.crt' in order to establish trust. In this case, either clientCertSecretRef or clientCertIssuerRef fields must be provided.\nIf not provided, a self-signed CA will be provisioned to issue the client certificate.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "clientCertIssuerRef": {
+              "description": "ClientCertIssuerRef is a reference to a cert-manager issuer object used to issue the client certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with clientCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via clientCASecretRef.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "group": {
+                  "description": "Group of the resource being referred to.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the resource being referred to.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to.",
+                  "type": "string"
+                }
+              }
+            },
+            "clientCertSecretRef": {
+              "description": "ClientCertSecretRef is a reference to a TLS Secret containing the client certificate.\nIt is mutually exclusive with clientCertIssuerRef.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "enabled": {
+              "description": "Enabled indicates whether TLS is enabled, determining if certificates should be issued and mounted to the MariaDB instance.\nIt is enabled by default.",
+              "type": "boolean"
+            },
+            "galeraSSTEnabled": {
+              "description": "GaleraSSTEnabled determines whether Galera SST connections should use TLS.\nIt disabled by default.",
+              "type": "boolean"
+            },
+            "required": {
+              "description": "Required specifies whether TLS must be enforced for all connections.\nUser TLS requirements take precedence over this.\nIt disabled by default.",
+              "type": "boolean"
+            },
+            "serverCASecretRef": {
+              "description": "ServerCASecretRef is a reference to a Secret containing the server certificate authority keypair. It is used to establish trust and issue server certificates.\nOne of:\n- Secret containing both the 'ca.crt' and 'ca.key' keys. This allows you to bring your own CA to Kubernetes to issue certificates.\n- Secret containing only the 'ca.crt' in order to establish trust. In this case, either serverCertSecretRef or serverCertIssuerRef must be provided.\nIf not provided, a self-signed CA will be provisioned to issue the server certificate.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "serverCertIssuerRef": {
+              "description": "ServerCertIssuerRef is a reference to a cert-manager issuer object used to issue the server certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with serverCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via serverCASecretRef.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "group": {
+                  "description": "Group of the resource being referred to.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the resource being referred to.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to.",
+                  "type": "string"
+                }
+              }
+            },
+            "serverCertSecretRef": {
+              "description": "ServerCertSecretRef is a reference to a TLS Secret containing the server certificate.\nIt is mutually exclusive with serverCertIssuerRef.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         },
         "tolerations": {
           "description": "Tolerations to be used in the Pod.",
@@ -5005,7 +6456,7 @@
           }
         },
         "username": {
-          "description": "Username is the initial username to be created by the operator once MariaDB is ready. It has all privileges on the initial database.\nThe initial User will have ALL PRIVILEGES in the initial Database.",
+          "description": "Username is the initial username to be created by the operator once MariaDB is ready.\nThe initial User will have ALL PRIVILEGES in the initial Database.",
           "type": "string"
         },
         "volumeMounts": {
@@ -5045,38 +6496,45 @@
               "name"
             ],
             "properties": {
+              "configMap": {
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#configmapvolumesource-v1-core.",
+                "type": "object",
+                "properties": {
+                  "defaultMode": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              },
               "csi": {
-                "description": "Represents a source location of a volume to mount, managed by an external CSI driver",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#csivolumesource-v1-core.",
                 "type": "object",
                 "required": [
                   "driver"
                 ],
                 "properties": {
                   "driver": {
-                    "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
                     "type": "string"
                   },
                   "fsType": {
-                    "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
                     "type": "string"
                   },
                   "nodePublishSecretRef": {
-                    "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
                     "type": "object",
                     "properties": {
                       "name": {
-                        "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
                         "type": "string"
                       }
-                    },
-                    "x-kubernetes-map-type": "atomic"
+                    }
                   },
                   "readOnly": {
-                    "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
                     "type": "boolean"
                   },
                   "volumeAttributes": {
-                    "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
                     "type": "object",
                     "additionalProperties": {
                       "type": "string"
@@ -5085,15 +6543,14 @@
                 }
               },
               "emptyDir": {
-                "description": "Represents an empty directory for a pod.\nEmpty directory volumes support ownership management and SELinux relabeling.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#emptydirvolumesource-v1-core.",
                 "type": "object",
                 "properties": {
                   "medium": {
-                    "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                    "description": "StorageMedium defines ways that storage can be allocated to a volume.",
                     "type": "string"
                   },
                   "sizeLimit": {
-                    "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
                     "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
                     "x-kubernetes-int-or-string": true
                   }
@@ -5103,7 +6560,7 @@
                 "type": "string"
               },
               "nfs": {
-                "description": "Represents an NFS mount that lasts the lifetime of a pod.\nNFS volumes do not support ownership management or SELinux relabeling.",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nfsvolumesource-v1-core.",
                 "type": "object",
                 "required": [
                   "path",
@@ -5111,33 +6568,41 @@
                 ],
                 "properties": {
                   "path": {
-                    "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                     "type": "boolean"
                   },
                   "server": {
-                    "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
                     "type": "string"
                   }
                 }
               },
               "persistentVolumeClaim": {
-                "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace.\nThis volume finds the bound PV and mounts that volume for the pod. A\nPersistentVolumeClaimVolumeSource is, essentially, a wrapper around another\ntype of volume that is owned by someone else (the system).",
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#persistentvolumeclaimvolumesource-v1-core.",
                 "type": "object",
                 "required": [
                   "claimName"
                 ],
                 "properties": {
                   "claimName": {
-                    "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
                     "type": "string"
                   },
                   "readOnly": {
-                    "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
                     "type": "boolean"
+                  }
+                }
+              },
+              "secret": {
+                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#secretvolumesource-v1-core.",
+                "type": "object",
+                "properties": {
+                  "defaultMode": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "secretName": {
+                    "type": "string"
                   }
                 }
               }
@@ -5219,6 +6684,10 @@
           "description": "CurrentPrimaryPodIndex is the primary Pod index.",
           "type": "integer"
         },
+        "defaultVersion": {
+          "description": "DefaultVersion is the MariaDB version used by the operator when it cannot infer the version\nfrom spec.image. This can happen if the image uses a digest (e.g. sha256) instead\nof a version tag.",
+          "type": "string"
+        },
         "galeraRecovery": {
           "description": "GaleraRecovery is the Galera recovery current state.",
           "type": "object",
@@ -5299,6 +6768,100 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "tls": {
+          "description": "TLS aggregates the status of the certificates used by the MariaDB instance.",
+          "type": "object",
+          "properties": {
+            "caBundle": {
+              "description": "CABundle is the status of the Certificate Authority bundle.",
+              "type": "array",
+              "items": {
+                "description": "CertificateStatus represents the current status of a TLS certificate.",
+                "type": "object",
+                "required": [
+                  "issuer",
+                  "subject"
+                ],
+                "properties": {
+                  "issuer": {
+                    "description": "Issuer is the issuer of the current certificate.",
+                    "type": "string"
+                  },
+                  "notAfter": {
+                    "description": "NotAfter indicates that the certificate is not valid after the given date.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "notBefore": {
+                    "description": "NotBefore indicates that the certificate is not valid before the given date.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "subject": {
+                    "description": "Subject is the subject of the current certificate.",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "clientCert": {
+              "description": "ClientCert is the status of the client certificate.",
+              "type": "object",
+              "required": [
+                "issuer",
+                "subject"
+              ],
+              "properties": {
+                "issuer": {
+                  "description": "Issuer is the issuer of the current certificate.",
+                  "type": "string"
+                },
+                "notAfter": {
+                  "description": "NotAfter indicates that the certificate is not valid after the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "notBefore": {
+                  "description": "NotBefore indicates that the certificate is not valid before the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "subject": {
+                  "description": "Subject is the subject of the current certificate.",
+                  "type": "string"
+                }
+              }
+            },
+            "serverCert": {
+              "description": "ServerCert is the status of the server certificate.",
+              "type": "object",
+              "required": [
+                "issuer",
+                "subject"
+              ],
+              "properties": {
+                "issuer": {
+                  "description": "Issuer is the issuer of the current certificate.",
+                  "type": "string"
+                },
+                "notAfter": {
+                  "description": "NotAfter indicates that the certificate is not valid after the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "notBefore": {
+                  "description": "NotBefore indicates that the certificate is not valid before the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "subject": {
+                  "description": "Subject is the subject of the current certificate.",
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -5310,5 +6873,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/mariadblist.json
+++ b/class_generator/schema/mariadblist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/mariadboperator.json
+++ b/class_generator/schema/mariadboperator.json
@@ -30,5 +30,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/mariadboperatorlist.json
+++ b/class_generator/schema/mariadboperatorlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/maxscale.json
+++ b/class_generator/schema/maxscale.json
@@ -41,6 +41,167 @@
               "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
               "type": "boolean"
             },
+            "nodeAffinity": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+              "type": "object",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                    "type": "object",
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "properties": {
+                      "preference": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "weight": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                  "type": "object",
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "type": "array",
+                      "items": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                }
+              }
+            },
             "podAntiAffinity": {
               "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
               "type": "object",
@@ -63,14 +224,13 @@
                         ],
                         "properties": {
                           "labelSelector": {
-                            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                             "type": "object",
                             "properties": {
                               "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "type": "array",
                                 "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                   "type": "object",
                                   "required": [
                                     "key",
@@ -78,15 +238,13 @@
                                   ],
                                   "properties": {
                                     "key": {
-                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                       "type": "string"
                                     },
                                     "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -98,14 +256,12 @@
                                 "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object",
                                 "additionalProperties": {
                                   "type": "string"
                                 }
                               }
-                            },
-                            "x-kubernetes-map-type": "atomic"
+                            }
                           },
                           "topologyKey": {
                             "type": "string"
@@ -130,14 +286,13 @@
                     ],
                     "properties": {
                       "labelSelector": {
-                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                         "type": "object",
                         "properties": {
                           "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                             "type": "array",
                             "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                               "type": "object",
                               "required": [
                                 "key",
@@ -145,15 +300,13 @@
                               ],
                               "properties": {
                                 "key": {
-                                  "description": "key is the label key that the selector applies to.",
                                   "type": "string"
                                 },
                                 "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                   "type": "string"
                                 },
                                 "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
@@ -165,14 +318,12 @@
                             "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object",
                             "additionalProperties": {
                               "type": "string"
                             }
                           }
-                        },
-                        "x-kubernetes-map-type": "atomic"
+                        }
                       },
                       "topologyKey": {
                         "type": "string"
@@ -927,6 +1078,21 @@
               "type": "integer",
               "format": "int32"
             },
+            "tcpSocket": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
             "timeoutSeconds": {
               "type": "integer",
               "format": "int32"
@@ -969,6 +1135,167 @@
                       "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
                       "type": "boolean"
                     },
+                    "nodeAffinity": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+                      "type": "object",
+                      "properties": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": {
+                          "type": "array",
+                          "items": {
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                            "type": "object",
+                            "required": [
+                              "preference",
+                              "weight"
+                            ],
+                            "properties": {
+                              "preference": {
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                }
+                              },
+                              "weight": {
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-type": "atomic"
+                        },
+                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                          "type": "object",
+                          "required": [
+                            "nodeSelectorTerms"
+                          ],
+                          "properties": {
+                            "nodeSelectorTerms": {
+                              "type": "array",
+                              "items": {
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                                "type": "object",
+                                "properties": {
+                                  "matchExpressions": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "matchFields": {
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                                      "type": "object",
+                                      "required": [
+                                        "key",
+                                        "operator"
+                                      ],
+                                      "properties": {
+                                        "key": {
+                                          "type": "string"
+                                        },
+                                        "operator": {
+                                          "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                          "type": "string"
+                                        },
+                                        "values": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-type": "atomic"
+                            }
+                          }
+                        }
+                      }
+                    },
                     "podAntiAffinity": {
                       "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
                       "type": "object",
@@ -991,14 +1318,13 @@
                                 ],
                                 "properties": {
                                   "labelSelector": {
-                                    "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                     "type": "object",
                                     "properties": {
                                       "matchExpressions": {
-                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                         "type": "array",
                                         "items": {
-                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                           "type": "object",
                                           "required": [
                                             "key",
@@ -1006,15 +1332,13 @@
                                           ],
                                           "properties": {
                                             "key": {
-                                              "description": "key is the label key that the selector applies to.",
                                               "type": "string"
                                             },
                                             "operator": {
-                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                               "type": "string"
                                             },
                                             "values": {
-                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                               "type": "array",
                                               "items": {
                                                 "type": "string"
@@ -1026,14 +1350,12 @@
                                         "x-kubernetes-list-type": "atomic"
                                       },
                                       "matchLabels": {
-                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                         "type": "object",
                                         "additionalProperties": {
                                           "type": "string"
                                         }
                                       }
-                                    },
-                                    "x-kubernetes-map-type": "atomic"
+                                    }
                                   },
                                   "topologyKey": {
                                     "type": "string"
@@ -1058,14 +1380,13 @@
                             ],
                             "properties": {
                               "labelSelector": {
-                                "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                                "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                                 "type": "object",
                                 "properties": {
                                   "matchExpressions": {
-                                    "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                     "type": "array",
                                     "items": {
-                                      "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                       "type": "object",
                                       "required": [
                                         "key",
@@ -1073,15 +1394,13 @@
                                       ],
                                       "properties": {
                                         "key": {
-                                          "description": "key is the label key that the selector applies to.",
                                           "type": "string"
                                         },
                                         "operator": {
-                                          "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                          "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                           "type": "string"
                                         },
                                         "values": {
-                                          "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                           "type": "array",
                                           "items": {
                                             "type": "string"
@@ -1093,14 +1412,12 @@
                                     "x-kubernetes-list-type": "atomic"
                                   },
                                   "matchLabels": {
-                                    "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                     "type": "object",
                                     "additionalProperties": {
                                       "type": "string"
                                     }
                                   }
-                                },
-                                "x-kubernetes-map-type": "atomic"
+                                }
                               },
                               "topologyKey": {
                                 "type": "string"
@@ -1619,6 +1936,21 @@
               "type": "integer",
               "format": "int32"
             },
+            "tcpSocket": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
             "timeoutSeconds": {
               "type": "integer",
               "format": "int32"
@@ -1823,9 +2155,203 @@
             }
           }
         },
+        "startupProbe": {
+          "description": "StartupProbe to be used in the Container.",
+          "type": "object",
+          "properties": {
+            "exec": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#execaction-v1-core.",
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                }
+              }
+            },
+            "failureThreshold": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "httpGet": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#httpgetaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "path": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                },
+                "scheme": {
+                  "description": "URIScheme identifies the scheme used for connection to a host for Get actions",
+                  "type": "string"
+                }
+              }
+            },
+            "initialDelaySeconds": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "periodSeconds": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "successThreshold": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "tcpSocket": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#tcpsocketaction-v1-core.",
+              "type": "object",
+              "required": [
+                "port"
+              ],
+              "properties": {
+                "host": {
+                  "type": "string"
+                },
+                "port": {
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
+            "timeoutSeconds": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        },
         "suspend": {
           "description": "Suspend indicates whether the current resource should be suspended or not.\nThis can be useful for maintenance, as disabling the reconciliation prevents the operator from interfering with user operations during maintenance activities.",
           "type": "boolean"
+        },
+        "tls": {
+          "description": "TLS defines the PKI to be used with MaxScale.",
+          "type": "object",
+          "properties": {
+            "adminCASecretRef": {
+              "description": "AdminCASecretRef is a reference to a Secret containing the admin certificate authority keypair. It is used to establish trust and issue certificates for the MaxScale's administrative REST API and GUI.\nOne of:\n- Secret containing both the 'ca.crt' and 'ca.key' keys. This allows you to bring your own CA to Kubernetes to issue certificates.\n- Secret containing only the 'ca.crt' in order to establish trust. In this case, either adminCertSecretRef or adminCertIssuerRef fields must be provided.\nIf not provided, a self-signed CA will be provisioned to issue the server certificate.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "adminCertIssuerRef": {
+              "description": "AdminCertIssuerRef is a reference to a cert-manager issuer object used to issue the MaxScale's administrative REST API and GUI certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with adminCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via adminCASecretRef.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "group": {
+                  "description": "Group of the resource being referred to.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the resource being referred to.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to.",
+                  "type": "string"
+                }
+              }
+            },
+            "adminCertSecretRef": {
+              "description": "AdminCertSecretRef is a reference to a TLS Secret used by the MaxScale's administrative REST API and GUI.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "enabled": {
+              "description": "Enabled indicates whether TLS is enabled, determining if certificates should be issued and mounted to the MaxScale instance.\nIt is enabled by default when the referred MariaDB instance (via mariaDbRef) has TLS enabled and enforced.",
+              "type": "boolean"
+            },
+            "listenerCASecretRef": {
+              "description": "ListenerCASecretRef is a reference to a Secret containing the listener certificate authority keypair. It is used to establish trust and issue certificates for the MaxScale's listeners.\nOne of:\n- Secret containing both the 'ca.crt' and 'ca.key' keys. This allows you to bring your own CA to Kubernetes to issue certificates.\n- Secret containing only the 'ca.crt' in order to establish trust. In this case, either listenerCertSecretRef or listenerCertIssuerRef fields must be provided.\nIf not provided, a self-signed CA will be provisioned to issue the listener certificate.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "listenerCertIssuerRef": {
+              "description": "ListenerCertIssuerRef is a reference to a cert-manager issuer object used to issue the MaxScale's listeners certificate. cert-manager must be installed previously in the cluster.\nIt is mutually exclusive with listenerCertSecretRef.\nBy default, the Secret field 'ca.crt' provisioned by cert-manager will be added to the trust chain. A custom trust bundle may be specified via listenerCASecretRef.",
+              "type": "object",
+              "required": [
+                "name"
+              ],
+              "properties": {
+                "group": {
+                  "description": "Group of the resource being referred to.",
+                  "type": "string"
+                },
+                "kind": {
+                  "description": "Kind of the resource being referred to.",
+                  "type": "string"
+                },
+                "name": {
+                  "description": "Name of the resource being referred to.",
+                  "type": "string"
+                }
+              }
+            },
+            "listenerCertSecretRef": {
+              "description": "ListenerCertSecretRef is a reference to a TLS Secret used by the MaxScale's listeners.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "replicationSSLEnabled": {
+              "description": "ReplicationSSLEnabled specifies whether the replication SSL is enabled. If enabled, the SSL options will be added to the server configuration.\nIt is enabled by default when the referred MariaDB instance (via mariaDbRef) has replication enabled.\nIf the MariaDB servers are manually provided by the user via the 'servers' field, this must be set by the user as well.",
+              "type": "boolean"
+            },
+            "serverCASecretRef": {
+              "description": "ServerCASecretRef is a reference to a Secret containing the MariaDB server CA certificates. It is used to establish trust with MariaDB servers.\nThe Secret should contain a 'ca.crt' key in order to establish trust.\nIf not provided, and the reference to a MariaDB resource is set (mariaDbRef), it will be defaulted to the referred MariaDB CA bundle.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "serverCertSecretRef": {
+              "description": "ServerCertSecretRef is a reference to a TLS Secret used by MaxScale to connect to the MariaDB servers.\nIf not provided, and the reference to a MariaDB resource is set (mariaDbRef), it will be defaulted to the referred MariaDB client certificate (clientCertSecretRef).",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "verifyPeerCertificate": {
+              "description": "VerifyPeerCertificate specifies whether the peer certificate's signature should be validated against the CA.\nIt is disabled by default.",
+              "type": "boolean"
+            },
+            "verifyPeerHost": {
+              "description": "VerifyPeerHost specifies whether the peer certificate's SANs should match the peer host.\nIt is disabled by default.",
+              "type": "boolean"
+            }
+          }
         },
         "tolerations": {
           "description": "Tolerations to be used in the Pod.",
@@ -2159,6 +2685,128 @@
               }
             }
           }
+        },
+        "tls": {
+          "description": "TLS aggregates the status of the certificates used by the MaxScale instance.",
+          "type": "object",
+          "properties": {
+            "adminCert": {
+              "description": "AdminCert is the status of the admin certificate.",
+              "type": "object",
+              "required": [
+                "issuer",
+                "subject"
+              ],
+              "properties": {
+                "issuer": {
+                  "description": "Issuer is the issuer of the current certificate.",
+                  "type": "string"
+                },
+                "notAfter": {
+                  "description": "NotAfter indicates that the certificate is not valid after the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "notBefore": {
+                  "description": "NotBefore indicates that the certificate is not valid before the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "subject": {
+                  "description": "Subject is the subject of the current certificate.",
+                  "type": "string"
+                }
+              }
+            },
+            "caBundle": {
+              "description": "CABundle is the status of the Certificate Authority bundle.",
+              "type": "array",
+              "items": {
+                "description": "CertificateStatus represents the current status of a TLS certificate.",
+                "type": "object",
+                "required": [
+                  "issuer",
+                  "subject"
+                ],
+                "properties": {
+                  "issuer": {
+                    "description": "Issuer is the issuer of the current certificate.",
+                    "type": "string"
+                  },
+                  "notAfter": {
+                    "description": "NotAfter indicates that the certificate is not valid after the given date.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "notBefore": {
+                    "description": "NotBefore indicates that the certificate is not valid before the given date.",
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "subject": {
+                    "description": "Subject is the subject of the current certificate.",
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "listenerCert": {
+              "description": "ListenerCert is the status of the listener certificate.",
+              "type": "object",
+              "required": [
+                "issuer",
+                "subject"
+              ],
+              "properties": {
+                "issuer": {
+                  "description": "Issuer is the issuer of the current certificate.",
+                  "type": "string"
+                },
+                "notAfter": {
+                  "description": "NotAfter indicates that the certificate is not valid after the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "notBefore": {
+                  "description": "NotBefore indicates that the certificate is not valid before the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "subject": {
+                  "description": "Subject is the subject of the current certificate.",
+                  "type": "string"
+                }
+              }
+            },
+            "serverCert": {
+              "description": "ServerCert is the status of the MariaDB server certificate.",
+              "type": "object",
+              "required": [
+                "issuer",
+                "subject"
+              ],
+              "properties": {
+                "issuer": {
+                  "description": "Issuer is the issuer of the current certificate.",
+                  "type": "string"
+                },
+                "notAfter": {
+                  "description": "NotAfter indicates that the certificate is not valid after the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "notBefore": {
+                  "description": "NotBefore indicates that the certificate is not valid before the given date.",
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "subject": {
+                  "description": "Subject is the subject of the current certificate.",
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -2170,5 +2818,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/maxscalelist.json
+++ b/class_generator/schema/maxscalelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/odhdashboardconfig.json
+++ b/class_generator/schema/odhdashboardconfig.json
@@ -20,6 +20,7 @@
       "type": "object",
       "properties": {
         "dashboardConfig": {
+          "description": "Feature flag configurations; intended to just contain overrides",
           "type": "object",
           "properties": {
             "disableAcceleratorProfiles": {
@@ -124,6 +125,7 @@
           }
         },
         "groupsConfig": {
+          "description": "Ignored -- See \"Auth\" Resource",
           "type": "object",
           "required": [
             "adminGroups",
@@ -187,6 +189,7 @@
           }
         },
         "notebookController": {
+          "description": "Jupyter tile configurations",
           "type": "object",
           "required": [
             "enabled"

--- a/class_generator/schema/openshiftpipelinesascode.json
+++ b/class_generator/schema/openshiftpipelinesascode.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/openshiftpipelinesascodelist.json
+++ b/class_generator/schema/openshiftpipelinesascodelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/peerauthentication.json
+++ b/class_generator/schema/peerauthentication.json
@@ -22,7 +22,7 @@
           "type": "object",
           "properties": {
             "mode": {
-              "description": "Defines the mTLS mode used for peer authentication.",
+              "description": "Defines the mTLS mode used for peer authentication.\n\nValid Options: DISABLE, PERMISSIVE, STRICT",
               "type": "string",
               "enum": [
                 "UNSET",
@@ -36,11 +36,12 @@
         "portLevelMtls": {
           "description": "Port specific mutual TLS settings.",
           "type": "object",
+          "minProperties": 1,
           "additionalProperties": {
             "type": "object",
             "properties": {
               "mode": {
-                "description": "Defines the mTLS mode used for peer authentication.",
+                "description": "Defines the mTLS mode used for peer authentication.\n\nValid Options: DISABLE, PERMISSIVE, STRICT",
                 "type": "string",
                 "enum": [
                   "UNSET",
@@ -50,22 +51,52 @@
                 ]
               }
             }
-          }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "port must be between 1-65535",
+              "rule": "self.all(key, 0 < int(key) && int(key) <= 65535)"
+            }
+          ]
         },
         "selector": {
-          "description": "The selector determines the workloads to apply the ChannelAuthentication on.",
+          "description": "The selector determines the workloads to apply the PeerAuthentication on.",
           "type": "object",
           "properties": {
             "matchLabels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.",
               "type": "object",
+              "maxProperties": 4096,
               "additionalProperties": {
-                "type": "string"
-              }
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard not allowed in label value match",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "wildcard not allowed in label key match",
+                  "rule": "self.all(key, !key.contains('*'))"
+                },
+                {
+                  "message": "key must not be empty",
+                  "rule": "self.all(key, key.size() != 0)"
+                }
+              ]
             }
           }
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "portLevelMtls requires selector",
+          "rule": "(has(self.selector) && has(self.selector.matchLabels) && self.selector.matchLabels.size() > 0) || !has(self.portLevelMtls)"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/pipeline.json
+++ b/class_generator/schema/pipeline.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/pipelinelist.json
+++ b/class_generator/schema/pipelinelist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/pipelinerun.json
+++ b/class_generator/schema/pipelinerun.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/pipelinerunlist.json
+++ b/class_generator/schema/pipelinerunlist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/proxyconfig.json
+++ b/class_generator/schema/proxyconfig.json
@@ -18,13 +18,16 @@
       "type": "object",
       "properties": {
         "concurrency": {
-          "description": "The number of worker threads to run."
+          "description": "The number of worker threads to run.",
+          "format": "int32",
+          "minimum": 0
         },
         "environmentVariables": {
           "description": "Additional environment variables for the proxy.",
           "type": "object",
           "additionalProperties": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 2048
           }
         },
         "image": {
@@ -44,9 +47,27 @@
             "matchLabels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.",
               "type": "object",
+              "maxProperties": 4096,
               "additionalProperties": {
-                "type": "string"
-              }
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard not allowed in label value match",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "wildcard not allowed in label key match",
+                  "rule": "self.all(key, !key.contains('*'))"
+                },
+                {
+                  "message": "key must not be empty",
+                  "rule": "self.all(key, key.size() != 0)"
+                }
+              ]
             }
           }
         }

--- a/class_generator/schema/raycluster.json
+++ b/class_generator/schema/raycluster.json
@@ -172,6 +172,9 @@
                     "properties": {
                       "name": {
                         "type": "string"
+                      },
+                      "request": {
+                        "type": "string"
                       }
                     }
                   },
@@ -605,6 +608,7 @@
                                 "items": {
                                   "type": "object",
                                   "required": [
+                                    "error",
                                     "port",
                                     "protocol"
                                   ],
@@ -1944,6 +1948,9 @@
                                   "properties": {
                                     "name": {
                                       "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
                                     }
                                   }
                                 },
@@ -2927,6 +2934,9 @@
                                   ],
                                   "properties": {
                                     "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
                                       "type": "string"
                                     }
                                   }
@@ -3931,6 +3941,9 @@
                                   "properties": {
                                     "name": {
                                       "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
                                     }
                                   }
                                 },
@@ -4324,16 +4337,11 @@
                           "name": {
                             "type": "string"
                           },
-                          "source": {
-                            "type": "object",
-                            "properties": {
-                              "resourceClaimName": {
-                                "type": "string"
-                              },
-                              "resourceClaimTemplateName": {
-                                "type": "string"
-                              }
-                            }
+                          "resourceClaimName": {
+                            "type": "string"
+                          },
+                          "resourceClaimTemplateName": {
+                            "type": "string"
                           }
                         }
                       },
@@ -4341,6 +4349,46 @@
                         "name"
                       ],
                       "x-kubernetes-list-type": "map"
+                    },
+                    "resources": {
+                      "type": "object",
+                      "properties": {
+                        "claims": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "request": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "x-kubernetes-list-map-keys": [
+                            "name"
+                          ],
+                          "x-kubernetes-list-type": "map"
+                        },
+                        "limits": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        },
+                        "requests": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      }
                     },
                     "restartPolicy": {
                       "type": "string"
@@ -4404,6 +4452,9 @@
                           "type": "integer",
                           "format": "int64"
                         },
+                        "seLinuxChangePolicy": {
+                          "type": "string"
+                        },
                         "seLinuxOptions": {
                           "type": "object",
                           "properties": {
@@ -4442,6 +4493,9 @@
                             "format": "int64"
                           },
                           "x-kubernetes-list-type": "atomic"
+                        },
+                        "supplementalGroupsPolicy": {
+                          "type": "string"
                         },
                         "sysctls": {
                           "type": "array",
@@ -5190,6 +5244,17 @@
                                 "type": "string"
                               },
                               "type": {
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "image": {
+                            "type": "object",
+                            "properties": {
+                              "pullPolicy": {
+                                "type": "string"
+                              },
+                              "reference": {
                                 "type": "string"
                               }
                             }
@@ -7105,6 +7170,9 @@
                                     "properties": {
                                       "name": {
                                         "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
                                       }
                                     }
                                   },
@@ -8088,6 +8156,9 @@
                                     ],
                                     "properties": {
                                       "name": {
+                                        "type": "string"
+                                      },
+                                      "request": {
                                         "type": "string"
                                       }
                                     }
@@ -9092,6 +9163,9 @@
                                     "properties": {
                                       "name": {
                                         "type": "string"
+                                      },
+                                      "request": {
+                                        "type": "string"
                                       }
                                     }
                                   },
@@ -9485,16 +9559,11 @@
                             "name": {
                               "type": "string"
                             },
-                            "source": {
-                              "type": "object",
-                              "properties": {
-                                "resourceClaimName": {
-                                  "type": "string"
-                                },
-                                "resourceClaimTemplateName": {
-                                  "type": "string"
-                                }
-                              }
+                            "resourceClaimName": {
+                              "type": "string"
+                            },
+                            "resourceClaimTemplateName": {
+                              "type": "string"
                             }
                           }
                         },
@@ -9502,6 +9571,46 @@
                           "name"
                         ],
                         "x-kubernetes-list-type": "map"
+                      },
+                      "resources": {
+                        "type": "object",
+                        "properties": {
+                          "claims": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "required": [
+                                "name"
+                              ],
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-map-keys": [
+                              "name"
+                            ],
+                            "x-kubernetes-list-type": "map"
+                          },
+                          "limits": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          },
+                          "requests": {
+                            "type": "object",
+                            "additionalProperties": {
+                              "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                              "x-kubernetes-int-or-string": true
+                            }
+                          }
+                        }
                       },
                       "restartPolicy": {
                         "type": "string"
@@ -9565,6 +9674,9 @@
                             "type": "integer",
                             "format": "int64"
                           },
+                          "seLinuxChangePolicy": {
+                            "type": "string"
+                          },
                           "seLinuxOptions": {
                             "type": "object",
                             "properties": {
@@ -9603,6 +9715,9 @@
                               "format": "int64"
                             },
                             "x-kubernetes-list-type": "atomic"
+                          },
+                          "supplementalGroupsPolicy": {
+                            "type": "string"
                           },
                           "sysctls": {
                             "type": "array",
@@ -10351,6 +10466,17 @@
                                   "type": "string"
                                 },
                                 "type": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "image": {
+                              "type": "object",
+                              "properties": {
+                                "pullPolicy": {
+                                  "type": "string"
+                                },
+                                "reference": {
                                   "type": "string"
                                 }
                               }

--- a/class_generator/schema/rayjob.json
+++ b/class_generator/schema/rayjob.json
@@ -205,6 +205,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -638,6 +641,7 @@
                                     "items": {
                                       "type": "object",
                                       "required": [
+                                        "error",
                                         "port",
                                         "protocol"
                                       ],
@@ -1977,6 +1981,9 @@
                                       "properties": {
                                         "name": {
                                           "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
                                         }
                                       }
                                     },
@@ -2960,6 +2967,9 @@
                                       ],
                                       "properties": {
                                         "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
                                           "type": "string"
                                         }
                                       }
@@ -3964,6 +3974,9 @@
                                       "properties": {
                                         "name": {
                                           "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
                                         }
                                       }
                                     },
@@ -4357,16 +4370,11 @@
                               "name": {
                                 "type": "string"
                               },
-                              "source": {
-                                "type": "object",
-                                "properties": {
-                                  "resourceClaimName": {
-                                    "type": "string"
-                                  },
-                                  "resourceClaimTemplateName": {
-                                    "type": "string"
-                                  }
-                                }
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
                               }
                             }
                           },
@@ -4374,6 +4382,46 @@
                             "name"
                           ],
                           "x-kubernetes-list-type": "map"
+                        },
+                        "resources": {
+                          "type": "object",
+                          "properties": {
+                            "claims": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "limits": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "requests": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          }
                         },
                         "restartPolicy": {
                           "type": "string"
@@ -4437,6 +4485,9 @@
                               "type": "integer",
                               "format": "int64"
                             },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
                             "seLinuxOptions": {
                               "type": "object",
                               "properties": {
@@ -4475,6 +4526,9 @@
                                 "format": "int64"
                               },
                               "x-kubernetes-list-type": "atomic"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
                             },
                             "sysctls": {
                               "type": "array",
@@ -5223,6 +5277,17 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "image": {
+                                "type": "object",
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
                                     "type": "string"
                                   }
                                 }
@@ -7138,6 +7203,9 @@
                                         "properties": {
                                           "name": {
                                             "type": "string"
+                                          },
+                                          "request": {
+                                            "type": "string"
                                           }
                                         }
                                       },
@@ -8121,6 +8189,9 @@
                                         ],
                                         "properties": {
                                           "name": {
+                                            "type": "string"
+                                          },
+                                          "request": {
                                             "type": "string"
                                           }
                                         }
@@ -9125,6 +9196,9 @@
                                         "properties": {
                                           "name": {
                                             "type": "string"
+                                          },
+                                          "request": {
+                                            "type": "string"
                                           }
                                         }
                                       },
@@ -9518,16 +9592,11 @@
                                 "name": {
                                   "type": "string"
                                 },
-                                "source": {
-                                  "type": "object",
-                                  "properties": {
-                                    "resourceClaimName": {
-                                      "type": "string"
-                                    },
-                                    "resourceClaimTemplateName": {
-                                      "type": "string"
-                                    }
-                                  }
+                                "resourceClaimName": {
+                                  "type": "string"
+                                },
+                                "resourceClaimTemplateName": {
+                                  "type": "string"
                                 }
                               }
                             },
@@ -9535,6 +9604,46 @@
                               "name"
                             ],
                             "x-kubernetes-list-type": "map"
+                          },
+                          "resources": {
+                            "type": "object",
+                            "properties": {
+                              "claims": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "limits": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
                           },
                           "restartPolicy": {
                             "type": "string"
@@ -9598,6 +9707,9 @@
                                 "type": "integer",
                                 "format": "int64"
                               },
+                              "seLinuxChangePolicy": {
+                                "type": "string"
+                              },
                               "seLinuxOptions": {
                                 "type": "object",
                                 "properties": {
@@ -9636,6 +9748,9 @@
                                   "format": "int64"
                                 },
                                 "x-kubernetes-list-type": "atomic"
+                              },
+                              "supplementalGroupsPolicy": {
+                                "type": "string"
                               },
                               "sysctls": {
                                 "type": "array",
@@ -10384,6 +10499,17 @@
                                       "type": "string"
                                     },
                                     "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "image": {
+                                  "type": "object",
+                                  "properties": {
+                                    "pullPolicy": {
+                                      "type": "string"
+                                    },
+                                    "reference": {
                                       "type": "string"
                                     }
                                   }
@@ -12252,6 +12378,9 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
                                 }
                               }
                             },
@@ -13235,6 +13364,9 @@
                               ],
                               "properties": {
                                 "name": {
+                                  "type": "string"
+                                },
+                                "request": {
                                   "type": "string"
                                 }
                               }
@@ -14239,6 +14371,9 @@
                               "properties": {
                                 "name": {
                                   "type": "string"
+                                },
+                                "request": {
+                                  "type": "string"
                                 }
                               }
                             },
@@ -14632,16 +14767,11 @@
                       "name": {
                         "type": "string"
                       },
-                      "source": {
-                        "type": "object",
-                        "properties": {
-                          "resourceClaimName": {
-                            "type": "string"
-                          },
-                          "resourceClaimTemplateName": {
-                            "type": "string"
-                          }
-                        }
+                      "resourceClaimName": {
+                        "type": "string"
+                      },
+                      "resourceClaimTemplateName": {
+                        "type": "string"
                       }
                     }
                   },
@@ -14649,6 +14779,46 @@
                     "name"
                   ],
                   "x-kubernetes-list-type": "map"
+                },
+                "resources": {
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
                 },
                 "restartPolicy": {
                   "type": "string"
@@ -14712,6 +14882,9 @@
                       "type": "integer",
                       "format": "int64"
                     },
+                    "seLinuxChangePolicy": {
+                      "type": "string"
+                    },
                     "seLinuxOptions": {
                       "type": "object",
                       "properties": {
@@ -14750,6 +14923,9 @@
                         "format": "int64"
                       },
                       "x-kubernetes-list-type": "atomic"
+                    },
+                    "supplementalGroupsPolicy": {
+                      "type": "string"
                     },
                     "sysctls": {
                       "type": "array",
@@ -15498,6 +15674,17 @@
                             "type": "string"
                           },
                           "type": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "image": {
+                        "type": "object",
+                        "properties": {
+                          "pullPolicy": {
+                            "type": "string"
+                          },
+                          "reference": {
                             "type": "string"
                           }
                         }

--- a/class_generator/schema/rayservice.json
+++ b/class_generator/schema/rayservice.json
@@ -179,6 +179,9 @@
                         "properties": {
                           "name": {
                             "type": "string"
+                          },
+                          "request": {
+                            "type": "string"
                           }
                         }
                       },
@@ -612,6 +615,7 @@
                                     "items": {
                                       "type": "object",
                                       "required": [
+                                        "error",
                                         "port",
                                         "protocol"
                                       ],
@@ -1951,6 +1955,9 @@
                                       "properties": {
                                         "name": {
                                           "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
                                         }
                                       }
                                     },
@@ -2934,6 +2941,9 @@
                                       ],
                                       "properties": {
                                         "name": {
+                                          "type": "string"
+                                        },
+                                        "request": {
                                           "type": "string"
                                         }
                                       }
@@ -3938,6 +3948,9 @@
                                       "properties": {
                                         "name": {
                                           "type": "string"
+                                        },
+                                        "request": {
+                                          "type": "string"
                                         }
                                       }
                                     },
@@ -4331,16 +4344,11 @@
                               "name": {
                                 "type": "string"
                               },
-                              "source": {
-                                "type": "object",
-                                "properties": {
-                                  "resourceClaimName": {
-                                    "type": "string"
-                                  },
-                                  "resourceClaimTemplateName": {
-                                    "type": "string"
-                                  }
-                                }
+                              "resourceClaimName": {
+                                "type": "string"
+                              },
+                              "resourceClaimTemplateName": {
+                                "type": "string"
                               }
                             }
                           },
@@ -4348,6 +4356,46 @@
                             "name"
                           ],
                           "x-kubernetes-list-type": "map"
+                        },
+                        "resources": {
+                          "type": "object",
+                          "properties": {
+                            "claims": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "request": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "x-kubernetes-list-map-keys": [
+                                "name"
+                              ],
+                              "x-kubernetes-list-type": "map"
+                            },
+                            "limits": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            },
+                            "requests": {
+                              "type": "object",
+                              "additionalProperties": {
+                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                "x-kubernetes-int-or-string": true
+                              }
+                            }
+                          }
                         },
                         "restartPolicy": {
                           "type": "string"
@@ -4411,6 +4459,9 @@
                               "type": "integer",
                               "format": "int64"
                             },
+                            "seLinuxChangePolicy": {
+                              "type": "string"
+                            },
                             "seLinuxOptions": {
                               "type": "object",
                               "properties": {
@@ -4449,6 +4500,9 @@
                                 "format": "int64"
                               },
                               "x-kubernetes-list-type": "atomic"
+                            },
+                            "supplementalGroupsPolicy": {
+                              "type": "string"
                             },
                             "sysctls": {
                               "type": "array",
@@ -5197,6 +5251,17 @@
                                     "type": "string"
                                   },
                                   "type": {
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "image": {
+                                "type": "object",
+                                "properties": {
+                                  "pullPolicy": {
+                                    "type": "string"
+                                  },
+                                  "reference": {
                                     "type": "string"
                                   }
                                 }
@@ -7112,6 +7177,9 @@
                                         "properties": {
                                           "name": {
                                             "type": "string"
+                                          },
+                                          "request": {
+                                            "type": "string"
                                           }
                                         }
                                       },
@@ -8095,6 +8163,9 @@
                                         ],
                                         "properties": {
                                           "name": {
+                                            "type": "string"
+                                          },
+                                          "request": {
                                             "type": "string"
                                           }
                                         }
@@ -9099,6 +9170,9 @@
                                         "properties": {
                                           "name": {
                                             "type": "string"
+                                          },
+                                          "request": {
+                                            "type": "string"
                                           }
                                         }
                                       },
@@ -9492,16 +9566,11 @@
                                 "name": {
                                   "type": "string"
                                 },
-                                "source": {
-                                  "type": "object",
-                                  "properties": {
-                                    "resourceClaimName": {
-                                      "type": "string"
-                                    },
-                                    "resourceClaimTemplateName": {
-                                      "type": "string"
-                                    }
-                                  }
+                                "resourceClaimName": {
+                                  "type": "string"
+                                },
+                                "resourceClaimTemplateName": {
+                                  "type": "string"
                                 }
                               }
                             },
@@ -9509,6 +9578,46 @@
                               "name"
                             ],
                             "x-kubernetes-list-type": "map"
+                          },
+                          "resources": {
+                            "type": "object",
+                            "properties": {
+                              "claims": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "name"
+                                  ],
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    },
+                                    "request": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-map-keys": [
+                                  "name"
+                                ],
+                                "x-kubernetes-list-type": "map"
+                              },
+                              "limits": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              },
+                              "requests": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            }
                           },
                           "restartPolicy": {
                             "type": "string"
@@ -9572,6 +9681,9 @@
                                 "type": "integer",
                                 "format": "int64"
                               },
+                              "seLinuxChangePolicy": {
+                                "type": "string"
+                              },
                               "seLinuxOptions": {
                                 "type": "object",
                                 "properties": {
@@ -9610,6 +9722,9 @@
                                   "format": "int64"
                                 },
                                 "x-kubernetes-list-type": "atomic"
+                              },
+                              "supplementalGroupsPolicy": {
+                                "type": "string"
                               },
                               "sysctls": {
                                 "type": "array",
@@ -10358,6 +10473,17 @@
                                       "type": "string"
                                     },
                                     "type": {
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "image": {
+                                  "type": "object",
+                                  "properties": {
+                                    "pullPolicy": {
+                                      "type": "string"
+                                    },
+                                    "reference": {
                                       "type": "string"
                                     }
                                   }
@@ -11167,6 +11293,7 @@
                             "items": {
                               "type": "object",
                               "required": [
+                                "error",
                                 "port",
                                 "protocol"
                               ],

--- a/class_generator/schema/repository.json
+++ b/class_generator/schema/repository.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/repositorylist.json
+++ b/class_generator/schema/repositorylist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/requestauthentication.json
+++ b/class_generator/schema/requestauthentication.json
@@ -20,6 +20,7 @@
         "jwtRules": {
           "description": "Define the list of JWTs that can be validated at the selected workloads' proxy.",
           "type": "array",
+          "maxItems": 4096,
           "items": {
             "type": "object",
             "required": [
@@ -30,12 +31,21 @@
                 "description": "The list of JWT [audiences](https://tools.ietf.org/html/rfc7519#section-4.1.3) that are allowed to access.",
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               },
               "forwardOriginalToken": {
                 "description": "If set to true, the original token will be kept for the upstream request.",
                 "type": "boolean"
+              },
+              "fromCookies": {
+                "description": "List of cookie names from which JWT is expected.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
               },
               "fromHeaders": {
                 "description": "List of header locations from which JWT is expected.",
@@ -48,7 +58,8 @@
                   "properties": {
                     "name": {
                       "description": "The HTTP header name.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "prefix": {
                       "description": "The prefix that should be stripped before decoding the token.",
@@ -61,12 +72,14 @@
                 "description": "List of query parameters from which JWT is expected.",
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "type": "string",
+                  "minLength": 1
                 }
               },
               "issuer": {
                 "description": "Identifies the issuer that issued the JWT.",
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               },
               "jwks": {
                 "description": "JSON Web Key Set of public keys to validate signature of the JWT.",
@@ -74,25 +87,48 @@
               },
               "jwksUri": {
                 "description": "URL of the provider's public key set to validate signature of the JWT.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 2048,
+                "minLength": 1,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "url must have scheme http:// or https://",
+                    "rule": "url(self).getScheme() in ['http', 'https']"
+                  }
+                ]
               },
               "jwks_uri": {
                 "description": "URL of the provider's public key set to validate signature of the JWT.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 2048,
+                "minLength": 1,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "url must have scheme http:// or https://",
+                    "rule": "url(self).getScheme() in ['http', 'https']"
+                  }
+                ]
               },
               "outputClaimToHeaders": {
                 "description": "This field specifies a list of operations to copy the claim to HTTP headers on a successfully verified token.",
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "required": [
+                    "header",
+                    "claim"
+                  ],
                   "properties": {
                     "claim": {
                       "description": "The name of the claim to be copied from.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     },
                     "header": {
                       "description": "The name of the header to be created.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1,
+                      "pattern": "^[-_A-Za-z0-9]+$"
                     }
                   }
                 }
@@ -100,8 +136,24 @@
               "outputPayloadToHeader": {
                 "description": "This field specifies the header name to output a successfully verified JWT payload to the backend.",
                 "type": "string"
+              },
+              "timeout": {
+                "description": "The maximum amount of time that the resolver, determined by the PILOT_JWT_ENABLE_REMOTE_JWKS environment variable, will spend waiting for the JWKS to be fetched.",
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "must be a valid duration greater than 1ms",
+                    "rule": "duration(self) >= duration('1ms')"
+                  }
+                ]
               }
-            }
+            },
+            "x-kubernetes-validations": [
+              {
+                "message": "only one of jwks or jwksUri can be set",
+                "rule": "(has(self.jwksUri)?1:0)+(has(self.jwks_uri)?1:0)+(has(self.jwks)?1:0)<=1"
+              }
+            ]
           }
         },
         "selector": {
@@ -111,35 +163,130 @@
             "matchLabels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.",
               "type": "object",
+              "maxProperties": 4096,
               "additionalProperties": {
-                "type": "string"
-              }
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard not allowed in label value match",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "wildcard not allowed in label key match",
+                  "rule": "self.all(key, !key.contains('*'))"
+                },
+                {
+                  "message": "key must not be empty",
+                  "rule": "self.all(key, key.size() != 0)"
+                }
+              ]
             }
           }
         },
         "targetRef": {
-          "description": "Optional.",
           "type": "object",
+          "required": [
+            "kind",
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "group is the group of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
             },
             "kind": {
               "description": "kind is kind of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
             },
             "name": {
               "description": "name is the name of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "minLength": 1
             },
             "namespace": {
               "description": "namespace is the namespace of the referent.",
-              "type": "string"
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "cross namespace referencing is not currently supported",
+                  "rule": "self.size() == 0"
+                }
+              ]
             }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+              "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+            }
+          ]
+        },
+        "targetRefs": {
+          "description": "Optional.",
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "name"
+            ],
+            "properties": {
+              "group": {
+                "description": "group is the group of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+              },
+              "kind": {
+                "description": "kind is kind of the target resource.",
+                "type": "string",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+              },
+              "name": {
+                "description": "name is the name of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "minLength": 1
+              },
+              "namespace": {
+                "description": "namespace is the namespace of the referent.",
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "cross namespace referencing is not currently supported",
+                    "rule": "self.size() == 0"
+                  }
+                ]
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+                "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+              }
+            ]
           }
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "only one of targetRefs or selector can be set",
+          "rule": "(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/resolutionrequest.json
+++ b/class_generator/schema/resolutionrequest.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/resolutionrequestlist.json
+++ b/class_generator/schema/resolutionrequestlist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/restore.json
+++ b/class_generator/schema/restore.json
@@ -1,5 +1,5 @@
 {
-  "description": "Restore is a Velero resource that represents the application of\nresources from a Velero backup to a target Kubernetes cluster.",
+  "description": "Restore is the Schema for the restores API. It is used to define restore jobs and its restoration source.",
   "type": "object",
   "properties": {
     "apiVersion": {
@@ -15,117 +15,867 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "RestoreSpec defines the specification for a Velero restore.",
+      "description": "RestoreSpec defines the desired state of restore",
       "type": "object",
+      "required": [
+        "mariaDbRef"
+      ],
       "properties": {
-        "backupName": {
-          "description": "BackupName is the unique name of the Velero backup to restore\nfrom.",
-          "type": "string"
-        },
-        "excludedNamespaces": {
-          "description": "ExcludedNamespaces contains a list of namespaces that are not\nincluded in the restore."
-        },
-        "excludedResources": {
-          "description": "ExcludedResources is a slice of resource names that are not\nincluded in the restore."
-        },
-        "existingResourcePolicy": {
-          "description": "ExistingResourcePolicy specifies the restore behavior for the Kubernetes resource to be restored"
-        },
-        "hooks": {
-          "description": "Hooks represent custom behaviors that should be executed during or post restore.",
+        "affinity": {
+          "description": "Affinity to be used in the Pod.",
           "type": "object",
           "properties": {
-            "resources": {
-              "type": "array",
-              "items": {
-                "description": "RestoreResourceHookSpec defines one or more RestoreResrouceHooks that should be executed based on\nthe rules defined for namespaces, resources, and label selector.",
-                "type": "object",
-                "required": [
-                  "name"
-                ],
-                "properties": {
-                  "excludedNamespaces": {
-                    "description": "ExcludedNamespaces specifies the namespaces to which this hook spec does not apply."
-                  },
-                  "excludedResources": {
-                    "description": "ExcludedResources specifies the resources to which this hook spec does not apply."
-                  },
-                  "includedNamespaces": {
-                    "description": "IncludedNamespaces specifies the namespaces to which this hook spec applies. If empty, it applies\nto all namespaces."
-                  },
-                  "includedResources": {
-                    "description": "IncludedResources specifies the resources to which this hook spec applies. If empty, it applies\nto all resources."
-                  },
-                  "labelSelector": {
-                    "description": "LabelSelector, if specified, filters the resources to which this hook spec applies.",
-                    "x-kubernetes-map-type": "atomic"
-                  },
-                  "name": {
-                    "description": "Name is the name of this hook.",
-                    "type": "string"
-                  },
-                  "postHooks": {
-                    "description": "PostHooks is a list of RestoreResourceHooks to execute during and after restoring a resource.",
-                    "type": "array",
-                    "items": {
-                      "description": "RestoreResourceHook defines a restore hook for a resource.",
-                      "type": "object",
-                      "properties": {
-                        "exec": {
-                          "description": "Exec defines an exec restore hook.",
-                          "type": "object",
-                          "required": [
-                            "command"
-                          ],
-                          "properties": {
-                            "command": {
-                              "description": "Command is the command and arguments to execute from within a container after a pod has been restored.",
-                              "type": "array",
-                              "minItems": 1,
-                              "items": {
-                                "type": "string"
+            "antiAffinityEnabled": {
+              "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
+              "type": "boolean"
+            },
+            "nodeAffinity": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+              "type": "object",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                    "type": "object",
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "properties": {
+                      "preference": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
                               }
                             },
-                            "container": {
-                              "description": "Container is the container in the pod where the command should be executed. If not specified,\nthe pod's first container is used.",
-                              "type": "string"
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
                             },
-                            "execTimeout": {
-                              "description": "ExecTimeout defines the maximum amount of time Velero should wait for the hook to complete before\nconsidering the execution a failure.",
-                              "type": "string"
-                            },
-                            "onError": {
-                              "description": "OnError specifies how Velero should behave if it encounters an error executing this hook.",
-                              "type": "string",
-                              "enum": [
-                                "Continue",
-                                "Fail"
-                              ]
-                            },
-                            "waitForReady": {
-                              "description": "WaitForReady ensures command will be launched when container is Ready instead of Running."
-                            },
-                            "waitTimeout": {
-                              "description": "WaitTimeout defines the maximum amount of time Velero should wait for the container to be Ready\nbefore attempting to run the command.",
-                              "type": "string"
-                            }
+                            "x-kubernetes-list-type": "atomic"
                           }
-                        },
-                        "init": {
-                          "description": "Init defines an init restore hook.",
-                          "type": "object",
-                          "properties": {
-                            "initContainers": {
-                              "description": "InitContainers is list of init containers to be added to a pod during its restore.",
-                              "x-kubernetes-preserve-unknown-fields": true
+                        }
+                      },
+                      "weight": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                  "type": "object",
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "type": "array",
+                      "items": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
                             },
-                            "timeout": {
-                              "description": "Timeout defines the maximum amount of time Velero should wait for the initContainers to complete.",
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                }
+              }
+            },
+            "podAntiAffinity": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
+              "type": "object",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#weightedpodaffinityterm-v1-core.",
+                    "type": "object",
+                    "required": [
+                      "podAffinityTerm",
+                      "weight"
+                    ],
+                    "properties": {
+                      "podAffinityTerm": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podaffinityterm-v1-core.",
+                        "type": "object",
+                        "required": [
+                          "topologyKey"
+                        ],
+                        "properties": {
+                          "labelSelector": {
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
+                            "type": "object",
+                            "properties": {
+                              "matchExpressions": {
+                                "type": "array",
+                                "items": {
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
+                                  "type": "object",
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ],
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
+                                      "type": "string"
+                                    },
+                                    "values": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-list-type": "atomic"
+                              },
+                              "matchLabels": {
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "topologyKey": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "weight": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podaffinityterm-v1-core.",
+                    "type": "object",
+                    "required": [
+                      "topologyKey"
+                    ],
+                    "properties": {
+                      "labelSelector": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "type": "object",
+                            "additionalProperties": {
                               "type": "string"
                             }
                           }
                         }
+                      },
+                      "topologyKey": {
+                        "type": "string"
                       }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                }
+              }
+            }
+          }
+        },
+        "args": {
+          "description": "Args to be used in the Container.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "backoffLimit": {
+          "description": "BackoffLimit defines the maximum number of attempts to successfully perform a Backup.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "backupRef": {
+          "description": "BackupRef is a reference to a Backup object. It has priority over S3 and Volume.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "database": {
+          "description": "Database defines the logical database to be restored. If not provided, all databases available in the backup are restored.\nIMPORTANT: The database must previously exist.",
+          "type": "string"
+        },
+        "imagePullSecrets": {
+          "description": "ImagePullSecrets is the list of pull Secrets to be used to pull the image.",
+          "type": "array",
+          "items": {
+            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "inheritMetadata": {
+          "description": "InheritMetadata defines the metadata to be inherited by children resources.",
+          "type": "object",
+          "properties": {
+            "annotations": {
+              "description": "Annotations to be added to children resources.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "labels": {
+              "description": "Labels to be added to children resources.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "logLevel": {
+          "description": "LogLevel to be used n the Backup Job. It defaults to 'info'.",
+          "type": "string"
+        },
+        "mariaDbRef": {
+          "description": "MariaDBRef is a reference to a MariaDB object.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "waitForIt": {
+              "description": "WaitForIt indicates whether the controller using this reference should wait for MariaDB to be ready.",
+              "type": "boolean"
+            }
+          }
+        },
+        "nodeSelector": {
+          "description": "NodeSelector to be used in the Pod.",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "podMetadata": {
+          "description": "PodMetadata defines extra metadata for the Pod.",
+          "type": "object",
+          "properties": {
+            "annotations": {
+              "description": "Annotations to be added to children resources.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            },
+            "labels": {
+              "description": "Labels to be added to children resources.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "podSecurityContext": {
+          "description": "SecurityContext holds pod-level security attributes and common container settings.",
+          "type": "object",
+          "properties": {
+            "appArmorProfile": {
+              "description": "AppArmorProfile defines a pod or container's AppArmor settings.",
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile loaded on the node that should be used.\nThe profile must be preconfigured on the node to work.\nMust match the loaded name of the profile.\nMust be set if and only if type is \"Localhost\".",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of AppArmor profile will be applied.\nValid options are:\n  Localhost - a profile pre-loaded on the node.\n  RuntimeDefault - the container runtime's default profile.\n  Unconfined - no AppArmor enforcement.",
+                  "type": "string"
+                }
+              }
+            },
+            "fsGroup": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "fsGroupChangePolicy": {
+              "description": "PodFSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume\nwhen volume is mounted.",
+              "type": "string"
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "seLinuxOptions": {
+              "description": "SELinuxOptions are the labels to be applied to the container",
+              "type": "object",
+              "properties": {
+                "level": {
+                  "description": "Level is SELinux level label that applies to the container.",
+                  "type": "string"
+                },
+                "role": {
+                  "description": "Role is a SELinux role label that applies to the container.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "Type is a SELinux type label that applies to the container.",
+                  "type": "string"
+                },
+                "user": {
+                  "description": "User is a SELinux user label that applies to the container.",
+                  "type": "string"
+                }
+              }
+            },
+            "seccompProfile": {
+              "description": "SeccompProfile defines a pod/container's seccomp profile settings.\nOnly one profile source may be set.",
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "localhostProfile": {
+                  "description": "localhostProfile indicates a profile defined in a file on the node should be used.\nThe profile must be preconfigured on the node to work.\nMust be a descending path, relative to the kubelet's configured seccomp profile location.\nMust be set if type is \"Localhost\". Must NOT be set for any other type.",
+                  "type": "string"
+                },
+                "type": {
+                  "description": "type indicates which kind of seccomp profile will be applied.\nValid options are:\n\nLocalhost - a profile defined in a file on the node should be used.\nRuntimeDefault - the container runtime default profile should be used.\nUnconfined - no profile should be applied.",
+                  "type": "string"
+                }
+              }
+            },
+            "supplementalGroups": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "x-kubernetes-list-type": "atomic"
+            }
+          }
+        },
+        "priorityClassName": {
+          "description": "PriorityClassName to be used in the Pod.",
+          "type": "string"
+        },
+        "resources": {
+          "description": "Resouces describes the compute resource requirements.",
+          "type": "object",
+          "properties": {
+            "limits": {
+              "description": "ResourceList is a set of (resource name, quantity) pairs.",
+              "type": "object",
+              "additionalProperties": {
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              }
+            },
+            "requests": {
+              "description": "ResourceList is a set of (resource name, quantity) pairs.",
+              "type": "object",
+              "additionalProperties": {
+                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                "x-kubernetes-int-or-string": true
+              }
+            }
+          }
+        },
+        "restartPolicy": {
+          "description": "RestartPolicy to be added to the Backup Job.",
+          "type": "string",
+          "enum": [
+            "Always",
+            "OnFailure",
+            "Never"
+          ]
+        },
+        "s3": {
+          "description": "S3 defines the configuration to restore backups from a S3 compatible storage. It has priority over Volume.",
+          "type": "object",
+          "required": [
+            "bucket",
+            "endpoint"
+          ],
+          "properties": {
+            "accessKeyIdSecretKeyRef": {
+              "description": "AccessKeyIdSecretKeyRef is a reference to a Secret key containing the S3 access key id.",
+              "type": "object",
+              "required": [
+                "key"
+              ],
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-map-type": "atomic"
+            },
+            "bucket": {
+              "description": "Bucket is the name Name of the bucket to store backups.",
+              "type": "string"
+            },
+            "endpoint": {
+              "description": "Endpoint is the S3 API endpoint without scheme.",
+              "type": "string"
+            },
+            "prefix": {
+              "description": "Prefix indicates a folder/subfolder in the bucket. For example: mariadb/ or mariadb/backups. A trailing slash '/' is added if not provided.",
+              "type": "string"
+            },
+            "region": {
+              "description": "Region is the S3 region name to use.",
+              "type": "string"
+            },
+            "secretAccessKeySecretKeyRef": {
+              "description": "AccessKeyIdSecretKeyRef is a reference to a Secret key containing the S3 secret key.",
+              "type": "object",
+              "required": [
+                "key"
+              ],
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-map-type": "atomic"
+            },
+            "sessionTokenSecretKeyRef": {
+              "description": "SessionTokenSecretKeyRef is a reference to a Secret key containing the S3 session token.",
+              "type": "object",
+              "required": [
+                "key"
+              ],
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-map-type": "atomic"
+            },
+            "tls": {
+              "description": "TLS provides the configuration required to establish TLS connections with S3.",
+              "type": "object",
+              "properties": {
+                "caSecretKeyRef": {
+                  "description": "CASecretKeyRef is a reference to a Secret key containing a CA bundle in PEM format used to establish TLS connections with S3.\nBy default, the system trust chain will be used, but you can use this field to add more CAs to the bundle.",
+                  "type": "object",
+                  "required": [
+                    "key"
+                  ],
+                  "properties": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "enabled": {
+                  "description": "Enabled is a flag to enable TLS.",
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        },
+        "securityContext": {
+          "description": "SecurityContext holds security configuration that will be applied to a container.",
+          "type": "object",
+          "properties": {
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
+            "capabilities": {
+              "description": "Adds and removes POSIX capabilities from running containers.",
+              "type": "object",
+              "properties": {
+                "add": {
+                  "description": "Added capabilities",
+                  "type": "array",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "drop": {
+                  "description": "Removed capabilities",
+                  "type": "array",
+                  "items": {
+                    "description": "Capability represent POSIX capabilities type",
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                }
+              }
+            },
+            "privileged": {
+              "type": "boolean"
+            },
+            "readOnlyRootFilesystem": {
+              "type": "boolean"
+            },
+            "runAsGroup": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        "serviceAccountName": {
+          "description": "ServiceAccountName is the name of the ServiceAccount to be used by the Pods.",
+          "type": "string"
+        },
+        "stagingStorage": {
+          "description": "StagingStorage defines the temporary storage used to keep external backups (i.e. S3) while they are being processed.\nIt defaults to an emptyDir volume, meaning that the backups will be temporarily stored in the node where the Restore Job is scheduled.",
+          "type": "object",
+          "properties": {
+            "persistentVolumeClaim": {
+              "description": "PersistentVolumeClaim is a Kubernetes PVC specification.",
+              "type": "object",
+              "properties": {
+                "accessModes": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "resources": {
+                  "description": "VolumeResourceRequirements describes the storage resource requirements for a volume.",
+                  "type": "object",
+                  "properties": {
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "selector": {
+                  "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                  "type": "object",
+                  "properties": {
+                    "matchExpressions": {
+                      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                      "type": "array",
+                      "items": {
+                        "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "operator"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "key is the label key that the selector applies to.",
+                            "type": "string"
+                          },
+                          "operator": {
+                            "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                            "type": "string"
+                          },
+                          "values": {
+                            "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    },
+                    "matchLabels": {
+                      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "x-kubernetes-map-type": "atomic"
+                },
+                "storageClassName": {
+                  "type": "string"
+                }
+              }
+            },
+            "volume": {
+              "description": "Volume is a Kubernetes volume specification.",
+              "type": "object",
+              "properties": {
+                "csi": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#csivolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "driver"
+                  ],
+                  "properties": {
+                    "driver": {
+                      "type": "string"
+                    },
+                    "fsType": {
+                      "type": "string"
+                    },
+                    "nodePublishSecretRef": {
+                      "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "volumeAttributes": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "emptyDir": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#emptydirvolumesource-v1-core.",
+                  "type": "object",
+                  "properties": {
+                    "medium": {
+                      "description": "StorageMedium defines ways that storage can be allocated to a volume.",
+                      "type": "string"
+                    },
+                    "sizeLimit": {
+                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                      "x-kubernetes-int-or-string": true
+                    }
+                  }
+                },
+                "nfs": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nfsvolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "path",
+                    "server"
+                  ],
+                  "properties": {
+                    "path": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
+                    },
+                    "server": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "persistentVolumeClaim": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#persistentvolumeclaimvolumesource-v1-core.",
+                  "type": "object",
+                  "required": [
+                    "claimName"
+                  ],
+                  "properties": {
+                    "claimName": {
+                      "type": "string"
+                    },
+                    "readOnly": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -133,128 +883,198 @@
             }
           }
         },
-        "includeClusterResources": {
-          "description": "IncludeClusterResources specifies whether cluster-scoped resources\nshould be included for consideration in the restore. If null, defaults\nto true."
+        "targetRecoveryTime": {
+          "description": "TargetRecoveryTime is a RFC3339 (1970-01-01T00:00:00Z) date and time that defines the point in time recovery objective.\nIt is used to determine the closest restoration source in time.",
+          "type": "string",
+          "format": "date-time"
         },
-        "includedNamespaces": {
-          "description": "IncludedNamespaces is a slice of namespace names to include objects\nfrom. If empty, all namespaces are included."
-        },
-        "includedResources": {
-          "description": "IncludedResources is a slice of resource names to include\nin the restore. If empty, all resources in the backup are included."
-        },
-        "itemOperationTimeout": {
-          "description": "ItemOperationTimeout specifies the time used to wait for RestoreItemAction operations\nThe default value is 4 hour.",
-          "type": "string"
-        },
-        "labelSelector": {
-          "description": "LabelSelector is a metav1.LabelSelector to filter with\nwhen restoring individual objects from the backup. If empty\nor nil, all objects are included. Optional.",
-          "x-kubernetes-map-type": "atomic"
-        },
-        "namespaceMapping": {
-          "description": "NamespaceMapping is a map of source namespace names\nto target namespace names to restore into. Any source\nnamespaces not included in the map will be restored into\nnamespaces of the same name.",
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
+        "tolerations": {
+          "description": "Tolerations to be used in the Pod.",
+          "type": "array",
+          "items": {
+            "description": "The pod this Toleration is attached to tolerates any taint that matches\nthe triple <key,value,effect> using the matching operator <operator>.",
+            "type": "object",
+            "properties": {
+              "effect": {
+                "description": "Effect indicates the taint effect to match. Empty means match all taint effects.\nWhen specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
+                "type": "string"
+              },
+              "key": {
+                "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys.\nIf the key is empty, operator must be Exists; this combination means to match all values and all keys.",
+                "type": "string"
+              },
+              "operator": {
+                "description": "Operator represents a key's relationship to the value.\nValid operators are Exists and Equal. Defaults to Equal.\nExists is equivalent to wildcard for value, so that a pod can\ntolerate all taints of a particular category.",
+                "type": "string"
+              },
+              "tolerationSeconds": {
+                "description": "TolerationSeconds represents the period of time the toleration (which must be\nof effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,\nit is not set, which means tolerate the taint forever (do not evict). Zero and\nnegative values will be treated as 0 (evict immediately) by the system.",
+                "type": "integer",
+                "format": "int64"
+              },
+              "value": {
+                "description": "Value is the taint value the toleration matches to.\nIf the operator is Exists, the value should be empty, otherwise just a regular string.",
+                "type": "string"
+              }
+            }
           }
         },
-        "orLabelSelectors": {
-          "description": "OrLabelSelectors is list of metav1.LabelSelector to filter with\nwhen restoring individual objects from the backup. If multiple provided\nthey will be joined by the OR operator. LabelSelector as well as\nOrLabelSelectors cannot co-exist in restore request, only one of them\ncan be used"
-        },
-        "preserveNodePorts": {
-          "description": "PreserveNodePorts specifies whether to restore old nodePorts from backup."
-        },
-        "resourceModifier": {
-          "description": "ResourceModifier specifies the reference to JSON resource patches that should be applied to resources before restoration.",
-          "required": [
-            "kind",
-            "name"
-          ],
-          "x-kubernetes-map-type": "atomic"
-        },
-        "restorePVs": {
-          "description": "RestorePVs specifies whether to restore all included\nPVs from snapshot"
-        },
-        "restoreStatus": {
-          "description": "RestoreStatus specifies which resources we should restore the status\nfield. If nil, no objects are included. Optional."
-        },
-        "scheduleName": {
-          "description": "ScheduleName is the unique name of the Velero schedule to restore\nfrom. If specified, and BackupName is empty, Velero will restore\nfrom the most recent successful backup created from this schedule.",
-          "type": "string"
-        },
-        "uploaderConfig": {
-          "description": "UploaderConfig specifies the configuration for the restore."
+        "volume": {
+          "description": "Volume is a Kubernetes Volume object that contains a backup.",
+          "type": "object",
+          "properties": {
+            "csi": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#csivolumesource-v1-core.",
+              "type": "object",
+              "required": [
+                "driver"
+              ],
+              "properties": {
+                "driver": {
+                  "type": "string"
+                },
+                "fsType": {
+                  "type": "string"
+                },
+                "nodePublishSecretRef": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#localobjectreference-v1-core.",
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "readOnly": {
+                  "type": "boolean"
+                },
+                "volumeAttributes": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "emptyDir": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#emptydirvolumesource-v1-core.",
+              "type": "object",
+              "properties": {
+                "medium": {
+                  "description": "StorageMedium defines ways that storage can be allocated to a volume.",
+                  "type": "string"
+                },
+                "sizeLimit": {
+                  "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                  "x-kubernetes-int-or-string": true
+                }
+              }
+            },
+            "nfs": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nfsvolumesource-v1-core.",
+              "type": "object",
+              "required": [
+                "path",
+                "server"
+              ],
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "readOnly": {
+                  "type": "boolean"
+                },
+                "server": {
+                  "type": "string"
+                }
+              }
+            },
+            "persistentVolumeClaim": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#persistentvolumeclaimvolumesource-v1-core.",
+              "type": "object",
+              "required": [
+                "claimName"
+              ],
+              "properties": {
+                "claimName": {
+                  "type": "string"
+                },
+                "readOnly": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
         }
       }
     },
     "status": {
-      "description": "RestoreStatus captures the current status of a Velero restore",
+      "description": "RestoreStatus defines the observed state of restore",
       "type": "object",
       "properties": {
-        "completionTimestamp": {
-          "description": "CompletionTimestamp records the time the restore operation was completed.\nCompletion time is recorded even on failed restore.\nThe server's time is used for StartTimestamps",
-          "format": "date-time"
-        },
-        "errors": {
-          "description": "Errors is a count of all error messages that were generated during\nexecution of the restore. The actual errors are stored in object storage.",
-          "type": "integer"
-        },
-        "failureReason": {
-          "description": "FailureReason is an error that caused the entire restore to fail.",
-          "type": "string"
-        },
-        "hookStatus": {
-          "description": "HookStatus contains information about the status of the hooks."
-        },
-        "phase": {
-          "description": "Phase is the current state of the Restore",
-          "type": "string",
-          "enum": [
-            "New",
-            "FailedValidation",
-            "InProgress",
-            "WaitingForPluginOperations",
-            "WaitingForPluginOperationsPartiallyFailed",
-            "Completed",
-            "PartiallyFailed",
-            "Failed",
-            "Finalizing",
-            "FinalizingPartiallyFailed"
-          ]
-        },
-        "progress": {
-          "description": "Progress contains information about the restore's execution progress. Note\nthat this information is best-effort only -- if Velero fails to update it\nduring a restore for any reason, it may be inaccurate/stale."
-        },
-        "restoreItemOperationsAttempted": {
-          "description": "RestoreItemOperationsAttempted is the total number of attempted\nasync RestoreItemAction operations for this restore.",
-          "type": "integer"
-        },
-        "restoreItemOperationsCompleted": {
-          "description": "RestoreItemOperationsCompleted is the total number of successfully completed\nasync RestoreItemAction operations for this restore.",
-          "type": "integer"
-        },
-        "restoreItemOperationsFailed": {
-          "description": "RestoreItemOperationsFailed is the total number of async\nRestoreItemAction operations for this restore which ended with an error.",
-          "type": "integer"
-        },
-        "startTimestamp": {
-          "description": "StartTimestamp records the time the restore operation was started.\nThe server's time is used for StartTimestamps",
-          "format": "date-time"
-        },
-        "validationErrors": {
-          "description": "ValidationErrors is a slice of all validation errors (if\napplicable)"
-        },
-        "warnings": {
-          "description": "Warnings is a count of all warning messages that were generated during\nexecution of the restore. The actual warnings are stored in object storage.",
-          "type": "integer"
+        "conditions": {
+          "description": "Conditions for the Restore object.",
+          "type": "array",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "type": "object",
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "type": "string",
+                "maxLength": 32768
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "type": "string",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+              }
+            }
+          }
         }
       }
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "velero.io",
+      "group": "k8s.mariadb.com",
       "kind": "Restore",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/restorelist.json
+++ b/class_generator/schema/restorelist.json
@@ -13,7 +13,7 @@
       "description": "List of restores. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/io.velero.v1.Restore"
+        "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.Restore"
       }
     },
     "kind": {
@@ -27,9 +27,9 @@
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "velero.io",
+      "group": "k8s.mariadb.com",
       "kind": "RestoreList",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
   "x-kubernetes-selectable-fields": [],

--- a/class_generator/schema/serviceentry.json
+++ b/class_generator/schema/serviceentry.json
@@ -1,5 +1,8 @@
 {
   "type": "object",
+  "required": [
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -23,51 +26,96 @@
         "addresses": {
           "description": "The virtual IP addresses associated with the service.",
           "type": "array",
+          "maxItems": 256,
           "items": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 64
           }
         },
         "endpoints": {
           "description": "One or more endpoints associated with the service.",
           "type": "array",
+          "maxItems": 4096,
           "items": {
             "type": "object",
             "properties": {
               "address": {
                 "description": "Address associated with the network endpoint without the port.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 256,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "UDS must be an absolute path or abstract socket",
+                    "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                  },
+                  {
+                    "message": "UDS may not be a dir",
+                    "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                  }
+                ]
               },
               "labels": {
                 "description": "One or more labels associated with the endpoint.",
                 "type": "object",
+                "maxProperties": 256,
                 "additionalProperties": {
                   "type": "string"
                 }
               },
               "locality": {
                 "description": "The locality associated with the endpoint.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 2048
               },
               "network": {
                 "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 2048
               },
               "ports": {
                 "description": "Set of ports associated with the endpoint.",
                 "type": "object",
+                "maxProperties": 128,
                 "additionalProperties": {
-                  "type": "integer"
-                }
+                  "type": "integer",
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
+                },
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port name must be valid",
+                    "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                  }
+                ]
               },
               "serviceAccount": {
                 "description": "The service account associated with the workload if a sidecar is present in the workload.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 253
               },
               "weight": {
                 "description": "The load balancing weight associated with the endpoint.",
-                "type": "integer"
+                "type": "integer",
+                "maximum": 4294967295,
+                "minimum": 0
               }
-            }
+            },
+            "x-kubernetes-validations": [
+              {
+                "message": "Address is required",
+                "rule": "has(self.address) || has(self.network)"
+              },
+              {
+                "message": "UDS may not include ports",
+                "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+              }
+            ]
           }
         },
         "exportTo": {
@@ -80,12 +128,20 @@
         "hosts": {
           "description": "The hosts associated with the ServiceEntry.",
           "type": "array",
+          "maxItems": 256,
+          "minItems": 1,
           "items": {
-            "type": "string"
+            "type": "string",
+            "x-kubernetes-validations": [
+              {
+                "message": "hostname cannot be wildcard",
+                "rule": "self != '*'"
+              }
+            ]
           }
         },
         "location": {
-          "description": "Specify whether the service should be considered external to the mesh or part of the mesh.",
+          "description": "Specify whether the service should be considered external to the mesh or part of the mesh.\n\nValid Options: MESH_EXTERNAL, MESH_INTERNAL",
           "type": "string",
           "enum": [
             "MESH_EXTERNAL",
@@ -95,6 +151,7 @@
         "ports": {
           "description": "The ports associated with the external service.",
           "type": "array",
+          "maxItems": 256,
           "items": {
             "type": "object",
             "required": [
@@ -104,25 +161,53 @@
             "properties": {
               "name": {
                 "description": "Label assigned to the port.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 256
               },
               "number": {
                 "description": "A valid non-negative integer port number.",
-                "type": "integer"
+                "type": "integer",
+                "maximum": 4294967295,
+                "minimum": 0,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               },
               "protocol": {
                 "description": "The protocol exposed on the port.",
-                "type": "string"
+                "type": "string",
+                "maxLength": 256
               },
               "targetPort": {
                 "description": "The port number on the endpoint where the traffic will be received.",
-                "type": "integer"
+                "type": "integer",
+                "maximum": 4294967295,
+                "minimum": 0,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
               }
             }
-          }
+          },
+          "x-kubernetes-list-map-keys": [
+            "name"
+          ],
+          "x-kubernetes-list-type": "map",
+          "x-kubernetes-validations": [
+            {
+              "message": "port number cannot be duplicated",
+              "rule": "self.all(l1, self.exists_one(l2, l1.number == l2.number))"
+            }
+          ]
         },
         "resolution": {
-          "description": "Service resolution mode for the hosts.",
+          "description": "Service resolution mode for the hosts.\n\nValid Options: NONE, STATIC, DNS, DNS_ROUND_ROBIN",
           "type": "string",
           "enum": [
             "NONE",
@@ -145,13 +230,39 @@
             "labels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which the configuration should be applied.",
               "type": "object",
+              "maxProperties": 256,
               "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard is not supported in selector",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
               }
             }
           }
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "only one of WorkloadSelector or Endpoints can be set",
+          "rule": "(has(self.workloadSelector)?1:0)+(has(self.endpoints)?1:0)<=1"
+        },
+        {
+          "message": "CIDR addresses are allowed only for NONE/STATIC resolution types",
+          "rule": "!(has(self.addresses) && self.addresses.exists(k, k.contains('/')) && (has(self.resolution) && self.resolution != 'STATIC' && self.resolution != 'NONE'))"
+        },
+        {
+          "message": "NONE mode cannot set endpoints",
+          "rule": "(!has(self.resolution) || self.resolution == 'NONE') ? !has(self.endpoints) : true"
+        },
+        {
+          "message": "DNS_ROUND_ROBIN mode cannot have multiple endpoints",
+          "rule": "(has(self.resolution) && self.resolution == 'DNS_ROUND_ROBIN') ? (!has(self.endpoints) || size(self.endpoints) == 1) : true"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/sidecar.json
+++ b/class_generator/schema/sidecar.json
@@ -31,7 +31,7 @@
                 "type": "string"
               },
               "captureMode": {
-                "description": "When the bind address is an IP, the captureMode option dictates how traffic to the listener is expected to be captured (or not).",
+                "description": "When the bind address is an IP, the captureMode option dictates how traffic to the listener is expected to be captured (or not).\n\nValid Options: DEFAULT, IPTABLES, NONE",
                 "type": "string",
                 "enum": [
                   "DEFAULT",
@@ -56,14 +56,18 @@
                   },
                   "number": {
                     "description": "A valid non-negative integer port number.",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   },
                   "protocol": {
                     "description": "The protocol exposed on the port.",
                     "type": "string"
                   },
                   "targetPort": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   }
                 }
               }
@@ -79,7 +83,7 @@
               "type": "object",
               "properties": {
                 "h2UpgradePolicy": {
-                  "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.",
+                  "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.\n\nValid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE",
                   "type": "string",
                   "enum": [
                     "DEFAULT",
@@ -99,7 +103,18 @@
                 },
                 "idleTimeout": {
                   "description": "The idle timeout for upstream connection pool connections.",
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "must be a valid duration greater than 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "maxConcurrentStreams": {
+                  "description": "The maximum number of concurrent streams allowed for a peer on one HTTP/2 connection.",
+                  "type": "integer",
+                  "format": "int32"
                 },
                 "maxRequestsPerConnection": {
                   "description": "Maximum number of requests per connection to a backend.",
@@ -123,11 +138,27 @@
               "properties": {
                 "connectTimeout": {
                   "description": "TCP connection timeout.",
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "must be a valid duration greater than 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
+                },
+                "idleTimeout": {
+                  "description": "The idle timeout for TCP connections.",
                   "type": "string"
                 },
                 "maxConnectionDuration": {
                   "description": "The maximum duration of a connection.",
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "must be a valid duration greater than 1ms",
+                      "rule": "duration(self) >= duration('1ms')"
+                    }
+                  ]
                 },
                 "maxConnections": {
                   "description": "Maximum number of HTTP1 /TCP connections to a destination host.",
@@ -140,15 +171,29 @@
                   "properties": {
                     "interval": {
                       "description": "The time duration between keep-alive probes.",
-                      "type": "string"
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "must be a valid duration greater than 1ms",
+                          "rule": "duration(self) >= duration('1ms')"
+                        }
+                      ]
                     },
                     "probes": {
                       "description": "Maximum number of keepalive probes to send without response before deciding the connection is dead.",
-                      "type": "integer"
+                      "type": "integer",
+                      "maximum": 4294967295,
+                      "minimum": 0
                     },
                     "time": {
                       "description": "The time duration a connection needs to be idle before keep-alive probes start being sent.",
-                      "type": "string"
+                      "type": "string",
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "must be a valid duration greater than 1ms",
+                          "rule": "duration(self) >= duration('1ms')"
+                        }
+                      ]
                     }
                   }
                 }
@@ -170,7 +215,7 @@
                 "type": "string"
               },
               "captureMode": {
-                "description": "The captureMode option dictates how traffic to the listener is expected to be captured (or not).",
+                "description": "The captureMode option dictates how traffic to the listener is expected to be captured (or not).\n\nValid Options: DEFAULT, IPTABLES, NONE",
                 "type": "string",
                 "enum": [
                   "DEFAULT",
@@ -187,7 +232,7 @@
                     "type": "object",
                     "properties": {
                       "h2UpgradePolicy": {
-                        "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.",
+                        "description": "Specify if http1.1 connection should be upgraded to http2 for the associated destination.\n\nValid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE",
                         "type": "string",
                         "enum": [
                           "DEFAULT",
@@ -207,7 +252,18 @@
                       },
                       "idleTimeout": {
                         "description": "The idle timeout for upstream connection pool connections.",
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
+                      },
+                      "maxConcurrentStreams": {
+                        "description": "The maximum number of concurrent streams allowed for a peer on one HTTP/2 connection.",
+                        "type": "integer",
+                        "format": "int32"
                       },
                       "maxRequestsPerConnection": {
                         "description": "Maximum number of requests per connection to a backend.",
@@ -231,11 +287,27 @@
                     "properties": {
                       "connectTimeout": {
                         "description": "TCP connection timeout.",
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
+                      },
+                      "idleTimeout": {
+                        "description": "The idle timeout for TCP connections.",
                         "type": "string"
                       },
                       "maxConnectionDuration": {
                         "description": "The maximum duration of a connection.",
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       },
                       "maxConnections": {
                         "description": "Maximum number of HTTP1 /TCP connections to a destination host.",
@@ -248,15 +320,29 @@
                         "properties": {
                           "interval": {
                             "description": "The time duration between keep-alive probes.",
-                            "type": "string"
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
                           },
                           "probes": {
                             "description": "Maximum number of keepalive probes to send without response before deciding the connection is dead.",
-                            "type": "integer"
+                            "type": "integer",
+                            "maximum": 4294967295,
+                            "minimum": 0
                           },
                           "time": {
                             "description": "The time duration a connection needs to be idle before keep-alive probes start being sent.",
-                            "type": "string"
+                            "type": "string",
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "must be a valid duration greater than 1ms",
+                                "rule": "duration(self) >= duration('1ms')"
+                              }
+                            ]
                           }
                         }
                       }
@@ -278,14 +364,18 @@
                   },
                   "number": {
                     "description": "A valid non-negative integer port number.",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   },
                   "protocol": {
                     "description": "The protocol exposed on the port.",
                     "type": "string"
                   },
                   "targetPort": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   }
                 }
               },
@@ -295,6 +385,10 @@
                 "properties": {
                   "caCertificates": {
                     "description": "REQUIRED if mode is `MUTUAL` or `OPTIONAL_MUTUAL`.",
+                    "type": "string"
+                  },
+                  "caCrl": {
+                    "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL) to use in verifying a presented client side certificate.",
                     "type": "string"
                   },
                   "cipherSuites": {
@@ -313,7 +407,7 @@
                     "type": "boolean"
                   },
                   "maxProtocolVersion": {
-                    "description": "Optional: Maximum TLS protocol version.",
+                    "description": "Optional: Maximum TLS protocol version.\n\nValid Options: TLS_AUTO, TLSV1_0, TLSV1_1, TLSV1_2, TLSV1_3",
                     "type": "string",
                     "enum": [
                       "TLS_AUTO",
@@ -324,7 +418,7 @@
                     ]
                   },
                   "minProtocolVersion": {
-                    "description": "Optional: Minimum TLS protocol version.",
+                    "description": "Optional: Minimum TLS protocol version.\n\nValid Options: TLS_AUTO, TLSV1_0, TLSV1_1, TLSV1_2, TLSV1_3",
                     "type": "string",
                     "enum": [
                       "TLS_AUTO",
@@ -335,7 +429,7 @@
                     ]
                   },
                   "mode": {
-                    "description": "Optional: Indicates whether connections to this port should be secured using TLS.",
+                    "description": "Optional: Indicates whether connections to this port should be secured using TLS.\n\nValid Options: PASSTHROUGH, SIMPLE, MUTUAL, AUTO_PASSTHROUGH, ISTIO_MUTUAL, OPTIONAL_MUTUAL",
                     "type": "string",
                     "enum": [
                       "PASSTHROUGH",
@@ -381,7 +475,7 @@
           }
         },
         "outboundTrafficPolicy": {
-          "description": "Configuration for the outbound traffic policy.",
+          "description": "Set the default behavior of the sidecar for handling outbound traffic from the application.",
           "type": "object",
           "properties": {
             "egressProxy": {
@@ -399,7 +493,9 @@
                   "type": "object",
                   "properties": {
                     "number": {
-                      "type": "integer"
+                      "type": "integer",
+                      "maximum": 4294967295,
+                      "minimum": 0
                     }
                   }
                 },
@@ -410,6 +506,7 @@
               }
             },
             "mode": {
+              "description": "\n\nValid Options: REGISTRY_ONLY, ALLOW_ANY",
               "type": "string",
               "enum": [
                 "REGISTRY_ONLY",
@@ -425,8 +522,16 @@
             "labels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which the configuration should be applied.",
               "type": "object",
+              "maxProperties": 256,
               "additionalProperties": {
-                "type": "string"
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard is not supported in selector",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
               }
             }
           }

--- a/class_generator/schema/sqljob.json
+++ b/class_generator/schema/sqljob.json
@@ -31,6 +31,167 @@
               "description": "AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.\nMake sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.",
               "type": "boolean"
             },
+            "nodeAffinity": {
+              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeaffinity-v1-core",
+              "type": "object",
+              "properties": {
+                "preferredDuringSchedulingIgnoredDuringExecution": {
+                  "type": "array",
+                  "items": {
+                    "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#preferredschedulingterm-v1-core",
+                    "type": "object",
+                    "required": [
+                      "preference",
+                      "weight"
+                    ],
+                    "properties": {
+                      "preference": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "weight": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  },
+                  "x-kubernetes-list-type": "atomic"
+                },
+                "requiredDuringSchedulingIgnoredDuringExecution": {
+                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselector-v1-core",
+                  "type": "object",
+                  "required": [
+                    "nodeSelectorTerms"
+                  ],
+                  "properties": {
+                    "nodeSelectorTerms": {
+                      "type": "array",
+                      "items": {
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorterm-v1-core",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchFields": {
+                            "type": "array",
+                            "items": {
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#nodeselectorrequirement-v1-core",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "A node selector operator is the set of operators that can be used in\na node selector requirement.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-type": "atomic"
+                    }
+                  }
+                }
+              }
+            },
             "podAntiAffinity": {
               "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podantiaffinity-v1-core.",
               "type": "object",
@@ -53,14 +214,13 @@
                         ],
                         "properties": {
                           "labelSelector": {
-                            "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                            "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                             "type": "object",
                             "properties": {
                               "matchExpressions": {
-                                "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                                 "type": "array",
                                 "items": {
-                                  "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                  "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                                   "type": "object",
                                   "required": [
                                     "key",
@@ -68,15 +228,13 @@
                                   ],
                                   "properties": {
                                     "key": {
-                                      "description": "key is the label key that the selector applies to.",
                                       "type": "string"
                                     },
                                     "operator": {
-                                      "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                      "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                       "type": "string"
                                     },
                                     "values": {
-                                      "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                       "type": "array",
                                       "items": {
                                         "type": "string"
@@ -88,14 +246,12 @@
                                 "x-kubernetes-list-type": "atomic"
                               },
                               "matchLabels": {
-                                "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                                 "type": "object",
                                 "additionalProperties": {
                                   "type": "string"
                                 }
                               }
-                            },
-                            "x-kubernetes-map-type": "atomic"
+                            }
                           },
                           "topologyKey": {
                             "type": "string"
@@ -120,14 +276,13 @@
                     ],
                     "properties": {
                       "labelSelector": {
-                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                        "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselector-v1-meta",
                         "type": "object",
                         "properties": {
                           "matchExpressions": {
-                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
                             "type": "array",
                             "items": {
-                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "description": "Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#labelselectorrequirement-v1-meta",
                               "type": "object",
                               "required": [
                                 "key",
@@ -135,15 +290,13 @@
                               ],
                               "properties": {
                                 "key": {
-                                  "description": "key is the label key that the selector applies to.",
                                   "type": "string"
                                 },
                                 "operator": {
-                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "description": "A label selector operator is the set of operators that can be used in a selector requirement.",
                                   "type": "string"
                                 },
                                 "values": {
-                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
                                   "type": "array",
                                   "items": {
                                     "type": "string"
@@ -155,14 +308,12 @@
                             "x-kubernetes-list-type": "atomic"
                           },
                           "matchLabels": {
-                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
                             "type": "object",
                             "additionalProperties": {
                               "type": "string"
                             }
                           }
-                        },
-                        "x-kubernetes-map-type": "atomic"
+                        }
                       },
                       "topologyKey": {
                         "type": "string"
@@ -527,6 +678,24 @@
           "description": "TimeZone defines the timezone associated with the cron expression.",
           "type": "string"
         },
+        "tlsCASecretRef": {
+          "description": "TLSCACertSecretRef is a reference toa CA Secret used to establish trust when executing the SqlJob.\nIf not provided, the CA bundle provided by the referred MariaDB is used.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        },
+        "tlsClientCertSecretRef": {
+          "description": "TLSClientCertSecretRef is a reference to a Kubernetes TLS Secret used as authentication when executing the SqlJob.\nIf not provided, the client certificate provided by the referred MariaDB is used.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        },
         "tolerations": {
           "description": "Tolerations to be used in the Pod.",
           "type": "array",
@@ -633,5 +802,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/sqljoblist.json
+++ b/class_generator/schema/sqljoblist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/stepaction.json
+++ b/class_generator/schema/stepaction.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/stepactionlist.json
+++ b/class_generator/schema/stepactionlist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/task.json
+++ b/class_generator/schema/task.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tasklist.json
+++ b/class_generator/schema/tasklist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/taskrun.json
+++ b/class_generator/schema/taskrun.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/taskrunlist.json
+++ b/class_generator/schema/taskrunlist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonaddon.json
+++ b/class_generator/schema/tektonaddon.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonaddonlist.json
+++ b/class_generator/schema/tektonaddonlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonchain.json
+++ b/class_generator/schema/tektonchain.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonchainlist.json
+++ b/class_generator/schema/tektonchainlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonconfig.json
+++ b/class_generator/schema/tektonconfig.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonconfiglist.json
+++ b/class_generator/schema/tektonconfiglist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonhub.json
+++ b/class_generator/schema/tektonhub.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonhublist.json
+++ b/class_generator/schema/tektonhublist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektoninstallerset.json
+++ b/class_generator/schema/tektoninstallerset.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektoninstallersetlist.json
+++ b/class_generator/schema/tektoninstallersetlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonpipeline.json
+++ b/class_generator/schema/tektonpipeline.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonpipelinelist.json
+++ b/class_generator/schema/tektonpipelinelist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonresult.json
+++ b/class_generator/schema/tektonresult.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektonresultlist.json
+++ b/class_generator/schema/tektonresultlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektontrigger.json
+++ b/class_generator/schema/tektontrigger.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/tektontriggerlist.json
+++ b/class_generator/schema/tektontriggerlist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/telemetry.json
+++ b/class_generator/schema/telemetry.json
@@ -41,7 +41,7 @@
                 "type": "object",
                 "properties": {
                   "mode": {
-                    "description": "This determines whether or not to apply the access logging configuration based on the direction of traffic relative to the proxied workload.",
+                    "description": "This determines whether or not to apply the access logging configuration based on the direction of traffic relative to the proxied workload.\n\nValid Options: CLIENT_AND_SERVER, CLIENT, SERVER",
                     "type": "string",
                     "enum": [
                       "CLIENT_AND_SERVER",
@@ -62,7 +62,8 @@
                   "properties": {
                     "name": {
                       "description": "Required.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 }
@@ -86,15 +87,16 @@
                       "description": "Optional."
                     },
                     "match": {
-                      "description": "Match allows provides the scope of the override.",
+                      "description": "Match allows providing the scope of the override.",
                       "type": "object",
                       "properties": {
                         "customMetric": {
                           "description": "Allows free-form specification of a metric.",
-                          "type": "string"
+                          "type": "string",
+                          "minLength": 1
                         },
                         "metric": {
-                          "description": "One of the well-known Istio Standard Metrics.",
+                          "description": "One of the well-known [Istio Standard Metrics](https://istio.io/latest/docs/reference/config/metrics/).\n\nValid Options: ALL_METRICS, REQUEST_COUNT, REQUEST_DURATION, REQUEST_SIZE, RESPONSE_SIZE, TCP_OPENED_CONNECTIONS, TCP_CLOSED_CONNECTIONS, TCP_SENT_BYTES, TCP_RECEIVED_BYTES, GRPC_REQUEST_MESSAGES, GRPC_RESPONSE_MESSAGES",
                           "type": "string",
                           "enum": [
                             "ALL_METRICS",
@@ -111,7 +113,7 @@
                           ]
                         },
                         "mode": {
-                          "description": "Controls which mode of metrics generation is selected: CLIENT and/or SERVER.",
+                          "description": "Controls which mode of metrics generation is selected: `CLIENT`, `SERVER`, or `CLIENT_AND_SERVER`.\n\nValid Options: CLIENT_AND_SERVER, CLIENT, SERVER",
                           "type": "string",
                           "enum": [
                             "CLIENT_AND_SERVER",
@@ -128,7 +130,7 @@
                         "type": "object",
                         "properties": {
                           "operation": {
-                            "description": "Operation controls whether or not to update/add a tag, or to remove it.",
+                            "description": "Operation controls whether or not to update/add a tag, or to remove it.\n\nValid Options: UPSERT, REMOVE",
                             "type": "string",
                             "enum": [
                               "UPSERT",
@@ -139,7 +141,17 @@
                             "description": "Value is only considered if the operation is `UPSERT`.",
                             "type": "string"
                           }
-                        }
+                        },
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "value must be set when operation is UPSERT",
+                            "rule": "((has(self.operation) ? self.operation : '') == 'UPSERT') ? self.value != '' : true"
+                          },
+                          {
+                            "message": "value must not be set when operation is REMOVE",
+                            "rule": "((has(self.operation) ? self.operation : '') == 'REMOVE') ? !has(self.value) : true"
+                          }
+                        ]
                       }
                     }
                   }
@@ -156,14 +168,21 @@
                   "properties": {
                     "name": {
                       "description": "Required.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 }
               },
               "reportingInterval": {
                 "description": "Optional.",
-                "type": "string"
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "must be a valid duration greater than 1ms",
+                    "rule": "duration(self) >= duration('1ms')"
+                  }
+                ]
               }
             }
           }
@@ -175,32 +194,121 @@
             "matchLabels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.",
               "type": "object",
+              "maxProperties": 4096,
               "additionalProperties": {
-                "type": "string"
-              }
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard not allowed in label value match",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "wildcard not allowed in label key match",
+                  "rule": "self.all(key, !key.contains('*'))"
+                },
+                {
+                  "message": "key must not be empty",
+                  "rule": "self.all(key, key.size() != 0)"
+                }
+              ]
             }
           }
         },
         "targetRef": {
-          "description": "Optional.",
           "type": "object",
+          "required": [
+            "kind",
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "group is the group of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
             },
             "kind": {
               "description": "kind is kind of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
             },
             "name": {
               "description": "name is the name of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "minLength": 1
             },
             "namespace": {
               "description": "namespace is the namespace of the referent.",
-              "type": "string"
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "cross namespace referencing is not currently supported",
+                  "rule": "self.size() == 0"
+                }
+              ]
             }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+              "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+            }
+          ]
+        },
+        "targetRefs": {
+          "description": "Optional.",
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "name"
+            ],
+            "properties": {
+              "group": {
+                "description": "group is the group of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+              },
+              "kind": {
+                "description": "kind is kind of the target resource.",
+                "type": "string",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+              },
+              "name": {
+                "description": "name is the name of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "minLength": 1
+              },
+              "namespace": {
+                "description": "namespace is the namespace of the referent.",
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "cross namespace referencing is not currently supported",
+                    "rule": "self.size() == 0"
+                  }
+                ]
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+                "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+              }
+            ]
           }
         },
         "tracing": {
@@ -218,6 +326,9 @@
                     "environment": {
                       "description": "Environment adds the value of an environment variable to each span.",
                       "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "defaultValue": {
                           "description": "Optional.",
@@ -225,13 +336,17 @@
                         },
                         "name": {
                           "description": "Name of the environment variable from which to extract the tag value.",
-                          "type": "string"
+                          "type": "string",
+                          "minLength": 1
                         }
                       }
                     },
                     "header": {
                       "description": "RequestHeader adds the value of an header from the request to each span.",
                       "type": "object",
+                      "required": [
+                        "name"
+                      ],
                       "properties": {
                         "defaultValue": {
                           "description": "Optional.",
@@ -239,17 +354,22 @@
                         },
                         "name": {
                           "description": "Name of the header from which to extract the tag value.",
-                          "type": "string"
+                          "type": "string",
+                          "minLength": 1
                         }
                       }
                     },
                     "literal": {
                       "description": "Literal adds the same, hard-coded value to each span.",
                       "type": "object",
+                      "required": [
+                        "value"
+                      ],
                       "properties": {
                         "value": {
                           "description": "The tag value to use.",
-                          "type": "string"
+                          "type": "string",
+                          "minLength": 1
                         }
                       }
                     }
@@ -264,7 +384,7 @@
                 "type": "object",
                 "properties": {
                   "mode": {
-                    "description": "This determines whether or not to apply the tracing configuration based on the direction of traffic relative to the proxied workload.",
+                    "description": "This determines whether or not to apply the tracing configuration based on the direction of traffic relative to the proxied workload.\n\nValid Options: CLIENT_AND_SERVER, CLIENT, SERVER",
                     "type": "string",
                     "enum": [
                       "CLIENT_AND_SERVER",
@@ -285,19 +405,29 @@
                   "properties": {
                     "name": {
                       "description": "Required.",
-                      "type": "string"
+                      "type": "string",
+                      "minLength": 1
                     }
                   }
                 }
               },
               "randomSamplingPercentage": {
-                "description": "Controls the rate at which traffic will be selected for tracing if no prior sampling decision has been made."
+                "description": "Controls the rate at which traffic will be selected for tracing if no prior sampling decision has been made.",
+                "format": "double",
+                "maximum": 100,
+                "minimum": 0
               },
               "useRequestIdForTraceSampling": {}
             }
           }
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "only one of targetRefs or selector can be set",
+          "rule": "(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/trigger.json
+++ b/class_generator/schema/trigger.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/triggerbinding.json
+++ b/class_generator/schema/triggerbinding.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/triggerbindinglist.json
+++ b/class_generator/schema/triggerbindinglist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/triggerlist.json
+++ b/class_generator/schema/triggerlist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/triggertemplate.json
+++ b/class_generator/schema/triggertemplate.json
@@ -7,5 +7,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/triggertemplatelist.json
+++ b/class_generator/schema/triggertemplatelist.json
@@ -32,5 +32,6 @@
       "version": "v1beta1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/user.json
+++ b/class_generator/schema/user.json
@@ -1,47 +1,236 @@
 {
-  "description": "Upon log in, every user of the system receives a User and Identity resource. Administrators may directly manipulate the attributes of the users for their own tracking, or set groups via the API. The user name is unique and is chosen based on the value provided by the identity provider - if a user already exists with the incoming name, the user name may have a number appended to it depending on the configuration of the system.\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "User is the Schema for the users API.  It is used to define grants as if you were running a 'CREATE USER' statement.",
   "type": "object",
-  "required": [
-    "groups"
-  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
       "type": "string"
-    },
-    "fullName": {
-      "description": "FullName is the full name of user",
-      "type": "string"
-    },
-    "groups": {
-      "description": "Groups specifies group names this user is a member of. This field is deprecated and will be removed in a future release. Instead, create a Group object containing the name of this User.",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "identities": {
-      "description": "Identities are the identities associated with this user",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     },
     "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "type": "string"
     },
     "metadata": {
-      "description": "metadata is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
+    "spec": {
+      "description": "UserSpec defines the desired state of User",
+      "type": "object",
+      "required": [
+        "mariaDbRef"
+      ],
+      "properties": {
+        "cleanupPolicy": {
+          "description": "CleanupPolicy defines the behavior for cleaning up a SQL resource.",
+          "type": "string",
+          "enum": [
+            "Skip",
+            "Delete"
+          ]
+        },
+        "host": {
+          "description": "Host related to the User.",
+          "type": "string",
+          "maxLength": 255
+        },
+        "mariaDbRef": {
+          "description": "MariaDBRef is a reference to a MariaDB object.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "waitForIt": {
+              "description": "WaitForIt indicates whether the controller using this reference should wait for MariaDB to be ready.",
+              "type": "boolean"
+            }
+          }
+        },
+        "maxUserConnections": {
+          "description": "MaxUserConnections defines the maximum number of simultaneous connections that the User can establish.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "name": {
+          "description": "Name overrides the default name provided by metadata.name.",
+          "type": "string",
+          "maxLength": 80
+        },
+        "passwordHashSecretKeyRef": {
+          "description": "PasswordHashSecretKeyRef is a reference to the password hash to be used by the User.\nIf the referred Secret is labeled with \"k8s.mariadb.com/watch\", updates may be performed to the Secret in order to update the password hash.",
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "passwordPlugin": {
+          "description": "PasswordPlugin is a reference to the password plugin and arguments to be used by the User.",
+          "type": "object",
+          "properties": {
+            "pluginArgSecretKeyRef": {
+              "description": "PluginArgSecretKeyRef is a reference to the arguments to be provided to the authentication plugin for the User.\nIf the referred Secret is labeled with \"k8s.mariadb.com/watch\", updates may be performed to the Secret in order to update the authentication plugin arguments.",
+              "type": "object",
+              "required": [
+                "key"
+              ],
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-map-type": "atomic"
+            },
+            "pluginNameSecretKeyRef": {
+              "description": "PluginNameSecretKeyRef is a reference to the authentication plugin to be used by the User.\nIf the referred Secret is labeled with \"k8s.mariadb.com/watch\", updates may be performed to the Secret in order to update the authentication plugin.",
+              "type": "object",
+              "required": [
+                "key"
+              ],
+              "properties": {
+                "key": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "x-kubernetes-map-type": "atomic"
+            }
+          }
+        },
+        "passwordSecretKeyRef": {
+          "description": "PasswordSecretKeyRef is a reference to the password to be used by the User.\nIf not provided, the account will be locked and the password will expire.\nIf the referred Secret is labeled with \"k8s.mariadb.com/watch\", updates may be performed to the Secret in order to update the password.",
+          "type": "object",
+          "required": [
+            "key"
+          ],
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "x-kubernetes-map-type": "atomic"
+        },
+        "requeueInterval": {
+          "description": "RequeueInterval is used to perform requeue reconciliations.",
+          "type": "string"
+        },
+        "require": {
+          "description": "Require specifies TLS requirements for the user to connect. See: https://mariadb.com/kb/en/securing-connections-for-client-and-server/#requiring-tls.",
+          "type": "object",
+          "properties": {
+            "issuer": {
+              "description": "Issuer indicates that the TLS certificate provided by the user must be issued by a specific issuer.",
+              "type": "string"
+            },
+            "ssl": {
+              "description": "SSL indicates that the user must connect via TLS.",
+              "type": "boolean"
+            },
+            "subject": {
+              "description": "Subject indicates that the TLS certificate provided by the user must have a specific subject.",
+              "type": "string"
+            },
+            "x509": {
+              "description": "X509 indicates that the user must provide a valid x509 certificate to connect.",
+              "type": "boolean"
+            }
+          }
+        },
+        "retryInterval": {
+          "description": "RetryInterval is the interval used to perform retries.",
+          "type": "string"
+        }
+      }
+    },
+    "status": {
+      "description": "UserStatus defines the observed state of User",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Conditions for the User object.",
+          "type": "array",
+          "items": {
+            "description": "Condition contains details for one aspect of the current state of this API Resource.",
+            "type": "object",
+            "required": [
+              "lastTransitionTime",
+              "message",
+              "reason",
+              "status",
+              "type"
+            ],
+            "properties": {
+              "lastTransitionTime": {
+                "description": "lastTransitionTime is the last time the condition transitioned from one status to another.\nThis should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "message is a human readable message indicating details about the transition.\nThis may be an empty string.",
+                "type": "string",
+                "maxLength": 32768
+              },
+              "observedGeneration": {
+                "description": "observedGeneration represents the .metadata.generation that the condition was set based upon.\nFor instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date\nwith respect to the current state of the instance.",
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0
+              },
+              "reason": {
+                "description": "reason contains a programmatic identifier indicating the reason for the condition's last transition.\nProducers of specific condition types may define expected values and meanings for this field,\nand whether the values are considered a guaranteed API.\nThe value should be a CamelCase string.\nThis field may not be empty.",
+                "type": "string",
+                "maxLength": 1024,
+                "minLength": 1,
+                "pattern": "^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$"
+              },
+              "status": {
+                "description": "status of the condition, one of True, False, Unknown.",
+                "type": "string",
+                "enum": [
+                  "True",
+                  "False",
+                  "Unknown"
+                ]
+              },
+              "type": {
+                "description": "type of condition in CamelCase or in foo.example.com/CamelCase.",
+                "type": "string",
+                "maxLength": 316,
+                "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "user.openshift.io",
+      "group": "k8s.mariadb.com",
       "kind": "User",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/userlist.json
+++ b/class_generator/schema/userlist.json
@@ -1,5 +1,5 @@
 {
-  "description": "UserList is a collection of Users\n\nCompatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).",
+  "description": "UserList is a list of User",
   "type": "object",
   "required": [
     "items"
@@ -10,10 +10,10 @@
       "type": "string"
     },
     "items": {
-      "description": "Items is the list of users",
+      "description": "List of users. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
       "type": "array",
       "items": {
-        "$ref": "_definitions.json#/definitions/com.github.openshift.api.user.v1.User"
+        "$ref": "_definitions.json#/definitions/com.mariadb.k8s.v1alpha1.User"
       }
     },
     "kind": {
@@ -21,16 +21,17 @@
       "type": "string"
     },
     "metadata": {
-      "description": "metadata is the standard list's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
     }
   },
   "x-kubernetes-group-version-kind": [
     {
-      "group": "user.openshift.io",
+      "group": "k8s.mariadb.com",
       "kind": "UserList",
-      "version": "v1"
+      "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/verificationpolicy.json
+++ b/class_generator/schema/verificationpolicy.json
@@ -7,5 +7,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/verificationpolicylist.json
+++ b/class_generator/schema/verificationpolicylist.json
@@ -32,5 +32,6 @@
       "version": "v1alpha1"
     }
   ],
+  "x-kubernetes-selectable-fields": [],
   "$schema": "http://json-schema.org/schema#"
 }

--- a/class_generator/schema/virtualservice.json
+++ b/class_generator/schema/virtualservice.json
@@ -84,7 +84,7 @@
                           "type": "string"
                         },
                         "regex": {
-                          "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                          "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                           "type": "string"
                         }
                       }
@@ -99,7 +99,22 @@
                   },
                   "maxAge": {
                     "description": "Specifies how long the results of a preflight request can be cached.",
-                    "type": "string"
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "must be a valid duration greater than 1ms",
+                        "rule": "duration(self) >= duration('1ms')"
+                      }
+                    ]
+                  },
+                  "unmatchedPreflights": {
+                    "description": "Indicates whether preflight requests not matching the configured allowed origin shouldn't be forwarded to the upstream.\n\nValid Options: FORWARD, IGNORE",
+                    "type": "string",
+                    "enum": [
+                      "UNSPECIFIED",
+                      "FORWARD",
+                      "IGNORE"
+                    ]
                   }
                 }
               },
@@ -140,7 +155,9 @@
                   },
                   "status": {
                     "description": "Specifies the HTTP response status to be returned.",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   }
                 }
               },
@@ -181,11 +198,23 @@
                     "type": "object",
                     "properties": {
                       "exponentialDelay": {
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       },
                       "fixedDelay": {
                         "description": "Add a fixed delay before forwarding the request.",
-                        "type": "string"
+                        "type": "string",
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "must be a valid duration greater than 1ms",
+                            "rule": "duration(self) >= duration('1ms')"
+                          }
+                        ]
                       },
                       "percent": {
                         "description": "Percentage of requests on which the delay will be injected (0-100).",
@@ -264,7 +293,7 @@
                   "type": "object",
                   "properties": {
                     "authority": {
-                      "description": "HTTP Authority values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                      "description": "HTTP Authority values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                       "type": "object",
                       "properties": {
                         "exact": {
@@ -274,7 +303,7 @@
                           "type": "string"
                         },
                         "regex": {
-                          "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                          "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                           "type": "string"
                         }
                       }
@@ -299,7 +328,7 @@
                             "type": "string"
                           },
                           "regex": {
-                            "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                            "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                             "type": "string"
                           }
                         }
@@ -310,7 +339,7 @@
                       "type": "boolean"
                     },
                     "method": {
-                      "description": "HTTP Method values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                      "description": "HTTP Method values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                       "type": "object",
                       "properties": {
                         "exact": {
@@ -320,7 +349,7 @@
                           "type": "string"
                         },
                         "regex": {
-                          "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                          "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                           "type": "string"
                         }
                       }
@@ -331,7 +360,9 @@
                     },
                     "port": {
                       "description": "Specifies the ports on the host that is being addressed.",
-                      "type": "integer"
+                      "type": "integer",
+                      "maximum": 4294967295,
+                      "minimum": 0
                     },
                     "queryParams": {
                       "description": "Query parameters for matching.",
@@ -346,14 +377,14 @@
                             "type": "string"
                           },
                           "regex": {
-                            "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                            "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                             "type": "string"
                           }
                         }
                       }
                     },
                     "scheme": {
-                      "description": "URI Scheme values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                      "description": "URI Scheme values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                       "type": "object",
                       "properties": {
                         "exact": {
@@ -363,7 +394,7 @@
                           "type": "string"
                         },
                         "regex": {
-                          "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                          "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                           "type": "string"
                         }
                       }
@@ -384,7 +415,7 @@
                       "type": "string"
                     },
                     "uri": {
-                      "description": "URI to match values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                      "description": "URI to match values are case-sensitive and formatted as follows: - `exact: \"value\"` for exact string match - `prefix: \"value\"` for prefix-based match - `regex: \"value\"` for [RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                       "type": "object",
                       "properties": {
                         "exact": {
@@ -394,7 +425,7 @@
                           "type": "string"
                         },
                         "regex": {
-                          "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                          "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                           "type": "string"
                         }
                       }
@@ -412,7 +443,7 @@
                             "type": "string"
                           },
                           "regex": {
-                            "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                            "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                             "type": "string"
                           }
                         }
@@ -437,7 +468,9 @@
                     "type": "object",
                     "properties": {
                       "number": {
-                        "type": "integer"
+                        "type": "integer",
+                        "maximum": 4294967295,
+                        "minimum": 0
                       }
                     }
                   },
@@ -447,7 +480,10 @@
                   }
                 }
               },
-              "mirrorPercent": {},
+              "mirrorPercent": {
+                "maximum": 4294967295,
+                "minimum": 0
+              },
               "mirrorPercentage": {
                 "description": "Percentage of the traffic to be mirrored by the `mirror` field.",
                 "type": "object",
@@ -458,7 +494,10 @@
                   }
                 }
               },
-              "mirror_percent": {},
+              "mirror_percent": {
+                "maximum": 4294967295,
+                "minimum": 0
+              },
               "mirrors": {
                 "description": "Specifies the destinations to mirror HTTP traffic in addition to the original destination.",
                 "type": "array",
@@ -484,7 +523,9 @@
                           "type": "object",
                           "properties": {
                             "number": {
-                              "type": "integer"
+                              "type": "integer",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             }
                           }
                         },
@@ -520,7 +561,7 @@
                     "type": "string"
                   },
                   "derivePort": {
-                    "description": "On a redirect, dynamically set the port: * FROM_PROTOCOL_DEFAULT: automatically set to 80 for HTTP and 443 for HTTPS.",
+                    "description": "On a redirect, dynamically set the port: * FROM_PROTOCOL_DEFAULT: automatically set to 80 for HTTP and 443 for HTTPS.\n\nValid Options: FROM_PROTOCOL_DEFAULT, FROM_REQUEST_PORT",
                     "type": "string",
                     "enum": [
                       "FROM_PROTOCOL_DEFAULT",
@@ -529,11 +570,15 @@
                   },
                   "port": {
                     "description": "On a redirect, overwrite the port portion of the URL with this value.",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   },
                   "redirectCode": {
                     "description": "On a redirect, Specifies the HTTP status code to use in the redirect response.",
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 4294967295,
+                    "minimum": 0
                   },
                   "scheme": {
                     "description": "On a redirect, overwrite the scheme portion of the URL with this value.",
@@ -556,7 +601,13 @@
                   },
                   "perTryTimeout": {
                     "description": "Timeout per attempt for a given request, including the initial call and any retries.",
-                    "type": "string"
+                    "type": "string",
+                    "x-kubernetes-validations": [
+                      {
+                        "message": "must be a valid duration greater than 1ms",
+                        "rule": "duration(self) >= duration('1ms')"
+                      }
+                    ]
                   },
                   "retryOn": {
                     "description": "Specifies the conditions under which retry takes place.",
@@ -584,7 +635,7 @@
                     "type": "object",
                     "properties": {
                       "match": {
-                        "description": "RE2 style regex-based match (https://github.com/google/re2/wiki/Syntax).",
+                        "description": "[RE2 style regex-based match](https://github.com/google/re2/wiki/Syntax).",
                         "type": "string"
                       },
                       "rewrite": {
@@ -620,7 +671,9 @@
                           "type": "object",
                           "properties": {
                             "number": {
-                              "type": "integer"
+                              "type": "integer",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             }
                           }
                         },
@@ -691,7 +744,13 @@
               },
               "timeout": {
                 "description": "Timeout for HTTP requests, default is disabled.",
-                "type": "string"
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "must be a valid duration greater than 1ms",
+                    "rule": "duration(self) >= duration('1ms')"
+                  }
+                ]
               }
             }
           }
@@ -724,7 +783,9 @@
                     },
                     "port": {
                       "description": "Specifies the port on the host that is being addressed.",
-                      "type": "integer"
+                      "type": "integer",
+                      "maximum": 4294967295,
+                      "minimum": 0
                     },
                     "sourceLabels": {
                       "description": "One or more labels that constrain the applicability of a rule to workloads with the given labels.",
@@ -768,7 +829,9 @@
                           "type": "object",
                           "properties": {
                             "number": {
-                              "type": "integer"
+                              "type": "integer",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             }
                           }
                         },
@@ -823,7 +886,9 @@
                     },
                     "port": {
                       "description": "Specifies the port on the host that is being addressed.",
-                      "type": "integer"
+                      "type": "integer",
+                      "maximum": 4294967295,
+                      "minimum": 0
                     },
                     "sniHosts": {
                       "description": "SNI (server name indicator) to match on.",
@@ -871,7 +936,9 @@
                           "type": "object",
                           "properties": {
                             "number": {
-                              "type": "integer"
+                              "type": "integer",
+                              "maximum": 4294967295,
+                              "minimum": 0
                             }
                           }
                         },

--- a/class_generator/schema/wasmplugin.json
+++ b/class_generator/schema/wasmplugin.json
@@ -24,7 +24,7 @@
       ],
       "properties": {
         "failStrategy": {
-          "description": "Specifies the failure behavior for the plugin due to fatal errors.",
+          "description": "Specifies the failure behavior for the plugin due to fatal errors.\n\nValid Options: FAIL_CLOSE, FAIL_OPEN",
           "type": "string",
           "enum": [
             "FAIL_CLOSE",
@@ -32,7 +32,7 @@
           ]
         },
         "imagePullPolicy": {
-          "description": "The pull behaviour to be applied when fetching Wasm module by either OCI image or http/https.",
+          "description": "The pull behaviour to be applied when fetching Wasm module by either OCI image or `http/https`.\n\nValid Options: IfNotPresent, Always",
           "type": "string",
           "enum": [
             "UNSPECIFIED_POLICY",
@@ -53,7 +53,7 @@
             "type": "object",
             "properties": {
               "mode": {
-                "description": "Criteria for selecting traffic by their direction.",
+                "description": "Criteria for selecting traffic by their direction.\n\nValid Options: CLIENT, SERVER, CLIENT_AND_SERVER",
                 "type": "string",
                 "enum": [
                   "UNDEFINED",
@@ -87,7 +87,7 @@
           }
         },
         "phase": {
-          "description": "Determines where in the filter chain this `WasmPlugin` is to be injected.",
+          "description": "Determines where in the filter chain this `WasmPlugin` is to be injected.\n\nValid Options: AUTHN, AUTHZ, STATS",
           "type": "string",
           "enum": [
             "UNSPECIFIED_PHASE",
@@ -107,7 +107,8 @@
           "minLength": 1
         },
         "priority": {
-          "description": "Determines ordering of `WasmPlugins` in the same `phase`."
+          "description": "Determines ordering of `WasmPlugins` in the same `phase`.",
+          "format": "int32"
         },
         "selector": {
           "description": "Criteria used to select the specific set of pods/VMs on which this plugin configuration should be applied.",
@@ -116,9 +117,27 @@
             "matchLabels": {
               "description": "One or more labels that indicate a specific set of pods/VMs on which a policy should be applied.",
               "type": "object",
+              "maxProperties": 4096,
               "additionalProperties": {
-                "type": "string"
-              }
+                "type": "string",
+                "maxLength": 63,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "wildcard not allowed in label value match",
+                    "rule": "!self.contains('*')"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "wildcard not allowed in label key match",
+                  "rule": "self.all(key, !key.contains('*'))"
+                },
+                {
+                  "message": "key must not be empty",
+                  "rule": "self.all(key, key.size() != 0)"
+                }
+              ]
             }
           }
         },
@@ -128,29 +147,100 @@
           "pattern": "(^$|^[a-f0-9]{64}$)"
         },
         "targetRef": {
-          "description": "Optional.",
           "type": "object",
+          "required": [
+            "kind",
+            "name"
+          ],
           "properties": {
             "group": {
               "description": "group is the group of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
             },
             "kind": {
               "description": "kind is kind of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 63,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
             },
             "name": {
               "description": "name is the name of the target resource.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253,
+              "minLength": 1
             },
             "namespace": {
               "description": "namespace is the namespace of the referent.",
-              "type": "string"
+              "type": "string",
+              "x-kubernetes-validations": [
+                {
+                  "message": "cross namespace referencing is not currently supported",
+                  "rule": "self.size() == 0"
+                }
+              ]
             }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+              "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+            }
+          ]
+        },
+        "targetRefs": {
+          "description": "Optional.",
+          "type": "array",
+          "maxItems": 16,
+          "items": {
+            "type": "object",
+            "required": [
+              "kind",
+              "name"
+            ],
+            "properties": {
+              "group": {
+                "description": "group is the group of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "pattern": "^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+              },
+              "kind": {
+                "description": "kind is kind of the target resource.",
+                "type": "string",
+                "maxLength": 63,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$"
+              },
+              "name": {
+                "description": "name is the name of the target resource.",
+                "type": "string",
+                "maxLength": 253,
+                "minLength": 1
+              },
+              "namespace": {
+                "description": "namespace is the namespace of the referent.",
+                "type": "string",
+                "x-kubernetes-validations": [
+                  {
+                    "message": "cross namespace referencing is not currently supported",
+                    "rule": "self.size() == 0"
+                  }
+                ]
+              }
+            },
+            "x-kubernetes-validations": [
+              {
+                "message": "Support kinds are core/Service, networking.istio.io/ServiceEntry, gateway.networking.k8s.io/Gateway",
+                "rule": "[self.group, self.kind] in [['core','Service'], ['','Service'], ['gateway.networking.k8s.io','Gateway'], ['networking.istio.io','ServiceEntry']]"
+              }
+            ]
           }
         },
         "type": {
-          "description": "Specifies the type of Wasm Extension to be used.",
+          "description": "Specifies the type of Wasm Extension to be used.\n\nValid Options: HTTP, NETWORK",
           "type": "string",
           "enum": [
             "UNSPECIFIED_PLUGIN_TYPE",
@@ -161,7 +251,13 @@
         "url": {
           "description": "URL of a Wasm module or OCI container.",
           "type": "string",
-          "minLength": 1
+          "minLength": 1,
+          "x-kubernetes-validations": [
+            {
+              "message": "url must have schema one of [http, https, file, oci]",
+              "rule": "isURL(self) ? (url(self).getScheme() in ['', 'http', 'https', 'oci', 'file']) : (isURL('http://' + self) && url('http://' +self).getScheme() in ['', 'http', 'https', 'oci', 'file'])"
+            }
+          ]
         },
         "verificationKey": {
           "type": "string"
@@ -192,14 +288,20 @@
                     "maxLength": 2048
                   },
                   "valueFrom": {
-                    "description": "Source for the environment variable's value.",
+                    "description": "Source for the environment variable's value.\n\nValid Options: INLINE, HOST",
                     "type": "string",
                     "enum": [
                       "INLINE",
                       "HOST"
                     ]
                   }
-                }
+                },
+                "x-kubernetes-validations": [
+                  {
+                    "message": "value may only be set when valueFrom is INLINE",
+                    "rule": "(has(self.valueFrom) ? self.valueFrom : '') != 'HOST' || !has(self.value)"
+                  }
+                ]
               },
               "x-kubernetes-list-map-keys": [
                 "name"
@@ -208,7 +310,13 @@
             }
           }
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "only one of targetRefs or selector can be set",
+          "rule": "(has(self.selector)?1:0)+(has(self.targetRef)?1:0)+(has(self.targetRefs)?1:0)<=1"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/workbenches.json
+++ b/class_generator/schema/workbenches.json
@@ -49,7 +49,13 @@
           "description": "Namespace for workbenches to be installed, configurable only once when workbenches are enabled, defaults to \"rhods-notebooks\"",
           "type": "string",
           "maxLength": 63,
-          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$"
+          "pattern": "^([a-z0-9]([-a-z0-9]*[a-z0-9])?)?$",
+          "x-kubernetes-validations": [
+            {
+              "message": "WorkbenchNamespace is immutable",
+              "rule": "self == oldSelf"
+            }
+          ]
         }
       }
     },

--- a/class_generator/schema/workloadentry.json
+++ b/class_generator/schema/workloadentry.json
@@ -1,5 +1,8 @@
 {
   "type": "object",
+  "required": [
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -19,39 +22,81 @@
       "properties": {
         "address": {
           "description": "Address associated with the network endpoint without the port.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 256,
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS must be an absolute path or abstract socket",
+              "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+            },
+            {
+              "message": "UDS may not be a dir",
+              "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+            }
+          ]
         },
         "labels": {
           "description": "One or more labels associated with the endpoint.",
           "type": "object",
+          "maxProperties": 256,
           "additionalProperties": {
             "type": "string"
           }
         },
         "locality": {
           "description": "The locality associated with the endpoint.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 2048
         },
         "network": {
           "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 2048
         },
         "ports": {
           "description": "Set of ports associated with the endpoint.",
           "type": "object",
+          "maxProperties": 128,
           "additionalProperties": {
-            "type": "integer"
-          }
+            "type": "integer",
+            "maximum": 4294967295,
+            "minimum": 0,
+            "x-kubernetes-validations": [
+              {
+                "message": "port must be between 1-65535",
+                "rule": "0 < self && self <= 65535"
+              }
+            ]
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "port name must be valid",
+              "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+            }
+          ]
         },
         "serviceAccount": {
           "description": "The service account associated with the workload if a sidecar is present in the workload.",
-          "type": "string"
+          "type": "string",
+          "maxLength": 253
         },
         "weight": {
           "description": "The load balancing weight associated with the endpoint.",
-          "type": "integer"
+          "type": "integer",
+          "maximum": 4294967295,
+          "minimum": 0
         }
-      }
+      },
+      "x-kubernetes-validations": [
+        {
+          "message": "Address is required",
+          "rule": "has(self.address) || has(self.network)"
+        },
+        {
+          "message": "UDS may not include ports",
+          "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+        }
+      ]
     },
     "status": {
       "x-kubernetes-preserve-unknown-fields": true

--- a/class_generator/schema/workloadgroup.json
+++ b/class_generator/schema/workloadgroup.json
@@ -1,5 +1,8 @@
 {
   "type": "object",
+  "required": [
+    "spec"
+  ],
   "properties": {
     "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
@@ -14,7 +17,7 @@
       "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
     },
     "spec": {
-      "description": "`WorkloadGroup` enables specifying the properties of a single workload for bootstrap and provides a template for `WorkloadEntry`, similar to how `Deployment` specifies properties of workloads via `Pod` templates.",
+      "description": "Describes a collection of workload instances. See more details at: https://istio.io/docs/reference/config/networking/workload-group.html",
       "type": "object",
       "required": [
         "template"
@@ -26,12 +29,14 @@
           "properties": {
             "annotations": {
               "type": "object",
+              "maxProperties": 256,
               "additionalProperties": {
                 "type": "string"
               }
             },
             "labels": {
               "type": "object",
+              "maxProperties": 256,
               "additionalProperties": {
                 "type": "string"
               }
@@ -45,12 +50,16 @@
             "exec": {
               "description": "Health is determined by how the command that is executed exited.",
               "type": "object",
+              "required": [
+                "command"
+              ],
               "properties": {
                 "command": {
                   "description": "Command to run.",
                   "type": "array",
                   "items": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1
                   }
                 }
               }
@@ -58,7 +67,8 @@
             "failureThreshold": {
               "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.",
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "minimum": 0
             },
             "httpGet": {
               "description": "`httpGet` is performed to a given endpoint and the status/able to connect determines health.",
@@ -78,7 +88,8 @@
                     "type": "object",
                     "properties": {
                       "name": {
-                        "type": "string"
+                        "type": "string",
+                        "pattern": "^[-_A-Za-z0-9]+$"
                       },
                       "value": {
                         "type": "string"
@@ -92,27 +103,44 @@
                 },
                 "port": {
                   "description": "Port on which the endpoint lives.",
-                  "type": "integer"
+                  "type": "integer",
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 },
                 "scheme": {
-                  "type": "string"
+                  "type": "string",
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "scheme must be one of [HTTP, HTTPS]",
+                      "rule": "self in ['', 'HTTP', 'HTTPS']"
+                    }
+                  ]
                 }
               }
             },
             "initialDelaySeconds": {
               "description": "Number of seconds after the container has started before readiness probes are initiated.",
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "minimum": 0
             },
             "periodSeconds": {
               "description": "How often (in seconds) to perform the probe.",
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "minimum": 0
             },
             "successThreshold": {
               "description": "Minimum consecutive successes for the probe to be considered successful after having failed.",
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "minimum": 0
             },
             "tcpSocket": {
               "description": "Health is determined by if the proxy is able to connect.",
@@ -125,14 +153,23 @@
                   "type": "string"
                 },
                 "port": {
-                  "type": "integer"
+                  "type": "integer",
+                  "maximum": 4294967295,
+                  "minimum": 0,
+                  "x-kubernetes-validations": [
+                    {
+                      "message": "port must be between 1-65535",
+                      "rule": "0 < self && self <= 65535"
+                    }
+                  ]
                 }
               }
             },
             "timeoutSeconds": {
               "description": "Number of seconds after which the probe times out.",
               "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "minimum": 0
             }
           }
         },
@@ -142,39 +179,77 @@
           "properties": {
             "address": {
               "description": "Address associated with the network endpoint without the port.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 256,
+              "x-kubernetes-validations": [
+                {
+                  "message": "UDS must be an absolute path or abstract socket",
+                  "rule": "self.startsWith('unix://') ? (self.substring(7,8) == '/' || self.substring(7,8) == '@') : true"
+                },
+                {
+                  "message": "UDS may not be a dir",
+                  "rule": "self.startsWith('unix://') ? !self.endsWith('/') : true"
+                }
+              ]
             },
             "labels": {
               "description": "One or more labels associated with the endpoint.",
               "type": "object",
+              "maxProperties": 256,
               "additionalProperties": {
                 "type": "string"
               }
             },
             "locality": {
               "description": "The locality associated with the endpoint.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 2048
             },
             "network": {
               "description": "Network enables Istio to group endpoints resident in the same L3 domain/network.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 2048
             },
             "ports": {
               "description": "Set of ports associated with the endpoint.",
               "type": "object",
+              "maxProperties": 128,
               "additionalProperties": {
-                "type": "integer"
-              }
+                "type": "integer",
+                "maximum": 4294967295,
+                "minimum": 0,
+                "x-kubernetes-validations": [
+                  {
+                    "message": "port must be between 1-65535",
+                    "rule": "0 < self && self <= 65535"
+                  }
+                ]
+              },
+              "x-kubernetes-validations": [
+                {
+                  "message": "port name must be valid",
+                  "rule": "self.all(key, size(key) < 63 && key.matches('^[a-zA-Z0-9](?:[-a-zA-Z0-9]*[a-zA-Z0-9])?$'))"
+                }
+              ]
             },
             "serviceAccount": {
               "description": "The service account associated with the workload if a sidecar is present in the workload.",
-              "type": "string"
+              "type": "string",
+              "maxLength": 253
             },
             "weight": {
               "description": "The load balancing weight associated with the endpoint.",
-              "type": "integer"
+              "type": "integer",
+              "maximum": 4294967295,
+              "minimum": 0
             }
-          }
+          },
+          "x-kubernetes-validations": [
+            {
+              "message": "UDS may not include ports",
+              "rule": "(has(self.address) && self.address.startsWith('unix://')) ? !has(self.ports) : true"
+            }
+          ]
         }
       }
     },

--- a/class_generator/schema/ztunnel.json
+++ b/class_generator/schema/ztunnel.json
@@ -1,0 +1,4037 @@
+{
+  "description": "ZTunnel represents a deployment of the Istio ztunnel component.",
+  "type": "object",
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
+    },
+    "spec": {
+      "description": "ZTunnelSpec defines the desired state of ZTunnel",
+      "type": "object",
+      "required": [
+        "namespace",
+        "version"
+      ],
+      "properties": {
+        "namespace": {
+          "description": "Namespace to which the Istio ztunnel component should be installed.",
+          "type": "string"
+        },
+        "profile": {
+          "description": "The built-in installation configuration profile to use.\nThe 'default' profile is 'ambient' and it is always applied.\nMust be one of: ambient, default, demo, empty, external, preview, remote, stable.",
+          "type": "string",
+          "enum": [
+            "ambient",
+            "default",
+            "demo",
+            "empty",
+            "external",
+            "openshift-ambient",
+            "openshift",
+            "preview",
+            "remote",
+            "stable"
+          ]
+        },
+        "values": {
+          "description": "Defines the values to be passed to the Helm charts when installing Istio ztunnel.",
+          "type": "object",
+          "properties": {
+            "global": {
+              "description": "Part of the global configuration applicable to the Istio ztunnel component.",
+              "type": "object",
+              "properties": {
+                "defaultResources": {
+                  "description": "See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#resource-requests-and-limits-of-pod-and-container\n\nDeprecated: Marked as deprecated in pkg/apis/values_types.proto.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "hub": {
+                  "description": "Specifies the docker hub for Istio images.",
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "Specifies the image pull policy for the Istio images. one of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.\n\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ]
+                },
+                "imagePullSecrets": {
+                  "description": "ImagePullSecrets for the control plane ServiceAccount, list of secrets in the same namespace\nto use for pulling any images in pods that reference this ServiceAccount.\nMust be set for any cluster configured with private docker registry.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "logAsJson": {
+                  "description": "Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.",
+                  "type": "boolean"
+                },
+                "logging": {
+                  "description": "Specifies the global logging level settings for the Istio control plane components.",
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "description": "Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>\nThe control plane has different scopes depending on component, but can configure default log level across all components\nIf empty, default scope and level will be used as configured in code",
+                      "type": "string"
+                    }
+                  }
+                },
+                "platform": {
+                  "description": "Platform in which Istio is deployed. Possible values are: \"openshift\" and \"gcp\"\nAn empty value means it is a vanilla Kubernetes distribution, therefore no special\ntreatment will be considered.",
+                  "type": "string"
+                },
+                "tag": {
+                  "description": "Specifies the tag for the Istio docker images.",
+                  "type": "string"
+                },
+                "variant": {
+                  "description": "The variant of the Istio container images to use. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                }
+              }
+            },
+            "ztunnel": {
+              "description": "Configuration for the Istio ztunnel plugin.",
+              "type": "object",
+              "properties": {
+                "Annotations": {
+                  "description": "Annotations to apply to all top level resources",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "Labels": {
+                  "description": "Labels to apply to all top level resources",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "caAddress": {
+                  "description": "The address of the CA for CSR.",
+                  "type": "string"
+                },
+                "env": {
+                  "description": "A `key: value` mapping of environment variables to add to the pod",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "hub": {
+                  "description": "Hub to pull the container image from. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "image": {
+                  "description": "Image name to pull from. Image will be `Hub/Image:Tag-Variant`.\nIf Image contains a \"/\", it will replace the entire `image` in the pod.",
+                  "type": "string"
+                },
+                "imagePullPolicy": {
+                  "description": "Specifies the image pull policy for the Istio images. one of Always, Never, IfNotPresent.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated.\n\nMore info: https://kubernetes.io/docs/concepts/containers/images#updating-images",
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "Never",
+                    "IfNotPresent"
+                  ]
+                },
+                "imagePullSecrets": {
+                  "description": "List of secret names to add to the service account as image pull secrets\nto use for pulling any images in pods that reference this ServiceAccount.\nMust be set for any cluster configured with private docker registry.",
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "istioNamespace": {
+                  "description": "Specifies the default namespace for the Istio control plane components.",
+                  "type": "string"
+                },
+                "logAsJson": {
+                  "description": "Specifies whether istio components should output logs in json format by adding --log_as_json argument to each container.",
+                  "type": "boolean"
+                },
+                "logging": {
+                  "description": "Same as `global.logging.level`, but will override it if set",
+                  "type": "object",
+                  "properties": {
+                    "level": {
+                      "description": "Comma-separated minimum per-scope logging level of messages to output, in the form of <scope>:<level>,<scope>:<level>\nThe control plane has different scopes depending on component, but can configure default log level across all components\nIf empty, default scope and level will be used as configured in code",
+                      "type": "string"
+                    }
+                  }
+                },
+                "meshConfig": {
+                  "description": "meshConfig defines runtime configuration of components.\nFor ztunnel, only defaultConfig is used, but this is nested under `meshConfig` for consistency with other components.",
+                  "type": "object",
+                  "properties": {
+                    "accessLogEncoding": {
+                      "description": "Encoding for the proxy access log (`TEXT` or `JSON`).\nDefault value is `TEXT`.",
+                      "type": "string",
+                      "enum": [
+                        "TEXT",
+                        "JSON"
+                      ]
+                    },
+                    "accessLogFile": {
+                      "description": "File address for the proxy access log (e.g. /dev/stdout).\nEmpty value disables access logging.",
+                      "type": "string"
+                    },
+                    "accessLogFormat": {
+                      "description": "Format for the proxy access log\nEmpty value results in proxy's default access log format",
+                      "type": "string"
+                    },
+                    "ca": {
+                      "description": "If specified, Istiod will authorize and forward the CSRs from the workloads to the specified external CA\nusing the Istio CA gRPC API.",
+                      "type": "object",
+                      "required": [
+                        "address"
+                      ],
+                      "properties": {
+                        "address": {
+                          "description": "REQUIRED. Address of the CA server implementing the Istio CA gRPC API.\nCan be IP address or a fully qualified DNS name with port\nEg: custom-ca.default.svc.cluster.local:8932, 192.168.23.2:9000",
+                          "type": "string"
+                        },
+                        "istiodSide": {
+                          "description": "Use istiodSide to specify CA Server integrate to Istiod side or Agent side\nDefault: true",
+                          "type": "boolean"
+                        },
+                        "requestTimeout": {
+                          "description": "timeout for forward CSR requests from Istiod to External CA\nDefault: 10s",
+                          "type": "string"
+                        },
+                        "tlsSettings": {
+                          "description": "Use the tlsSettings to specify the tls mode to use.\nRegarding tlsSettings:\n- DISABLE MODE is legitimate for the case Istiod is making the request via an Envoy sidecar.\nDISABLE MODE can also be used for testing\n- TLS MUTUAL MODE be on by default. If the CA certificates\n(cert bundle to verify the CA server's certificate) is omitted, Istiod will\nuse the system root certs to verify the CA server's certificate.",
+                          "type": "object",
+                          "properties": {
+                            "caCertificates": {
+                              "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "caCrl": {
+                              "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                              "type": "string"
+                            },
+                            "clientCertificate": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "credentialName": {
+                              "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                              "type": "string"
+                            },
+                            "insecureSkipVerify": {
+                              "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                              "type": "boolean"
+                            },
+                            "mode": {
+                              "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                              "type": "string",
+                              "enum": [
+                                "DISABLE",
+                                "SIMPLE",
+                                "MUTUAL",
+                                "ISTIO_MUTUAL"
+                              ]
+                            },
+                            "privateKey": {
+                              "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                              "type": "string"
+                            },
+                            "sni": {
+                              "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                              "type": "string"
+                            },
+                            "subjectAltNames": {
+                              "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caCertificates": {
+                      "description": "The extra root certificates for workload-to-workload communication.\nThe plugin certificates (the 'cacerts' secret) or self-signed certificates (the 'istio-ca-secret' secret)\nare automatically added by Istiod.\nThe CA certificate that signs the workload certificates is automatically added by Istio Agent.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "certSigners": {
+                            "description": "when Istiod is acting as RA(registration authority)\nIf set, they are used for these signers. Otherwise, this trustAnchor is used for all signers.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "pem": {
+                            "description": "The PEM data of the certificate.",
+                            "type": "string"
+                          },
+                          "spiffeBundleUrl": {
+                            "description": "The SPIFFE bundle endpoint URL that complies to:\nhttps://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#the-spiffe-trust-domain-and-bundle\nThe endpoint should support authentication based on Web PKI:\nhttps://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Trust_Domain_and_Bundle.md#521-web-pki\nThe certificate is retrieved from the endpoint.",
+                            "type": "string"
+                          },
+                          "trustDomains": {
+                            "description": "Optional. Specify the list of trust domains to which this trustAnchor data belongs.\nIf set, they are used for these trust domains. Otherwise, this trustAnchor is used for default trust domain\nand its aliases.\nNote that we can have multiple trustAnchor data for a same trustDomain.\nIn that case, trustAnchors with a same trust domain will be merged and used together to verify peer certificates.\nIf neither certSigners nor trustDomains is set, this trustAnchor is used for all trust domains and all signers.\nIf only trustDomains is set, this trustAnchor is used for these trustDomains and all signers.\nIf only certSigners is set, this trustAnchor is used for these certSigners and all trust domains.\nIf both certSigners and trustDomains is set, this trustAnchor is only used for these signers and trust domains.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "At most one of [pem spiffeBundleUrl] should be set",
+                            "rule": "(has(self.pem)?1:0) + (has(self.spiffeBundleUrl)?1:0) <= 1"
+                          }
+                        ]
+                      }
+                    },
+                    "certificates": {
+                      "description": "Configure the provision of certificates.\n\nNote: Deprecated, please refer to Cert-Manager or other cert provisioning solutions to sign DNS certificates.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                      "type": "array",
+                      "items": {
+                        "description": "Certificate configures the provision of a certificate and its key.\nExample 1: key and cert stored in a secret\n```\n{ secretName: galley-cert\n\n\t  secretNamespace: istio-system\n\t  dnsNames:\n\t    - galley.istio-system.svc\n\t    - galley.mydomain.com\n\t}\n\n```\nExample 2: key and cert stored in a directory\n```\n{ dnsNames:\n  - pilot.istio-system\n  - pilot.istio-system.svc\n  - pilot.mydomain.com\n    }\n\n```",
+                        "type": "object",
+                        "properties": {
+                          "dnsNames": {
+                            "description": "The DNS names for the certificate. A certificate may contain\nmultiple DNS names.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "secretName": {
+                            "description": "Name of the secret the certificate and its key will be stored into.\nIf it is empty, it will not be stored into a secret.\nInstead, the certificate and its key will be stored into a hard-coded directory.",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "configSources": {
+                      "description": "ConfigSource describes a source of configuration data for networking\nrules, and other Istio configuration artifacts. Multiple data sources\ncan be configured for a single control plane.",
+                      "type": "array",
+                      "items": {
+                        "description": "ConfigSource describes information about a configuration store inside a\nmesh. A single control plane instance can interact with one or more data\nsources.",
+                        "type": "object",
+                        "properties": {
+                          "address": {
+                            "description": "Address of the server implementing the Istio Mesh Configuration\nprotocol (MCP). Can be IP address or a fully qualified DNS name.\nUse xds:// to specify a grpc-based xds backend, k8s:// to specify a k8s controller or\nfs:/// to specify a file-based backend with absolute path to the directory.",
+                            "type": "string"
+                          },
+                          "subscribedResources": {
+                            "description": "Describes the source of configuration, if nothing is specified default is MCP",
+                            "type": "array",
+                            "items": {
+                              "description": "Resource describes the source of configuration",
+                              "type": "string",
+                              "enum": [
+                                "SERVICE_REGISTRY"
+                              ]
+                            }
+                          },
+                          "tlsSettings": {
+                            "description": "Use the tlsSettings to specify the tls mode to use. If the MCP server\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                            "type": "object",
+                            "properties": {
+                              "caCertificates": {
+                                "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                "type": "string"
+                              },
+                              "caCrl": {
+                                "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                                "type": "string"
+                              },
+                              "clientCertificate": {
+                                "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                "type": "string"
+                              },
+                              "credentialName": {
+                                "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                                "type": "string"
+                              },
+                              "insecureSkipVerify": {
+                                "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                                "type": "boolean"
+                              },
+                              "mode": {
+                                "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                                "type": "string",
+                                "enum": [
+                                  "DISABLE",
+                                  "SIMPLE",
+                                  "MUTUAL",
+                                  "ISTIO_MUTUAL"
+                                ]
+                              },
+                              "privateKey": {
+                                "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                "type": "string"
+                              },
+                              "sni": {
+                                "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                                "type": "string"
+                              },
+                              "subjectAltNames": {
+                                "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "connectTimeout": {
+                      "description": "Connection timeout used by Envoy. (MUST be >=1ms)\nDefault timeout is 10s.",
+                      "type": "string"
+                    },
+                    "defaultConfig": {
+                      "description": "Default proxy config used by gateway and sidecars.\nIn case of Kubernetes, the proxy config is applied once during the injection process,\nand remain constant for the duration of the pod. The rest of the mesh config can be changed\nat runtime and config gets distributed dynamically.\nOn Kubernetes, this can be overridden on individual pods with the `proxy.istio.io/config` annotation.",
+                      "type": "object",
+                      "properties": {
+                        "availabilityZone": {
+                          "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                          "type": "string"
+                        },
+                        "binaryPath": {
+                          "description": "Path to the proxy binary",
+                          "type": "string"
+                        },
+                        "caCertificatesPem": {
+                          "description": "The PEM data of the extra root certificates for workload-to-workload communication.\nThis includes the certificates defined in MeshConfig and any other certificates that Istiod uses as CA.\nThe plugin certificates (the 'cacerts' secret), self-signed certificates (the 'istio-ca-secret' secret)\nare added automatically by Istiod.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "concurrency": {
+                          "description": "The number of worker threads to run.\nIf unset, which is recommended, this will be automatically determined based on CPU requests/limits.\nIf set to 0, all cores on the machine will be used, ignoring CPU requests or limits. This can lead to major performance\nissues if CPU limits are also set.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "configPath": {
+                          "description": "Path to the generated configuration file directory.\nProxy agent generates the actual configuration and stores it in this directory.",
+                          "type": "string"
+                        },
+                        "controlPlaneAuthPolicy": {
+                          "description": "AuthenticationPolicy defines how the proxy is authenticated when it connects to the control plane.\nDefault is set to `MUTUAL_TLS`.",
+                          "type": "string",
+                          "enum": [
+                            "NONE",
+                            "MUTUAL_TLS",
+                            "INHERIT"
+                          ]
+                        },
+                        "customConfigFile": {
+                          "description": "File path of custom proxy configuration, currently used by proxies\nin front of istiod.",
+                          "type": "string"
+                        },
+                        "discoveryAddress": {
+                          "description": "Address of the discovery service exposing xDS with mTLS connection.\nThe inject configuration may override this value.",
+                          "type": "string"
+                        },
+                        "discoveryRefreshDelay": {
+                          "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                          "type": "string"
+                        },
+                        "drainDuration": {
+                          "description": "restart. MUST be >=1s (e.g., _1s/1m/1h_)\nDefault drain duration is `45s`.",
+                          "type": "string"
+                        },
+                        "envoyAccessLogService": {
+                          "description": "Address of the service to which access logs from Envoys should be\nsent. (e.g. `accesslog-service:15000`). See [Access Log\nService](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/accesslog/v2/als.proto)\nfor details about Envoy's gRPC Access Log Service API.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "Address of a remove service used for various purposes (access log\nreceiver, metrics receiver, etc.). Can be IP address or a fully\nqualified DNS name.",
+                              "type": "string"
+                            },
+                            "tcpKeepalive": {
+                              "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                                  "type": "string"
+                                },
+                                "probes": {
+                                  "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "time": {
+                                  "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "tlsSettings": {
+                              "description": "Use the `tlsSettings` to specify the tls mode to use. If the remote service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                              "type": "object",
+                              "properties": {
+                                "caCertificates": {
+                                  "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "caCrl": {
+                                  "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                                  "type": "string"
+                                },
+                                "clientCertificate": {
+                                  "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "credentialName": {
+                                  "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                                  "type": "string"
+                                },
+                                "insecureSkipVerify": {
+                                  "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                                  "type": "boolean"
+                                },
+                                "mode": {
+                                  "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                                  "type": "string",
+                                  "enum": [
+                                    "DISABLE",
+                                    "SIMPLE",
+                                    "MUTUAL",
+                                    "ISTIO_MUTUAL"
+                                  ]
+                                },
+                                "privateKey": {
+                                  "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "sni": {
+                                  "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                                  "type": "string"
+                                },
+                                "subjectAltNames": {
+                                  "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "envoyMetricsService": {
+                          "description": "Address of the Envoy Metrics Service implementation (e.g. `metrics-service:15000`).\nSee [Metric Service](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/metrics/v2/metrics_service.proto)\nfor details about Envoy's Metrics Service API.",
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "description": "Address of a remove service used for various purposes (access log\nreceiver, metrics receiver, etc.). Can be IP address or a fully\nqualified DNS name.",
+                              "type": "string"
+                            },
+                            "tcpKeepalive": {
+                              "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                              "type": "object",
+                              "properties": {
+                                "interval": {
+                                  "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                                  "type": "string"
+                                },
+                                "probes": {
+                                  "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "time": {
+                                  "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "tlsSettings": {
+                              "description": "Use the `tlsSettings` to specify the tls mode to use. If the remote service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                              "type": "object",
+                              "properties": {
+                                "caCertificates": {
+                                  "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "caCrl": {
+                                  "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                                  "type": "string"
+                                },
+                                "clientCertificate": {
+                                  "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "credentialName": {
+                                  "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                                  "type": "string"
+                                },
+                                "insecureSkipVerify": {
+                                  "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                                  "type": "boolean"
+                                },
+                                "mode": {
+                                  "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                                  "type": "string",
+                                  "enum": [
+                                    "DISABLE",
+                                    "SIMPLE",
+                                    "MUTUAL",
+                                    "ISTIO_MUTUAL"
+                                  ]
+                                },
+                                "privateKey": {
+                                  "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "sni": {
+                                  "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                                  "type": "string"
+                                },
+                                "subjectAltNames": {
+                                  "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "envoyMetricsServiceAddress": {
+                          "description": "Deprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                          "type": "string"
+                        },
+                        "extraStatTags": {
+                          "description": "An additional list of tags to extract from the in-proxy Istio telemetry. These extra tags can be\nadded by configuring the telemetry extension. Each additional tag needs to be present in this list.\nExtra tags emitted by the telemetry extensions must be listed here so that they can be processed\nand exposed as Prometheus metrics.\nDeprecated: `istio.stats` is a native filter now, this field is no longer needed.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "gatewayTopology": {
+                          "description": "Topology encapsulates the configuration which describes where the proxy is\nlocated i.e. behind a (or N) trusted proxy (proxies) or directly exposed\nto the internet. This configuration only effects gateways and is applied\nto all the gateways in the cluster unless overridden via annotations of the\ngateway workloads.",
+                          "type": "object",
+                          "properties": {
+                            "forwardClientCertDetails": {
+                              "description": "Configures how the gateway proxy handles x-forwarded-client-cert (XFCC)\nheader in the incoming request.",
+                              "type": "string",
+                              "enum": [
+                                "UNDEFINED",
+                                "SANITIZE",
+                                "FORWARD_ONLY",
+                                "APPEND_FORWARD",
+                                "SANITIZE_SET",
+                                "ALWAYS_FORWARD_ONLY"
+                              ]
+                            },
+                            "numTrustedProxies": {
+                              "description": "Number of trusted proxies deployed in front of the Istio gateway proxy.\nWhen this option is set to value N greater than zero, the trusted client\naddress is assumed to be the Nth address from the right end of the\nX-Forwarded-For (XFF) header from the incoming request. If the\nX-Forwarded-For (XFF) header is missing or has fewer than N addresses, the\ngateway proxy falls back to using the immediate downstream connection's\nsource address as the trusted client address.\nNote that the gateway proxy will append the downstream connection's source\naddress to the X-Forwarded-For (XFF) address and set the\nX-Envoy-External-Address header to the trusted client address before\nforwarding it to the upstream services in the cluster.\nThe default value of numTrustedProxies is 0.\nSee [Envoy XFF](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-for)\nheader handling for more details.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "proxyProtocol": {
+                              "description": "Enables [PROXY protocol](http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt) for\ndownstream connections on a gateway.",
+                              "type": "object"
+                            }
+                          }
+                        },
+                        "holdApplicationUntilProxyStarts": {
+                          "description": "Boolean flag for enabling/disabling the holdApplicationUntilProxyStarts behavior.\nThis feature adds hooks to delay application startup until the pod proxy\nis ready to accept traffic, mitigating some startup race conditions.\nDefault value is 'false'.",
+                          "type": "boolean"
+                        },
+                        "image": {
+                          "description": "Specifies the details of the proxy image.",
+                          "type": "object",
+                          "properties": {
+                            "imageType": {
+                              "description": "The image type of the image.\nIstio publishes default, debug, and distroless images.\nOther values are allowed if those image types (example: centos) are published to the specified hub.\nsupported values: default, debug, distroless.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "interceptionMode": {
+                          "description": "The mode used to redirect inbound traffic to Envoy.",
+                          "type": "string",
+                          "enum": [
+                            "REDIRECT",
+                            "TPROXY",
+                            "NONE"
+                          ]
+                        },
+                        "meshId": {
+                          "description": "The unique identifier for the [service mesh](https://istio.io/docs/reference/glossary/#service-mesh)\nAll control planes running in the same service mesh should specify the same mesh ID.\nMesh ID is used to label telemetry reports for cases where telemetry from multiple meshes is mixed together.",
+                          "type": "string"
+                        },
+                        "privateKeyProvider": {
+                          "description": "Specifies the details of the Private Key Provider configuration for gateway and sidecar proxies.",
+                          "type": "object",
+                          "properties": {
+                            "cryptomb": {
+                              "description": "Use CryptoMb private key provider",
+                              "type": "object",
+                              "properties": {
+                                "fallback": {
+                                  "description": "If the private key provider isn\u2019t available (eg. the required hardware capability doesn\u2019t existed)\nEnvoy will fallback to the BoringSSL default implementation when the fallback is true.\nThe default value is false.",
+                                  "type": "boolean"
+                                },
+                                "pollDelay": {
+                                  "description": "How long to wait until the per-thread processing queue should be processed. If the processing queue\ngets full (eight sign or decrypt requests are received) it is processed immediately.\nHowever, if the queue is not filled before the delay has expired, the requests already in the queue\nare processed, even if the queue is not full.\nIn effect, this value controls the balance between latency and throughput.\nThe duration needs to be set to a value greater than or equal to 1 millisecond.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "qat": {
+                              "description": "Use QAT private key provider",
+                              "type": "object",
+                              "properties": {
+                                "fallback": {
+                                  "description": "If the private key provider isn\u2019t available (eg. the required hardware capability doesn\u2019t existed)\nEnvoy will fallback to the BoringSSL default implementation when the fallback is true.\nThe default value is false.",
+                                  "type": "boolean"
+                                },
+                                "pollDelay": {
+                                  "description": "How long to wait before polling the hardware accelerator after a request has been submitted there.\nHaving a small value leads to quicker answers from the hardware but causes more polling loop spins,\nleading to potentially larger CPU usage.\nThe duration needs to be set to a value greater than or equal to 1 millisecond.",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "At most one of [cryptomb qat] should be set",
+                              "rule": "(has(self.cryptomb)?1:0) + (has(self.qat)?1:0) <= 1"
+                            }
+                          ]
+                        },
+                        "proxyAdminPort": {
+                          "description": "Port on which Envoy should listen for administrative commands.\nDefault port is `15000`.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "proxyBootstrapTemplatePath": {
+                          "description": "Path to the proxy bootstrap template file",
+                          "type": "string"
+                        },
+                        "proxyHeaders": {
+                          "description": "Define the set of headers to add/modify for HTTP request/responses.\n\nTo enable an optional header, simply set the field. If no specific configuration is required, an empty object (`{}`) will enable it.\nNote: currently all headers are enabled by default.\n\nBelow shows an example of customizing the `server` header and disabling the `X-Envoy-Attempt-Count` header:\n\n```yaml\nproxyHeaders:\n\n\tserver:\n\t  value: \"my-custom-server\"\n\t# Explicitly enable Request IDs.\n\t# As this is the default, this has no effect.\n\trequestId: {}\n\tattemptCount:\n\t  disabled: true\n\n```\n\nSome headers are enabled by default, and require explicitly disabling. See below for an example of disabling all default-enabled headers:\n\n```yaml\nproxyHeaders:\n\n\tforwardedClientCert: SANITIZE\n\tserver:\n\t  disabled: true\n\trequestId:\n\t  disabled: true\n\tattemptCount:\n\t  disabled: true\n\tenvoyDebugHeaders:\n\t  disabled: true\n\tmetadataExchangeHeaders:\n\t  mode: IN_MESH\n\n```",
+                          "type": "object",
+                          "properties": {
+                            "attemptCount": {
+                              "description": "Controls the `X-Envoy-Attempt-Count` header.\nIf enabled, this header will be added on outbound request headers (including gateways) that have retries configured.\nIf disabled, this header will not be set. If it is already present, it will be preserved.\nThis header is enabled by default if not configured.",
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "envoyDebugHeaders": {
+                              "description": "Controls various `X-Envoy-*` headers, such as `X-Envoy-Overloaded` and `X-Envoy-Upstream-Service-Time`. If enabled,\nthese headers will be included.\nIf disabled, these headers will not be set. If they are already present, they will be preserved.\nSee the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/router/v3/router.proto#envoy-v3-api-field-extensions-filters-http-router-v3-router-suppress-envoy-headers) for more details.\nThese headers are enabled by default if not configured.",
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "forwardedClientCert": {
+                              "description": "Controls the `X-Forwarded-Client-Cert` header for inbound sidecar requests. To set this on gateways, use the `Topology` setting.\nTo disable the header, configure either `SANITIZE` (to always remove the header, if present) or `FORWARD_ONLY` (to leave the header as-is).\nBy default, `APPEND_FORWARD` will be used.",
+                              "type": "string",
+                              "enum": [
+                                "UNDEFINED",
+                                "SANITIZE",
+                                "FORWARD_ONLY",
+                                "APPEND_FORWARD",
+                                "SANITIZE_SET",
+                                "ALWAYS_FORWARD_ONLY"
+                              ]
+                            },
+                            "metadataExchangeHeaders": {
+                              "description": "Controls Istio metadata exchange headers `X-Envoy-Peer-Metadata` and `X-Envoy-Peer-Metadata-Id`.\nBy default, the behavior is unspecified.\nIf IN_MESH, these headers will not be appended to outbound requests from sidecars to services not in-mesh.",
+                              "type": "object",
+                              "properties": {
+                                "mode": {
+                                  "type": "string",
+                                  "enum": [
+                                    "UNDEFINED",
+                                    "IN_MESH"
+                                  ]
+                                }
+                              }
+                            },
+                            "requestId": {
+                              "description": "Controls the `X-Request-Id` header. If enabled, a request ID is generated for each request if one is not already set.\nThis applies to all types of traffic (inbound, outbound, and gateways).\nIf disabled, no request ID will be generate for the request. If it is already present, it will be preserved.\nWarning: request IDs are a critical component to mesh tracing and logging, so disabling this is not recommended.\nThis header is enabled by default if not configured.",
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean"
+                                }
+                              }
+                            },
+                            "server": {
+                              "description": "Controls the `server` header. If enabled, the `Server: istio-envoy` header is set in response headers for inbound traffic (including gateways).\nIf disabled, the `Server` header is not modified. If it is already present, it will be preserved.",
+                              "type": "object",
+                              "properties": {
+                                "disabled": {
+                                  "type": "boolean"
+                                },
+                                "value": {
+                                  "description": "If set, and the server header is enabled, this value will be set as the server header. By default, `istio-envoy` will be used.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "setCurrentClientCertDetails": {
+                              "description": "This field is valid only when forward_client_cert_details is APPEND_FORWARD or SANITIZE_SET\nand the client connection is mTLS. It specifies the fields in\nthe client certificate to be forwarded. Note that `Hash` is always set, and\n`By` is always set when the client certificate presents the URI type Subject Alternative Name value.",
+                              "type": "object",
+                              "properties": {
+                                "cert": {
+                                  "description": "Whether to forward the entire client cert in URL encoded PEM format. This will appear in the\nXFCC header comma separated from other values with the value Cert=\"PEM\".\nDefaults to false.",
+                                  "type": "boolean"
+                                },
+                                "chain": {
+                                  "description": "Whether to forward the entire client cert chain (including the leaf cert) in URL encoded PEM\nformat. This will appear in the XFCC header comma separated from other values with the value\nChain=\"PEM\".\nDefaults to false.",
+                                  "type": "boolean"
+                                },
+                                "dns": {
+                                  "description": "Whether to forward the DNS type Subject Alternative Names of the client cert.\nDefaults to true.",
+                                  "type": "boolean"
+                                },
+                                "subject": {
+                                  "description": "Whether to forward the subject of the client cert. Defaults to true.",
+                                  "type": "boolean"
+                                },
+                                "uri": {
+                                  "description": "Whether to forward the URI type Subject Alternative Name of the client cert. Defaults to\ntrue.",
+                                  "type": "boolean"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "proxyMetadata": {
+                          "description": "Additional environment variables for the proxy.\nNames starting with `ISTIO_META_` will be included in the generated bootstrap and sent to the XDS server.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "proxyStatsMatcher": {
+                          "description": "Proxy stats matcher defines configuration for reporting custom Envoy stats.\nTo reduce memory and CPU overhead from Envoy stats system, Istio proxies by\ndefault create and expose only a subset of Envoy stats. This option is to\ncontrol creation of additional Envoy stats with prefix, suffix, and regex\nexpressions match on the name of the stats. This replaces the stats\ninclusion annotations\n(`sidecar.istio.io/statsInclusionPrefixes`,\n`sidecar.istio.io/statsInclusionRegexps`, and\n`sidecar.istio.io/statsInclusionSuffixes`). For example, to enable stats\nfor circuit breakers, request retries, upstream connections, and request timeouts,\nyou can specify stats matcher as follows:\n```yaml\nproxyStatsMatcher:\n\n\tinclusionRegexps:\n\t  - .*outlier_detection.*\n\t  - .*upstream_rq_retry.*\n\t  - .*upstream_cx_.*\n\tinclusionSuffixes:\n\t  - upstream_rq_timeout\n\n```\nNote including more Envoy stats might increase number of time series\ncollected by prometheus significantly. Care needs to be taken on Prometheus\nresource provision and configuration to reduce cardinality.",
+                          "type": "object",
+                          "properties": {
+                            "inclusionPrefixes": {
+                              "description": "Proxy stats name prefix matcher for inclusion.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "inclusionRegexps": {
+                              "description": "Proxy stats name regexps matcher for inclusion.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "inclusionSuffixes": {
+                              "description": "Proxy stats name suffix matcher for inclusion.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "readinessProbe": {
+                          "description": "VM Health Checking readiness probe. This health check config exactly mirrors the\nkubernetes readiness probe configuration both in schema and logic.\nOnly one health check method of 3 can be set at a time.",
+                          "type": "object",
+                          "properties": {
+                            "exec": {
+                              "description": "Exec specifies a command to execute in the container.",
+                              "type": "object",
+                              "properties": {
+                                "command": {
+                                  "description": "Command is the command line to execute inside the container, the working directory for the\ncommand  is root ('/') in the container's filesystem. The command is simply exec'd, it is\nnot run inside a shell, so traditional shell instructions ('|', etc) won't work. To use\na shell, you need to explicitly call out to that shell.\nExit status of 0 is treated as live/healthy and non-zero is unhealthy.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "failureThreshold": {
+                              "description": "Minimum consecutive failures for the probe to be considered failed after having succeeded.\nDefaults to 3. Minimum value is 1.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "grpc": {
+                              "description": "GRPC specifies a GRPC HealthCheckRequest.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "port": {
+                                  "description": "Port number of the gRPC service. Number must be in the range 1 to 65535.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "service": {
+                                  "description": "Service is the name of the service to place in the gRPC HealthCheckRequest\n(see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).\n\nIf this is not specified, the default behavior is defined by gRPC.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "httpGet": {
+                              "description": "HTTPGet specifies an HTTP GET request to perform.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Host name to connect to, defaults to the pod IP. You probably want to set\n\"Host\" in httpHeaders instead.",
+                                  "type": "string"
+                                },
+                                "httpHeaders": {
+                                  "description": "Custom headers to set in the request. HTTP allows repeated headers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "value"
+                                    ],
+                                    "properties": {
+                                      "name": {
+                                        "description": "The header field name.\nThis will be canonicalized upon output, so case-variant names will be understood as the same header.",
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "description": "The header field value",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                },
+                                "path": {
+                                  "description": "Path to access on the HTTP server.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Name or number of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                },
+                                "scheme": {
+                                  "description": "Scheme to use for connecting to the host.\nDefaults to HTTP.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "initialDelaySeconds": {
+                              "description": "Number of seconds after the container has started before liveness probes are initiated.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "periodSeconds": {
+                              "description": "How often (in seconds) to perform the probe.\nDefault to 10 seconds. Minimum value is 1.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "successThreshold": {
+                              "description": "Minimum consecutive successes for the probe to be considered successful after having failed.\nDefaults to 1. Must be 1 for liveness and startup. Minimum value is 1.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "tcpSocket": {
+                              "description": "TCPSocket specifies a connection to a TCP port.",
+                              "type": "object",
+                              "required": [
+                                "port"
+                              ],
+                              "properties": {
+                                "host": {
+                                  "description": "Optional: Host name to connect to, defaults to the pod IP.",
+                                  "type": "string"
+                                },
+                                "port": {
+                                  "description": "Number or name of the port to access on the container.\nNumber must be in the range 1 to 65535.\nName must be an IANA_SVC_NAME.",
+                                  "x-kubernetes-int-or-string": true
+                                }
+                              }
+                            },
+                            "terminationGracePeriodSeconds": {
+                              "description": "Optional duration in seconds the pod needs to terminate gracefully upon probe failure.\nThe grace period is the duration in seconds after the processes running in the pod are sent\na termination signal and the time when the processes are forcibly halted with a kill signal.\nSet this value longer than the expected cleanup time for your process.\nIf this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this\nvalue overrides the value provided by the pod spec.\nValue must be non-negative integer. The value zero indicates stop immediately via\nthe kill signal (no opportunity to shut down).\nThis is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.\nMinimum value is 1. spec.terminationGracePeriodSeconds is used if unset.",
+                              "type": "integer",
+                              "format": "int64"
+                            },
+                            "timeoutSeconds": {
+                              "description": "Number of seconds after which the probe times out.\nDefaults to 1 second. Minimum value is 1.\nMore info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes",
+                              "type": "integer",
+                              "format": "int32"
+                            }
+                          }
+                        },
+                        "runtimeValues": {
+                          "description": "Envoy [runtime configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/runtime) to set during bootstrapping.\nThis enables setting experimental, unsafe, unsupported, and deprecated features that should be used with extreme caution.",
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "string"
+                          }
+                        },
+                        "sds": {
+                          "description": "Secret Discovery Service(SDS) configuration to be used by the proxy.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                          "type": "object",
+                          "properties": {
+                            "enabled": {
+                              "description": "True if SDS is enabled.",
+                              "type": "boolean"
+                            },
+                            "k8sSaJwtPath": {
+                              "description": "Path of k8s service account JWT path.",
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "serviceCluster": {
+                          "description": "Service cluster defines the name for the `service_cluster` that is\nshared by all Envoy instances. This setting corresponds to\n`--service-cluster` flag in Envoy.  In a typical Envoy deployment, the\n`service-cluster` flag is used to identify the caller, for\nsource-based routing scenarios.\n\nSince Istio does not assign a local `service/service` version to each\nEnvoy instance, the name is same for all of them.  However, the\nsource/caller's identity (e.g., IP address) is encoded in the\n`--service-node` flag when launching Envoy.  When the RDS service\nreceives API calls from Envoy, it uses the value of the `service-node`\nflag to compute routes that are relative to the service instances\nlocated at that IP address.",
+                          "type": "string"
+                        },
+                        "statNameLength": {
+                          "description": "Maximum length of name field in Envoy's metrics. The length of the name field\nis determined by the length of a name field in a service and the set of labels that\ncomprise a particular version of the service. The default value is set to 189 characters.\nEnvoy's internal metrics take up 67 characters, for a total of 256 character name per metric.\nIncrease the value of this field if you find that the metrics from Envoys are truncated.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "statsdUdpAddress": {
+                          "description": "IP Address and Port of a statsd UDP listener (e.g. `10.75.241.127:9125`).",
+                          "type": "string"
+                        },
+                        "statusPort": {
+                          "description": "Port on which the agent should listen for administrative commands such as readiness probe.\nDefault is set to port `15020`.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "terminationDrainDuration": {
+                          "description": "The amount of time allowed for connections to complete on proxy shutdown.\nOn receiving `SIGTERM` or `SIGINT`, `istio-agent` tells the active Envoy to start gracefully draining,\ndiscouraging any new connections and allowing existing connections to complete. It then\nsleeps for the `terminationDrainDuration` and then kills any remaining active Envoy processes.\nIf not set, a default of `5s` will be applied.",
+                          "type": "string"
+                        },
+                        "tracing": {
+                          "description": "Tracing configuration to be used by the proxy.",
+                          "type": "object",
+                          "properties": {
+                            "customTags": {
+                              "description": "and gateways).\nThe key represents the name of the tag.\nEx:\n```yaml\ncustom_tags:\n\n\tnew_tag_name:\n\t  header:\n\t    name: custom-http-header-name\n\t    default_value: defaulted-value-from-custom-header\n\n```",
+                              "type": "object",
+                              "additionalProperties": {
+                                "description": "Configure custom tags that will be added to any active span.\nTags can be generated via literals, environment variables or an incoming request header.",
+                                "type": "object",
+                                "properties": {
+                                  "environment": {
+                                    "description": "The custom tag's value should be populated from an environmental\nvariable",
+                                    "type": "object",
+                                    "properties": {
+                                      "defaultValue": {
+                                        "description": "When the environment variable is not found,\nthe tag's value will be populated with this default value if specified,\notherwise the tag will not be populated.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name of the environment variable used to populate the tag's value",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "header": {
+                                    "description": "The custom tag's value is populated by an http header from\nan incoming request.",
+                                    "type": "object",
+                                    "properties": {
+                                      "defaultValue": {
+                                        "description": "Default value to be used for the tag when the named HTTP header does not exist.\nThe tag will be skipped if no default value is provided.",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "HTTP header name used to obtain the value from to populate the tag value.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "literal": {
+                                    "description": "The custom tag's value is the specified literal.",
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "description": "Static literal value used to populate the tag value.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "At most one of [literal environment header] should be set",
+                                    "rule": "(has(self.literal)?1:0) + (has(self.environment)?1:0) + (has(self.header)?1:0) <= 1"
+                                  }
+                                ]
+                              }
+                            },
+                            "datadog": {
+                              "description": "Use a Datadog tracer.",
+                              "type": "object",
+                              "properties": {
+                                "address": {
+                                  "description": "Address of the Datadog Agent.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "lightstep": {
+                              "description": "Use a Lightstep tracer.\nNOTE: For Istio 1.15+, this configuration option will result\nin using OpenTelemetry-based Lightstep integration.",
+                              "type": "object",
+                              "properties": {
+                                "accessToken": {
+                                  "description": "The Lightstep access token.",
+                                  "type": "string"
+                                },
+                                "address": {
+                                  "description": "Address of the Lightstep Satellite pool.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "maxPathTagLength": {
+                              "description": "Configures the maximum length of the request path to extract and include in the\nHttpUrl tag. Used to truncate length request paths to meet the needs of tracing\nbackend. If not set, then a length of 256 will be used.",
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "openCensusAgent": {
+                              "description": "Use an OpenCensus tracer exporting to an OpenCensus agent.",
+                              "type": "object",
+                              "properties": {
+                                "address": {
+                                  "description": "gRPC address for the OpenCensus agent (e.g. dns://authority/host:port or\nunix:path). See [gRPC naming\ndocs](https://github.com/grpc/grpc/blob/master/doc/naming.md) for\ndetails.",
+                                  "type": "string"
+                                },
+                                "context": {
+                                  "description": "Specifies the set of context propagation headers used for distributed\ntracing. Default is `[\"W3C_TRACE_CONTEXT\"]`. If multiple values are specified,\nthe proxy will attempt to read each header for each request and will\nwrite all headers.",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "TraceContext selects the context propagation headers used for\ndistributed tracing.",
+                                    "type": "string",
+                                    "enum": [
+                                      "UNSPECIFIED",
+                                      "W3C_TRACE_CONTEXT",
+                                      "GRPC_BIN",
+                                      "CLOUD_TRACE_CONTEXT",
+                                      "B3"
+                                    ]
+                                  }
+                                }
+                              }
+                            },
+                            "sampling": {
+                              "description": "The percentage of requests (0.0 - 100.0) that will be randomly selected for trace generation,\nif not requested by the client or not forced. Default is 1.0.",
+                              "type": "number"
+                            },
+                            "stackdriver": {
+                              "description": "Use a Stackdriver tracer.",
+                              "type": "object",
+                              "properties": {
+                                "debug": {
+                                  "description": "debug enables trace output to stdout.",
+                                  "type": "boolean"
+                                },
+                                "maxNumberOfAnnotations": {
+                                  "description": "The global default max number of annotation events per span.\ndefault is 200.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "maxNumberOfAttributes": {
+                                  "description": "The global default max number of attributes per span.\ndefault is 200.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "maxNumberOfMessageEvents": {
+                                  "description": "The global default max number of message events per span.\ndefault is 200.",
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              }
+                            },
+                            "tlsSettings": {
+                              "description": "Use the tlsSettings to specify the tls mode to use. If the remote tracing service\nuses Istio mutual TLS and shares the root CA with istiod, specify the TLS\nmode as `ISTIO_MUTUAL`.",
+                              "type": "object",
+                              "properties": {
+                                "caCertificates": {
+                                  "description": "OPTIONAL: The path to the file containing certificate authority\ncertificates to use in verifying a presented server certificate. If\nomitted, the proxy will verify the server's certificate using\nthe OS CA certificates.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "caCrl": {
+                                  "description": "OPTIONAL: The path to the file containing the certificate revocation list (CRL)\nto use in verifying a presented server certificate. `CRL` is a list of certificates\nthat have been revoked by the CA (Certificate Authority) before their scheduled expiration date.\nIf specified, the proxy will verify if the presented certificate is part of the revoked list of certificates.\nIf omitted, the proxy will not verify the certificate against the `crl`. Note that if `credentialName` is set,\n`CRL` cannot be specified using `caCrl`, rather it has to be specified inside the credential.",
+                                  "type": "string"
+                                },
+                                "clientCertificate": {
+                                  "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient-side TLS certificate to use.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "credentialName": {
+                                  "description": "The name of the secret that holds the TLS certs for the\nclient including the CA certificates. This secret must exist in\nthe namespace of the proxy using the certificates.\nAn Opaque secret should contain the following keys and values:\n`key: <privateKey>`, `cert: <clientCert>`, `cacert: <CACertificate>`,\n`crl: <certificateRevocationList>`\nHere CACertificate is used to verify the server certificate.\nFor mutual TLS, `cacert: <CACertificate>` can be provided in the\nsame secret or a separate secret named `<secret>-cacert`.\nA TLS secret for client certificates with an additional\n`ca.crt` key for CA certificates and `ca.crl` key for\ncertificate revocation list(CRL) is also supported.\nOnly one of client certificates and CA certificate\nor credentialName can be specified.\n\n**NOTE:** This field is applicable at sidecars only if\n`DestinationRule` has a `workloadSelector` specified.\nOtherwise the field will be applicable only at gateways, and\nsidecars will continue to use the certificate paths.",
+                                  "type": "string"
+                                },
+                                "insecureSkipVerify": {
+                                  "description": "`insecureSkipVerify` specifies whether the proxy should skip verifying the\nCA signature and SAN for the server certificate corresponding to the host.\nThe default value of this field is false.",
+                                  "type": "boolean"
+                                },
+                                "mode": {
+                                  "description": "Indicates whether connections to this port should be secured\nusing TLS. The value of this field determines how TLS is enforced.",
+                                  "type": "string",
+                                  "enum": [
+                                    "DISABLE",
+                                    "SIMPLE",
+                                    "MUTUAL",
+                                    "ISTIO_MUTUAL"
+                                  ]
+                                },
+                                "privateKey": {
+                                  "description": "REQUIRED if mode is `MUTUAL`. The path to the file holding the\nclient's private key.\nShould be empty if mode is `ISTIO_MUTUAL`.",
+                                  "type": "string"
+                                },
+                                "sni": {
+                                  "description": "SNI string to present to the server during TLS handshake.\nIf unspecified, SNI will be automatically set based on downstream HTTP\nhost/authority header for SIMPLE and MUTUAL TLS modes.",
+                                  "type": "string"
+                                },
+                                "subjectAltNames": {
+                                  "description": "A list of alternate names to verify the subject identity in the\ncertificate. If specified, the proxy will verify that the server\ncertificate's subject alt name matches one of the specified values.\nIf specified, this list overrides the value of `subjectAltNames`\nfrom the `ServiceEntry`. If unspecified, automatic validation of upstream\npresented certificate for new upstream connections will be done based on the\ndownstream HTTP host/authority header.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            },
+                            "zipkin": {
+                              "description": "Use a Zipkin tracer.",
+                              "type": "object",
+                              "properties": {
+                                "address": {
+                                  "description": "Address of the Zipkin service (e.g. _zipkin:9411_).",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "x-kubernetes-validations": [
+                            {
+                              "message": "At most one of [zipkin lightstep datadog stackdriver openCensusAgent] should be set",
+                              "rule": "(has(self.zipkin)?1:0) + (has(self.lightstep)?1:0) + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0) + (has(self.openCensusAgent)?1:0) <= 1"
+                            }
+                          ]
+                        },
+                        "tracingServiceName": {
+                          "description": "Used by Envoy proxies to assign the values for the service names in trace\nspans.",
+                          "type": "string",
+                          "enum": [
+                            "APP_LABEL_AND_NAMESPACE",
+                            "CANONICAL_NAME_ONLY",
+                            "CANONICAL_NAME_AND_NAMESPACE"
+                          ]
+                        },
+                        "zipkinAddress": {
+                          "description": "Address of the Zipkin service (e.g. _zipkin:9411_).\nDEPRECATED: Use [tracing][istio.mesh.v1alpha1.ProxyConfig.tracing] instead.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/proxy.proto.",
+                          "type": "string"
+                        }
+                      },
+                      "x-kubernetes-validations": [
+                        {
+                          "message": "At most one of [serviceCluster tracingServiceName] should be set",
+                          "rule": "(has(self.serviceCluster)?1:0) + (has(self.tracingServiceName)?1:0) <= 1"
+                        }
+                      ]
+                    },
+                    "defaultDestinationRuleExportTo": {
+                      "description": "The default value for the `DestinationRule.exportTo` field. Has the same\nsyntax as `defaultServiceExportTo`.\n\nIf not set the system will use \"*\" as the default value which implies that\ndestination rules are exported to all namespaces",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "defaultHttpRetryPolicy": {
+                      "description": "Configure the default HTTP retry policy.\nThe default number of retry attempts is set at 2 for these errors:\n\n\t\"connect-failure,refused-stream,unavailable,cancelled,retriable-status-codes\".\n\nSetting the number of attempts to 0 disables retry policy globally.\nThis setting can be overridden on a per-host basis using the Virtual Service\nAPI.\nAll settings in the retry policy except `perTryTimeout` can currently be\nconfigured globally via this field.",
+                      "type": "object",
+                      "properties": {
+                        "attempts": {
+                          "description": "Number of retries to be allowed for a given request. The interval\nbetween retries will be determined automatically (25ms+). When request\n`timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute)\nor `per_try_timeout` is configured, the actual number of retries attempted also depends on\nthe specified request `timeout` and `per_try_timeout` values. MUST be >= 0. If `0`, retries will be disabled.\nThe maximum possible number of requests made will be 1 + `attempts`.",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "perTryTimeout": {
+                          "description": "Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST be >=1ms.\nDefault is same value as request\n`timeout` of the [HTTP route](https://istio.io/docs/reference/config/networking/virtual-service/#HTTPRoute),\nwhich means no timeout.",
+                          "type": "string"
+                        },
+                        "retryOn": {
+                          "description": "Specifies the conditions under which retry takes place.\nOne or more policies can be specified using a \u2018,\u2019 delimited list.\nSee the [retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on)\nand [gRPC retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on) for more details.\n\nIn addition to the policies specified above, a list of HTTP status codes can be passed, such as `retryOn: \"503,reset\"`.\nNote these status codes refer to the actual responses received from the destination.\nFor example, if a connection is reset, Istio will translate this to 503 for it's response.\nHowever, the destination did not return a 503 error, so this would not match `\"503\"` (it would, however, match `\"reset\"`).\n\nIf not specified, this defaults to `connect-failure,refused-stream,unavailable,cancelled,503`.",
+                          "type": "string"
+                        },
+                        "retryRemoteLocalities": {
+                          "description": "Flag to specify whether the retries should retry to other localities.\nSee the [retry plugin configuration](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_connection_management#retry-plugin-configuration) for more details.",
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "defaultProviders": {
+                      "description": "Specifies extension providers to use by default in Istio configuration resources.",
+                      "type": "object",
+                      "properties": {
+                        "accessLogging": {
+                          "description": "Name of the default provider(s) for access logging.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "metrics": {
+                          "description": "Name of the default provider(s) for metrics.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "tracing": {
+                          "description": "Name of the default provider(s) for tracing.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "defaultServiceExportTo": {
+                      "description": "The default value for the ServiceEntry.exportTo field and services\nimported through container registry integrations, e.g. this applies to\nKubernetes Service resources. The value is a list of namespace names and\nreserved namespace aliases. The allowed namespace aliases are:\n```\n* - All Namespaces\n. - Current Namespace\n~ - No Namespace\n```\nIf not set the system will use \"*\" as the default value which implies that\nservices are exported to all namespaces.\n\n`All namespaces` is a reasonable default for implementations that don't\nneed to restrict access or visibility of services across namespace\nboundaries. If that requirement is present it is generally good practice to\nmake the default `Current namespace` so that services are only visible\nwithin their own namespaces by default. Operators can then expand the\nvisibility of services to other namespaces as needed. Use of `No Namespace`\nis expected to be rare but can have utility for deployments where\ndependency management needs to be precise even within the scope of a single\nnamespace.\n\nFor further discussion see the reference documentation for `ServiceEntry`,\n`Sidecar`, and `Gateway`.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "defaultVirtualServiceExportTo": {
+                      "description": "The default value for the VirtualService.exportTo field. Has the same\nsyntax as `defaultServiceExportTo`.\n\nIf not set the system will use \"*\" as the default value which implies that\nvirtual services are exported to all namespaces",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "disableEnvoyListenerLog": {
+                      "description": "This flag disables Envoy Listener logs.\nSee [Listener Access Log](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto#envoy-v3-api-field-config-listener-v3-listener-access-log)\nIstio Enables Envoy's listener access logs on \"NoRoute\" response flag.\nDefault value is `false`.",
+                      "type": "boolean"
+                    },
+                    "discoverySelectors": {
+                      "description": "A list of Kubernetes selectors that specify the set of namespaces that Istio considers when\ncomputing configuration updates for sidecars. This can be used to reduce Istio's computational load\nby limiting the number of entities (including services, pods, and endpoints) that are watched and processed.\nIf omitted, Istio will use the default behavior of processing all namespaces in the cluster.\nElements in the list are disjunctive (OR semantics), i.e. a namespace will be included if it matches any selector.\nThe following example selects any namespace that matches either below:\n1. The namespace has both of these labels: `env: prod` and `region: us-east1`\n2. The namespace has label `app` equal to `cassandra` or `spark`.\n```yaml\ndiscoverySelectors:\n  - matchLabels:\n    env: prod\n    region: us-east1\n  - matchExpressions:\n  - key: app\n    operator: In\n    values:\n  - cassandra\n  - spark\n\n```\nRefer to the [Kubernetes selector docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)\nfor additional detail on selector semantics.",
+                      "type": "array",
+                      "items": {
+                        "description": "A label selector is a label query over a set of resources. The result of matchLabels and\nmatchExpressions are ANDed. An empty label selector matches all objects. A null\nlabel selector matches no objects.",
+                        "type": "object",
+                        "properties": {
+                          "matchExpressions": {
+                            "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                            "type": "array",
+                            "items": {
+                              "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "operator"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the label key that the selector applies to.",
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                  "type": "string"
+                                },
+                                "values": {
+                                  "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                  "type": "array",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "x-kubernetes-list-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "matchLabels": {
+                            "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      }
+                    },
+                    "dnsRefreshRate": {
+                      "description": "Configures DNS refresh rate for Envoy clusters of type `STRICT_DNS`\nDefault refresh rate is `60s`.",
+                      "type": "string"
+                    },
+                    "enableAutoMtls": {
+                      "description": "This flag is used to enable mutual `TLS` automatically for service to service communication\nwithin the mesh, default true.\nIf set to true, and a given service does not have a corresponding `DestinationRule` configured,\nor its `DestinationRule` does not have ClientTLSSettings specified, Istio configures client side\nTLS configuration appropriately. More specifically,\nIf the upstream authentication policy is in `STRICT` mode, use Istio provisioned certificate\nfor mutual `TLS` to connect to upstream.\nIf upstream service is in plain text mode, use plain text.\nIf the upstream authentication policy is in PERMISSIVE mode, Istio configures clients to use\nmutual `TLS` when server sides are capable of accepting mutual `TLS` traffic.\nIf service `DestinationRule` exists and has `ClientTLSSettings` specified, that is always used instead.",
+                      "type": "boolean"
+                    },
+                    "enableEnvoyAccessLogService": {
+                      "description": "This flag enables Envoy's gRPC Access Log Service.\nSee [Access Log Service](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/grpc/v3/als.proto)\nfor details about Envoy's gRPC Access Log Service API.\nDefault value is `false`.",
+                      "type": "boolean"
+                    },
+                    "enablePrometheusMerge": {
+                      "description": "If enabled, Istio agent will merge metrics exposed by the application with metrics from Envoy\nand Istio agent. The sidecar injection will replace `prometheus.io` annotations present on the pod\nand redirect them towards Istio agent, which will then merge metrics of from the application with Istio metrics.\nThis relies on the annotations `prometheus.io/scrape`, `prometheus.io/port`, and\n`prometheus.io/path` annotations.\nIf you are running a separately managed Envoy with an Istio sidecar, this may cause issues, as the metrics will collide.\nIn this case, it is recommended to disable aggregation on that deployment with the\n`prometheus.istio.io/merge-metrics: \"false\"` annotation.\nIf not specified, this will be enabled by default.",
+                      "type": "boolean"
+                    },
+                    "enableTracing": {
+                      "description": "Flag to control generation of trace spans and request IDs.\nRequires a trace span collector defined in the proxy configuration.",
+                      "type": "boolean"
+                    },
+                    "extensionProviders": {
+                      "description": "Defines a list of extension providers that extend Istio's functionality. For example, the AuthorizationPolicy\ncan be used with an extension provider to delegate the authorization decision to a custom authorization system.",
+                      "type": "array",
+                      "maxItems": 1000,
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "datadog": {
+                            "description": "Configures a Datadog tracing provider.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "maxTagLength": {
+                                "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service for the Datadog agent.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"datadog.default.svc.cluster.local\" or \"bar/datadog.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "envoyExtAuthzGrpc": {
+                            "description": "Configures an external authorizer that implements the Envoy ext_authz filter authorization check service using the gRPC API.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "failOpen": {
+                                "description": "If true, the HTTP request or TCP connection will be allowed even if the communication with the authorization service has failed,\nor if the authorization service has returned a HTTP 5xx error.\nDefault is false. For HTTP request, it will be rejected with 403 (HTTP Forbidden). For TCP connection, it will be closed immediately.",
+                                "type": "boolean"
+                              },
+                              "includeRequestBodyInCheck": {
+                                "description": "If set, the client request body will be included in the authorization request sent to the authorization service.",
+                                "type": "object",
+                                "properties": {
+                                  "allowPartialMessage": {
+                                    "description": "When this field is true, ext-authz filter will buffer the message until maxRequestBytes is reached.\nThe authorization request will be dispatched and no 413 HTTP error will be returned by the filter.\nA \"x-envoy-auth-partial-body: false|true\" metadata header will be added to the authorization request message\nindicating if the body data is partial.",
+                                    "type": "boolean"
+                                  },
+                                  "maxRequestBytes": {
+                                    "description": "Sets the maximum size of a message body that the ext-authz filter will hold in memory.\nIf maxRequestBytes is reached, and allowPartialMessage is false, Envoy will return a 413 (Payload Too Large).\nOtherwise the request will be sent to the provider with a partial message.\nNote that this setting will have precedence over the failOpen field, the 413 will be returned even when the\nfailOpen is set to true.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "packAsBytes": {
+                                    "description": "If true, the body sent to the external authorization service in the gRPC authorization request is set with raw bytes\nin the [raw_body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153).\nOtherwise, it will be filled with UTF-8 string in the [body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147).\nThis field only works with the envoyExtAuthzGrpc provider and has no effect for the envoyExtAuthzHttp provider.",
+                                    "type": "boolean"
+                                  }
+                                }
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service that implements the Envoy ext_authz gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"my-ext-authz.foo.svc.cluster.local\" or \"bar/my-ext-authz.example.com\".",
+                                "type": "string"
+                              },
+                              "statusOnError": {
+                                "description": "Sets the HTTP status that is returned to the client when there is a network error to the authorization service.\nThe default status is \"403\" (HTTP Forbidden).",
+                                "type": "string"
+                              },
+                              "timeout": {
+                                "description": "The maximum duration that the proxy will wait for a response from the provider, this is the timeout for a specific request (default timeout: 600s).\nWhen this timeout condition is met, the proxy marks the communication to the authorization service as failure.\nIn this situation, the response sent back to the client will depend on the configured `failOpen` field.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "envoyExtAuthzHttp": {
+                            "description": "Configures an external authorizer that implements the Envoy ext_authz filter authorization check service using the HTTP API.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "failOpen": {
+                                "description": "If true, the user request will be allowed even if the communication with the authorization service has failed,\nor if the authorization service has returned a HTTP 5xx error.\nDefault is false and the request will be rejected with \"Forbidden\" response.",
+                                "type": "boolean"
+                              },
+                              "headersToDownstreamOnAllow": {
+                                "description": "List of headers from the authorization service that should be forwarded to downstream when the authorization\ncheck result is allowed (HTTP code 200).\nIf not specified, the original response will not be modified and forwarded to downstream as-is.\nNote, any existing headers will be overridden.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "headersToDownstreamOnDeny": {
+                                "description": "List of headers from the authorization service that should be forwarded to downstream when the authorization\ncheck result is not allowed (HTTP code other than 200).\nIf not specified, all the authorization response headers, except *Authority (Host)* will be in the response to\nthe downstream.\nWhen a header is included in this list, *Path*, *Status*, *Content-Length*, *WWWAuthenticate* and *Location* are\nautomatically added.\nNote, the body from the authorization service is always included in the response to downstream.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "headersToUpstreamOnAllow": {
+                                "description": "List of headers from the authorization service that should be added or overridden in the original request and\nforwarded to the upstream when the authorization check result is allowed (HTTP code 200).\nIf not specified, the original request will not be modified and forwarded to backend as-is.\nNote, any existing headers will be overridden.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "includeAdditionalHeadersInCheck": {
+                                "description": "Set of additional fixed headers that should be included in the authorization request sent to the authorization service.\nKey is the header name and value is the header value.\nNote that client request of the same key or headers specified in includeRequestHeadersInCheck will be overridden.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              },
+                              "includeHeadersInCheck": {
+                                "description": "DEPRECATED. Use includeRequestHeadersInCheck instead.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "includeRequestBodyInCheck": {
+                                "description": "If set, the client request body will be included in the authorization request sent to the authorization service.",
+                                "type": "object",
+                                "properties": {
+                                  "allowPartialMessage": {
+                                    "description": "When this field is true, ext-authz filter will buffer the message until maxRequestBytes is reached.\nThe authorization request will be dispatched and no 413 HTTP error will be returned by the filter.\nA \"x-envoy-auth-partial-body: false|true\" metadata header will be added to the authorization request message\nindicating if the body data is partial.",
+                                    "type": "boolean"
+                                  },
+                                  "maxRequestBytes": {
+                                    "description": "Sets the maximum size of a message body that the ext-authz filter will hold in memory.\nIf maxRequestBytes is reached, and allowPartialMessage is false, Envoy will return a 413 (Payload Too Large).\nOtherwise the request will be sent to the provider with a partial message.\nNote that this setting will have precedence over the failOpen field, the 413 will be returned even when the\nfailOpen is set to true.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "packAsBytes": {
+                                    "description": "If true, the body sent to the external authorization service in the gRPC authorization request is set with raw bytes\nin the [raw_body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L153).\nOtherwise, it will be filled with UTF-8 string in the [body field](https://github.com/envoyproxy/envoy/blame/cffb095d59d7935abda12b9509bcd136808367bb/api/envoy/service/auth/v3/attribute_context.proto#L147).\nThis field only works with the envoyExtAuthzGrpc provider and has no effect for the envoyExtAuthzHttp provider.",
+                                    "type": "boolean"
+                                  }
+                                }
+                              },
+                              "includeRequestHeadersInCheck": {
+                                "description": "List of client request headers that should be included in the authorization request sent to the authorization service.\nNote that in addition to the headers specified here following headers are included by default:\n1. *Host*, *Method*, *Path* and *Content-Length* are automatically sent.\n2. *Content-Length* will be set to 0 and the request will not have a message body. However, the authorization\nrequest can include the buffered client request body (controlled by includeRequestBodyInCheck setting),\nconsequently the value of Content-Length of the authorization request reflects the size of its payload size.\n\nExact, prefix and suffix matches are supported (similar to the\n[authorization policy rule syntax](https://istio.io/latest/docs/reference/config/security/authorization-policy/#Rule)\nexcept the presence match):\n- Exact match: \"abc\" will match on value \"abc\".\n- Prefix match: \"abc*\" will match on value \"abc\" and \"abcd\".\n- Suffix match: \"*abc\" will match on value \"abc\" and \"xabc\".",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "pathPrefix": {
+                                "description": "Sets a prefix to the value of authorization request header *Path*.\nFor example, setting this to \"/check\" for an original user request at path \"/admin\" will cause the\nauthorization check request to be sent to the authorization service at the path \"/check/admin\" instead of \"/admin\".",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service that implements the Envoy ext_authz HTTP authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"my-ext-authz.foo.svc.cluster.local\" or \"bar/my-ext-authz.example.com\".",
+                                "type": "string"
+                              },
+                              "statusOnError": {
+                                "description": "Sets the HTTP status that is returned to the client when there is a network error to the authorization service.\nThe default status is \"403\" (HTTP Forbidden).",
+                                "type": "string"
+                              },
+                              "timeout": {
+                                "description": "The maximum duration that the proxy will wait for a response from the provider (default timeout: 600s).\nWhen this timeout condition is met, the proxy marks the communication to the authorization service as failure.\nIn this situation, the response sent back to the client will depend on the configured `failOpen` field.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "envoyFileAccessLog": {
+                            "description": "Configures an Envoy File Access Log provider.",
+                            "type": "object",
+                            "properties": {
+                              "logFormat": {
+                                "description": "Optional. Allows overriding of the default access log format.",
+                                "type": "object",
+                                "properties": {
+                                  "labels": {
+                                    "description": "JSON structured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)\ncan be used as values for fields within the Struct. Values are rendered\nas strings, numbers, or boolean values, as appropriate\n(see: [format dictionaries](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries)). Nested JSON is\nsupported for some command operators (e.g. `FILTER_STATE` or `DYNAMIC_METADATA`).\nUse `labels: {}` for default envoy JSON log format.\n\nExample:\n```\nlabels:\n\n\tstatus: \"%RESPONSE_CODE%\"\n\tmessage: \"%LOCAL_REPLY_BODY%\"\n\n```",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "text": {
+                                    "description": "Textual format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be\nused in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)\nprovides more information.\n\nNOTE: Istio will insert a newline ('\\n') on all formats (if missing).\n\nExample: `text: \"%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\"`",
+                                    "type": "string"
+                                  }
+                                },
+                                "x-kubernetes-validations": [
+                                  {
+                                    "message": "At most one of [text labels] should be set",
+                                    "rule": "(has(self.text)?1:0) + (has(self.labels)?1:0) <= 1"
+                                  }
+                                ]
+                              },
+                              "path": {
+                                "description": "Path to a local file to write the access log entries.\nThis may be used to write to streams, via `/dev/stderr` and `/dev/stdout`\nIf unspecified, defaults to `/dev/stdout`.",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "envoyHttpAls": {
+                            "description": "Configures an Envoy Access Logging Service provider for HTTP traffic.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "additionalRequestHeadersToLog": {
+                                "description": "Optional. Additional request headers to log.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalResponseHeadersToLog": {
+                                "description": "Optional. Additional response headers to log.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalResponseTrailersToLog": {
+                                "description": "Optional. Additional response trailers to log.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "filterStateObjectsToLog": {
+                                "description": "Optional. Additional filter state objects to log.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "logName": {
+                                "description": "Optional. The friendly name of the access log.\nDefaults:\n-  \"http_envoy_accesslog\"\n-  \"listener_envoy_accesslog\"",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "envoyOtelAls": {
+                            "description": "Configures an Envoy Open Telemetry Access Logging Service provider.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "logFormat": {
+                                "description": "Optional. Format for the proxy access log\nEmpty value results in proxy's default access log format, following Envoy access logging formatting.",
+                                "type": "object",
+                                "properties": {
+                                  "labels": {
+                                    "description": "Optional. Additional attributes that describe the specific event occurrence.\nStructured format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators)\ncan be used as values for fields within the Struct. Values are rendered\nas strings, numbers, or boolean values, as appropriate\n(see: [format dictionaries](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-dictionaries)). Nested JSON is\nsupported for some command operators (e.g. FILTER_STATE or DYNAMIC_METADATA).\nAlias to `attributes` field in [Open Telemetry](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/open_telemetry/v3/logs_service.proto)\n\nExample:\n```\nlabels:\n\n\tstatus: \"%RESPONSE_CODE%\"\n\tmessage: \"%LOCAL_REPLY_BODY%\"\n\n```",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "text": {
+                                    "description": "Textual format for the envoy access logs. Envoy [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#command-operators) may be\nused in the format. The [format string documentation](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-strings)\nprovides more information.\nAlias to `body` field in [Open Telemetry](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/access_loggers/open_telemetry/v3/logs_service.proto)\nExample: `text: \"%LOCAL_REPLY_BODY%:%RESPONSE_CODE%:path=%REQ(:path)%\"`",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "logName": {
+                                "description": "Optional. The friendly name of the access log.\nDefaults:\n- \"otel_envoy_accesslog\"",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "envoyTcpAls": {
+                            "description": "Configures an Envoy Access Logging Service provider for TCP traffic.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "filterStateObjectsToLog": {
+                                "description": "Optional. Additional filter state objects to log.",
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "logName": {
+                                "description": "Optional. The friendly name of the access log.\nDefaults:\n- \"tcp_envoy_accesslog\"\n- \"listener_envoy_accesslog\"",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service that implements the Envoy ALS gRPC authorization service.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"envoy-als.foo.svc.cluster.local\" or \"bar/envoy-als.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "lightstep": {
+                            "description": "Configures a Lightstep tracing provider.\nDeprecated: For Istio 1.15+, please use an OpenTelemetryTracingProvider instead, more details can be found at https://github.com/istio/istio/issues/40027\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "accessToken": {
+                                "description": "The Lightstep access token.",
+                                "type": "string"
+                              },
+                              "maxTagLength": {
+                                "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service for the Lightstep collector.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"lightstep.default.svc.cluster.local\" or \"bar/lightstep.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "name": {
+                            "description": "REQUIRED. A unique name identifying the extension provider.",
+                            "type": "string"
+                          },
+                          "opencensus": {
+                            "description": "Configures an OpenCensusAgent tracing provider.\nDeprecated: OpenCensus is deprecated, more details can be found at https://opentelemetry.io/blog/2023/sunsetting-opencensus/\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "context": {
+                                "description": "Specifies the set of context propagation headers used for distributed\ntracing. Default is `[\"W3C_TRACE_CONTEXT\"]`. If multiple values are specified,\nthe proxy will attempt to read each header for each request and will\nwrite all headers.",
+                                "type": "array",
+                                "items": {
+                                  "description": "TraceContext selects the context propagation headers used for\ndistributed tracing.",
+                                  "type": "string",
+                                  "enum": [
+                                    "UNSPECIFIED",
+                                    "W3C_TRACE_CONTEXT",
+                                    "GRPC_BIN",
+                                    "CLOUD_TRACE_CONTEXT",
+                                    "B3"
+                                  ]
+                                }
+                              },
+                              "maxTagLength": {
+                                "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service for the OpenCensusAgent.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"ocagent.default.svc.cluster.local\" or \"bar/ocagent.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "opentelemetry": {
+                            "description": "Configures an OpenTelemetry tracing provider.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "dynatraceSampler": {
+                                "description": "The Dynatrace adaptive traffic management (ATM) sampler.\n\nExample configuration:\n\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: \"{your-environment-id}.live.dynatrace.com\"\n    http:\n    path: \"/api/v2/otlp/v1/traces\"\n    timeout: 10s\n    headers:\n  - name: \"Authorization\"\n    value: \"Api-Token dt0c01.\"\n    resourceDetectors:\n    dynatrace: {}\n    dynatraceSampler:\n    tenant: \"{your-environment-id}\"\n    clusterId: 1234",
+                                "type": "object",
+                                "required": [
+                                  "clusterId",
+                                  "tenant"
+                                ],
+                                "properties": {
+                                  "clusterId": {
+                                    "description": "REQUIRED. The identifier of the cluster in the Dynatrace platform.\nThe cluster here is Dynatrace-specific concept and not related to the cluster concept in Istio/Envoy.\n\nThe value can be obtained from the Istio deployment page in Dynatrace.",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "httpService": {
+                                    "description": "Optional. Dynatrace HTTP API to obtain sampling configuration.\n\nWhen not provided, the Dynatrace Sampler will re-use the configuration from the OpenTelemetryTracingProvider HTTP Exporter\n(`service`, `port` and `http`), including the access token.",
+                                    "type": "object",
+                                    "required": [
+                                      "http",
+                                      "port",
+                                      "service"
+                                    ],
+                                    "properties": {
+                                      "http": {
+                                        "description": "REQUIRED. Specifies sampling configuration URI.",
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "headers": {
+                                            "description": "Optional. Allows specifying custom HTTP headers that will be added\nto each HTTP request sent.",
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "required": [
+                                                "name",
+                                                "value"
+                                              ],
+                                              "properties": {
+                                                "name": {
+                                                  "description": "REQUIRED. The HTTP header name.",
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "description": "REQUIRED. The HTTP header value.",
+                                                  "type": "string"
+                                                }
+                                              }
+                                            }
+                                          },
+                                          "path": {
+                                            "description": "REQUIRED. Specifies the path on the service.",
+                                            "type": "string"
+                                          },
+                                          "timeout": {
+                                            "description": "Optional. Specifies the timeout for the HTTP request.\nIf not specified, the default is 3s.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "port": {
+                                        "description": "REQUIRED. Specifies the port of the service.",
+                                        "type": "integer",
+                                        "format": "int32"
+                                      },
+                                      "service": {
+                                        "description": "REQUIRED. Specifies the Dynatrace environment to obtain the sampling configuration.\nThe format is `<Hostname>`, where `<Hostname>` is the fully qualified Dynatrace environment\nhost name defined in the ServiceEntry.\n\nExample: \"{your-environment-id}.live.dynatrace.com\".",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "rootSpansPerMinute": {
+                                    "description": "Optional. Number of sampled spans per minute to be used\nwhen the adaptive value cannot be obtained from the Dynatrace API.\n\nA default value of `1000` is used when:\n\n- `rootSpansPerMinute` is unset\n- `rootSpansPerMinute` is set to 0",
+                                    "type": "integer",
+                                    "format": "int32"
+                                  },
+                                  "tenant": {
+                                    "description": "REQUIRED. The Dynatrace customer's tenant identifier.\n\nThe value can be obtained from the Istio deployment page in Dynatrace.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "grpc": {
+                                "description": "Optional. Specifies the configuration for exporting OTLP traces via GRPC.\nWhen empty, traces will check whether HTTP is set.\nIf not, traces will use default GRPC configurations.\n\nThe following example shows how to configure the OpenTelemetry ExtensionProvider to export via GRPC:\n\n1. Add/change the OpenTelemetry extension provider in `MeshConfig`\n```yaml\n  - name: opentelemetry\n    opentelemetry:\n    port: 8090\n    service: tracing.example.com\n    grpc:\n    timeout: 10s\n    initialMetadata:\n  - name: \"Authentication\"\n    value: \"token-xxxxx\"\n\n```\n\n2. Deploy a `ServiceEntry` for the observability back-end\n```yaml\napiVersion: networking.istio.io/v1alpha3\nkind: ServiceEntry\nmetadata:\n\n\tname: tracing-grpc\n\nspec:\n\n\thosts:\n\t- tracing.example.com\n\tports:\n\t- number: 8090\n\t  name: grpc-port\n\t  protocol: GRPC\n\tresolution: DNS\n\tlocation: MESH_EXTERNAL\n\n```",
+                                "type": "object",
+                                "properties": {
+                                  "initialMetadata": {
+                                    "description": "Optional. Additional metadata to include in streams initiated to the GrpcService. This can be used for\nscenarios in which additional ad hoc authorization headers (e.g. \"x-foo-bar: baz-key\") are to\nbe injected.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "REQUIRED. The HTTP header name.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "REQUIRED. The HTTP header value.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "timeout": {
+                                    "description": "Optional. Specifies the timeout for the GRPC request.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "http": {
+                                "description": "Optional. Specifies the configuration for exporting OTLP traces via HTTP.\nWhen empty, traces will be exported via gRPC.\n\nThe following example shows how to configure the OpenTelemetry ExtensionProvider to export via HTTP:\n\n1. Add/change the OpenTelemetry extension provider in `MeshConfig`\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: my.olly-backend.com\n    http:\n    path: \"/api/otlp/traces\"\n    timeout: 10s\n    headers:\n  - name: \"my-custom-header\"\n    value: \"some value\"\n\n```\n\n2. Deploy a `ServiceEntry` for the observability back-end\n```yaml\napiVersion: networking.istio.io/v1alpha3\nkind: ServiceEntry\nmetadata:\n\n\tname: my-olly-backend\n\nspec:\n\n\thosts:\n\t- my.olly-backend.com\n\tports:\n\t- number: 443\n\t  name: https-port\n\t  protocol: HTTPS\n\tresolution: DNS\n\tlocation: MESH_EXTERNAL\n\n---\napiVersion: networking.istio.io/v1alpha3\nkind: DestinationRule\nmetadata:\n\n\tname: my-olly-backend\n\nspec:\n\n\thost: my.olly-backend.com\n\ttrafficPolicy:\n\t  portLevelSettings:\n\t  - port:\n\t      number: 443\n\t    tls:\n\t      mode: SIMPLE\n\n```",
+                                "type": "object",
+                                "required": [
+                                  "path"
+                                ],
+                                "properties": {
+                                  "headers": {
+                                    "description": "Optional. Allows specifying custom HTTP headers that will be added\nto each HTTP request sent.",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "required": [
+                                        "name",
+                                        "value"
+                                      ],
+                                      "properties": {
+                                        "name": {
+                                          "description": "REQUIRED. The HTTP header name.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "description": "REQUIRED. The HTTP header value.",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "path": {
+                                    "description": "REQUIRED. Specifies the path on the service.",
+                                    "type": "string"
+                                  },
+                                  "timeout": {
+                                    "description": "Optional. Specifies the timeout for the HTTP request.\nIf not specified, the default is 3s.",
+                                    "type": "string"
+                                  }
+                                }
+                              },
+                              "maxTagLength": {
+                                "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "resourceDetectors": {
+                                "description": "Optional. Specifies [Resource Detectors](https://opentelemetry.io/docs/specs/otel/resource/sdk/)\nto be used by the OpenTelemetry Tracer. When multiple resources are provided, they are merged\naccording to the OpenTelemetry [Resource specification](https://opentelemetry.io/docs/specs/otel/resource/sdk/#merge).\n\nThe following example shows how to configure the Environment Resource Detector, that will\nread the attributes from the environment variable `OTEL_RESOURCE_ATTRIBUTES`:\n\n```yaml\n  - name: otel-tracing\n    opentelemetry:\n    port: 443\n    service: my.olly-backend.com\n    resourceDetectors:\n    environment: {}\n\n```",
+                                "type": "object",
+                                "properties": {
+                                  "dynatrace": {
+                                    "description": "Dynatrace Resource Detector.\nThe resource detector reads from the Dynatrace enrichment files\nand adds host/process related attributes to the OpenTelemetry resource.\n\nSee: [Enrich ingested data with Dynatrace-specific dimensions](https://docs.dynatrace.com/docs/shortlink/enrichment-files)",
+                                    "type": "object"
+                                  },
+                                  "environment": {
+                                    "description": "OpenTelemetry Environment Resource Detector.\nThe resource detector reads attributes from the environment variable `OTEL_RESOURCE_ATTRIBUTES`\nand adds them to the OpenTelemetry resource.\n\nSee: [Resource specification](https://opentelemetry.io/docs/specs/otel/resource/sdk/#specifying-resource-information-via-an-environment-variable)",
+                                    "type": "object"
+                                  }
+                                }
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the OpenTelemetry endpoint that will receive OTLP traces.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"otlp.default.svc.cluster.local\" or \"bar/otlp.example.com\".",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-validations": [
+                              {
+                                "message": "At most one of [dynatraceSampler] should be set",
+                                "rule": "(has(self.dynatraceSampler)?1:0) <= 1"
+                              }
+                            ]
+                          },
+                          "prometheus": {
+                            "description": "Configures a Prometheus metrics provider.",
+                            "type": "object"
+                          },
+                          "skywalking": {
+                            "description": "Configures a Apache SkyWalking provider.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "accessToken": {
+                                "description": "Optional. The SkyWalking OAP access token.",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service for the SkyWalking receiver.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"skywalking.default.svc.cluster.local\" or \"bar/skywalking.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          },
+                          "stackdriver": {
+                            "description": "Configures a Stackdriver provider.",
+                            "type": "object",
+                            "properties": {
+                              "debug": {
+                                "description": "debug enables trace output to stdout.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                                "type": "boolean"
+                              },
+                              "logging": {
+                                "description": "Optional. Controls Stackdriver logging behavior.",
+                                "type": "object",
+                                "properties": {
+                                  "labels": {
+                                    "description": "Collection of tag names and tag expressions to include in the log\nentry. Conflicts are resolved by the tag name by overriding previously\nsupplied values.\n\nExample:\n\n\tlabels:\n\t  path: request.url_path\n\t  foo: request.headers['x-foo']",
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "maxNumberOfAnnotations": {
+                                "description": "The global default max number of annotation events per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                                "type": "integer",
+                                "format": "int64"
+                              },
+                              "maxNumberOfAttributes": {
+                                "description": "The global default max number of attributes per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                                "type": "integer",
+                                "format": "int64"
+                              },
+                              "maxNumberOfMessageEvents": {
+                                "description": "The global default max number of message events per span.\ndefault is 200.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                                "type": "integer",
+                                "format": "int64"
+                              },
+                              "maxTagLength": {
+                                "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                                "type": "integer",
+                                "format": "int32"
+                              }
+                            }
+                          },
+                          "zipkin": {
+                            "description": "Configures a tracing provider that uses the Zipkin API.",
+                            "type": "object",
+                            "required": [
+                              "port",
+                              "service"
+                            ],
+                            "properties": {
+                              "enable64bitTraceId": {
+                                "description": "Optional. A 128 bit trace id will be used in Istio.\nIf true, will result in a 64 bit trace id being used.",
+                                "type": "boolean"
+                              },
+                              "maxTagLength": {
+                                "description": "Optional. Controls the overall path length allowed in a reported span.\nNOTE: currently only controls max length of the path tag.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "path": {
+                                "description": "Optional. Specifies the endpoint of Zipkin API.\nThe default value is \"/api/v2/spans\".",
+                                "type": "string"
+                              },
+                              "port": {
+                                "description": "REQUIRED. Specifies the port of the service.",
+                                "type": "integer",
+                                "format": "int32"
+                              },
+                              "service": {
+                                "description": "REQUIRED. Specifies the service that the Zipkin API.\nThe format is `[<Namespace>/]<Hostname>`. The specification of `<Namespace>` is required only when it is insufficient\nto unambiguously resolve a service in the service registry. The `<Hostname>` is a fully qualified host name of a\nservice defined by the Kubernetes service or ServiceEntry.\n\nExample: \"zipkin.default.svc.cluster.local\" or \"bar/zipkin.example.com\".",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "x-kubernetes-validations": [
+                          {
+                            "message": "At most one of [envoyExtAuthzHttp envoyExtAuthzGrpc zipkin lightstep datadog stackdriver opencensus skywalking opentelemetry prometheus envoyFileAccessLog envoyHttpAls envoyTcpAls envoyOtelAls] should be set",
+                            "rule": "(has(self.envoyExtAuthzHttp)?1:0) + (has(self.envoyExtAuthzGrpc)?1:0) + (has(self.zipkin)?1:0) + (has(self.lightstep)?1:0) + (has(self.datadog)?1:0) + (has(self.stackdriver)?1:0) + (has(self.opencensus)?1:0) + (has(self.skywalking)?1:0) + (has(self.opentelemetry)?1:0) + (has(self.prometheus)?1:0) + (has(self.envoyFileAccessLog)?1:0) + (has(self.envoyHttpAls)?1:0) + (has(self.envoyTcpAls)?1:0) + (has(self.envoyOtelAls)?1:0) <= 1"
+                          }
+                        ]
+                      }
+                    },
+                    "h2UpgradePolicy": {
+                      "description": "Specify if http1.1 connections should be upgraded to http2 by default.\nif sidecar is installed on all pods in the mesh, then this should be set to `UPGRADE`.\nIf one or more services or namespaces do not have sidecar(s), then this should be set to `DO_NOT_UPGRADE`.\nIt can be enabled by destination using the `destinationRule.trafficPolicy.connectionPool.http.h2UpgradePolicy` override.",
+                      "type": "string",
+                      "enum": [
+                        "DO_NOT_UPGRADE",
+                        "UPGRADE"
+                      ]
+                    },
+                    "inboundClusterStatName": {
+                      "description": "Name to be used while emitting statistics for inbound clusters. The same pattern is used while computing stat prefix for\nnetwork filters like TCP and Redis.\nBy default, Istio emits statistics with the pattern `inbound|<port>|<port-name>|<service-FQDN>`.\nFor example `inbound|7443|grpc-reviews|reviews.prod.svc.cluster.local`. This can be used to override that pattern.\n\nA Pattern can be composed of various pre-defined variables. The following variables are supported.\n\n- `%SERVICE%` - Will be substituted with short hostname of the service.\n- `%SERVICE_NAME%` - Will be substituted with name of the service.\n- `%SERVICE_FQDN%` - Will be substituted with FQDN of the service.\n- `%SERVICE_PORT%` - Will be substituted with port of the service.\n- `%TARGET_PORT%`  - Will be substituted with the target port of the service.\n- `%SERVICE_PORT_NAME%` - Will be substituted with port name of the service.\n\nFollowing are some examples of supported patterns for reviews:\n\n- `%SERVICE_FQDN%_%SERVICE_PORT%` will use reviews.prod.svc.cluster.local_7443 as the stats name.\n- `%SERVICE%` will use reviews.prod as the stats name.",
+                      "type": "string"
+                    },
+                    "inboundTrafficPolicy": {
+                      "description": "Set the default behavior of the sidecar for handling inbound\ntraffic to the application.  If your application listens on\nlocalhost, you will need to set this to `LOCALHOST`.",
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "PASSTHROUGH",
+                            "LOCALHOST"
+                          ]
+                        }
+                      }
+                    },
+                    "ingressClass": {
+                      "description": "Class of ingress resources to be processed by Istio ingress\ncontroller. This corresponds to the value of\n`kubernetes.io/ingress.class` annotation.",
+                      "type": "string"
+                    },
+                    "ingressControllerMode": {
+                      "description": "Defines whether to use Istio ingress controller for annotated or all ingress resources.\nDefault mode is `STRICT`.",
+                      "type": "string",
+                      "enum": [
+                        "UNSPECIFIED",
+                        "OFF",
+                        "DEFAULT",
+                        "STRICT"
+                      ]
+                    },
+                    "ingressSelector": {
+                      "description": "Defines which gateway deployment to use as the Ingress controller. This field corresponds to\nthe Gateway.selector field, and will be set as `istio: INGRESS_SELECTOR`.\nBy default, `ingressgateway` is used, which will select the default IngressGateway as it has the\n`istio: ingressgateway` labels.\nIt is recommended that this is the same value as ingressService.",
+                      "type": "string"
+                    },
+                    "ingressService": {
+                      "description": "Name of the Kubernetes service used for the istio ingress controller.\nIf no ingress controller is specified, the default value `istio-ingressgateway` is used.",
+                      "type": "string"
+                    },
+                    "localityLbSetting": {
+                      "description": "Locality based load balancing distribution or failover settings.\nIf unspecified, locality based load balancing will be enabled by default.\nHowever, this requires outlierDetection to actually take effect for a particular\nservice, see https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/failover/",
+                      "type": "object",
+                      "properties": {
+                        "distribute": {
+                          "description": "Optional: only one of distribute, failover or failoverPriority can be set.\nExplicitly specify loadbalancing weight across different zones and geographical locations.\nRefer to [Locality weighted load balancing](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/locality_weight)\nIf empty, the locality weight is set according to the endpoints number within it.",
+                          "type": "array",
+                          "items": {
+                            "description": "Describes how traffic originating in the 'from' zone or sub-zone is\ndistributed over a set of 'to' zones. Syntax for specifying a zone is\n{region}/{zone}/{sub-zone} and terminal wildcards are allowed on any\nsegment of the specification. Examples:\n\n`*` - matches all localities\n\n`us-west/*` - all zones and sub-zones within the us-west region\n\n`us-west/zone-1/*` - all sub-zones within us-west/zone-1",
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "description": "Originating locality, '/' separated, e.g. 'region/zone/sub_zone'.",
+                                "type": "string"
+                              },
+                              "to": {
+                                "description": "Map of upstream localities to traffic distribution weights. The sum of\nall weights should be 100. Any locality not present will\nreceive no traffic.",
+                                "type": "object",
+                                "additionalProperties": {
+                                  "type": "integer",
+                                  "format": "int32"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "enabled": {
+                          "description": "Enable locality load balancing. This is DestinationRule-level and will override mesh-wide settings in entirety.\ne.g. true means that turn on locality load balancing for this DestinationRule no matter what mesh-wide settings is.",
+                          "type": "boolean"
+                        },
+                        "failover": {
+                          "description": "Optional: only one of distribute, failover or failoverPriority can be set.\nExplicitly specify the region traffic will land on when endpoints in local region becomes unhealthy.\nShould be used together with OutlierDetection to detect unhealthy endpoints.\nNote: if no OutlierDetection specified, this will not take effect.",
+                          "type": "array",
+                          "items": {
+                            "description": "Specify the traffic failover policy across regions. Since zone and sub-zone\nfailover is supported by default this only needs to be specified for\nregions when the operator needs to constrain traffic failover so that\nthe default behavior of failing over to any endpoint globally does not\napply. This is useful when failing over traffic across regions would not\nimprove service health or may need to be restricted for other reasons\nlike regulatory controls.",
+                            "type": "object",
+                            "properties": {
+                              "from": {
+                                "description": "Originating region.",
+                                "type": "string"
+                              },
+                              "to": {
+                                "description": "Destination region the traffic will fail over to when endpoints in\nthe 'from' region becomes unhealthy.",
+                                "type": "string"
+                              }
+                            }
+                          }
+                        },
+                        "failoverPriority": {
+                          "description": "failoverPriority is an ordered list of labels used to sort endpoints to do priority based load balancing.\nThis is to support traffic failover across different groups of endpoints.\nTwo kinds of labels can be specified:\n\n  - Specify only label keys `[key1, key2, key3]`, istio would compare the label values of client with endpoints.\n    Suppose there are total N label keys `[key1, key2, key3, ...keyN]` specified:\n\n    1. Endpoints matching all N labels with the client proxy have priority P(0) i.e. the highest priority.\n    2. Endpoints matching the first N-1 labels with the client proxy have priority P(1) i.e. second highest priority.\n    3. By extension of this logic, endpoints matching only the first label with the client proxy has priority P(N-1) i.e. second lowest priority.\n    4. All the other endpoints have priority P(N) i.e. lowest priority.\n\n  - Specify labels with key and value `[key1=value1, key2=value2, key3=value3]`, istio would compare the labels with endpoints.\n    Suppose there are total N labels `[key1=value1, key2=value2, key3=value3, ...keyN=valueN]` specified:\n\n    1. Endpoints matching all N labels have priority P(0) i.e. the highest priority.\n    2. Endpoints matching the first N-1 labels have priority P(1) i.e. second highest priority.\n    3. By extension of this logic, endpoints matching only the first label has priority P(N-1) i.e. second lowest priority.\n    4. All the other endpoints have priority P(N) i.e. lowest priority.\n\nNote: For a label to be considered for match, the previous labels must match, i.e. nth label would be considered matched only if first n-1 labels match.\n\nIt can be any label specified on both client and server workloads.\nThe following labels which have special semantic meaning are also supported:\n\n  - `topology.istio.io/network` is used to match the network metadata of an endpoint, which can be specified by pod/namespace label `topology.istio.io/network`, sidecar env `ISTIO_META_NETWORK` or MeshNetworks.\n  - `topology.istio.io/cluster` is used to match the clusterID of an endpoint, which can be specified by pod label `topology.istio.io/cluster` or pod env `ISTIO_META_CLUSTER_ID`.\n  - `topology.kubernetes.io/region` is used to match the region metadata of an endpoint, which maps to Kubernetes node label `topology.kubernetes.io/region` or the deprecated label `failure-domain.beta.kubernetes.io/region`.\n  - `topology.kubernetes.io/zone` is used to match the zone metadata of an endpoint, which maps to Kubernetes node label `topology.kubernetes.io/zone` or the deprecated label `failure-domain.beta.kubernetes.io/zone`.\n  - `topology.istio.io/subzone` is used to match the subzone metadata of an endpoint, which maps to Istio node label `topology.istio.io/subzone`.\n  - `kubernetes.io/hostname` is used to match the current node of an endpoint, which maps to Kubernetes node label `kubernetes.io/hostname`.\n\nThe below topology config indicates the following priority levels:\n\n```yaml\nfailoverPriority:\n- \"topology.istio.io/network\"\n- \"topology.kubernetes.io/region\"\n- \"topology.kubernetes.io/zone\"\n- \"topology.istio.io/subzone\"\n```\n\n1. endpoints match same [network, region, zone, subzone] label with the client proxy have the highest priority.\n2. endpoints have same [network, region, zone] label but different [subzone] label with the client proxy have the second highest priority.\n3. endpoints have same [network, region] label but different [zone] label with the client proxy have the third highest priority.\n4. endpoints have same [network] but different [region] labels with the client proxy have the fourth highest priority.\n5. all the other endpoints have the same lowest priority.\n\nSuppose a service associated endpoints reside in multi clusters, the below example represents:\n1. endpoints in `clusterA` and has `version=v1` label have P(0) priority.\n2. endpoints not in `clusterA` but has `version=v1` label have P(1) priority.\n2. all the other endpoints have P(2) priority.\n\n```yaml\nfailoverPriority:\n- \"version=v1\"\n- \"topology.istio.io/cluster=clusterA\"\n```\n\nOptional: only one of distribute, failover or failoverPriority can be set.\nAnd it should be used together with `OutlierDetection` to detect unhealthy endpoints, otherwise has no effect.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
+                    "meshMTLS": {
+                      "description": "The below configuration parameters can be used to specify TLSConfig for mesh traffic.\nFor example, a user could enable min TLS version for ISTIO_MUTUAL traffic and specify a curve for non ISTIO_MUTUAL traffic like below:\n```yaml\nmeshConfig:\n\n\tmeshMTLS:\n\t  minProtocolVersion: TLSV1_3\n\ttlsDefaults:\n\t  Note: applicable only for non ISTIO_MUTUAL scenarios\n\t  ecdhCurves:\n\t    - P-256\n\t    - P-512\n\n```\nConfiguration of mTLS for traffic between workloads with ISTIO_MUTUAL TLS traffic.\n\nNote: Mesh mTLS does not respect ECDH curves.",
+                      "type": "object",
+                      "properties": {
+                        "cipherSuites": {
+                          "description": "Optional: If specified, the TLS connection will only support the specified cipher list when negotiating TLS 1.0-1.2.\nIf not specified, the following cipher suites will be used:\n```\nECDHE-ECDSA-AES256-GCM-SHA384\nECDHE-RSA-AES256-GCM-SHA384\nECDHE-ECDSA-AES128-GCM-SHA256\nECDHE-RSA-AES128-GCM-SHA256\nAES256-GCM-SHA384\nAES128-GCM-SHA256\n```",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "ecdhCurves": {
+                          "description": "Optional: If specified, the TLS connection will only support the specified ECDH curves for the DH key exchange.\nIf not specified, the default curves enforced by Envoy will be used. For details about the default curves, refer to\n[Ecdh Curves](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "minProtocolVersion": {
+                          "description": "Optional: the minimum TLS protocol version. The default minimum\nTLS version will be TLS 1.2. As servers may not be Envoy and be\nset to TLS 1.2 (e.g., workloads using mTLS without sidecars), the\nminimum TLS version for clients may also be TLS 1.2.\nIn the current Istio implementation, the maximum TLS protocol version\nis TLS 1.3.",
+                          "type": "string",
+                          "enum": [
+                            "TLS_AUTO",
+                            "TLSV1_2",
+                            "TLSV1_3"
+                          ]
+                        }
+                      }
+                    },
+                    "outboundClusterStatName": {
+                      "description": "Name to be used while emitting statistics for outbound clusters. The same pattern is used while computing stat prefix for\nnetwork filters like TCP and Redis.\nBy default, Istio emits statistics with the pattern `outbound|<port>|<subsetname>|<service-FQDN>`.\nFor example `outbound|8080|v2|reviews.prod.svc.cluster.local`. This can be used to override that pattern.\n\nA Pattern can be composed of various pre-defined variables. The following variables are supported.\n\n- `%SERVICE%` - Will be substituted with short hostname of the service.\n- `%SERVICE_NAME%` - Will be substituted with name of the service.\n- `%SERVICE_FQDN%` - Will be substituted with FQDN of the service.\n- `%SERVICE_PORT%` - Will be substituted with port of the service.\n- `%SERVICE_PORT_NAME%` - Will be substituted with port name of the service.\n- `%SUBSET_NAME%` - Will be substituted with subset.\n\nFollowing are some examples of supported patterns for reviews:\n\n- `%SERVICE_FQDN%_%SERVICE_PORT%` will use `reviews.prod.svc.cluster.local_7443` as the stats name.\n- `%SERVICE%` will use reviews.prod as the stats name.",
+                      "type": "string"
+                    },
+                    "outboundTrafficPolicy": {
+                      "description": "Set the default behavior of the sidecar for handling outbound\ntraffic from the application.\n\nCan be overridden at a Sidecar level by setting the `OutboundTrafficPolicy` in the\n[Sidecar API](https://istio.io/docs/reference/config/networking/sidecar/#OutboundTrafficPolicy).\n\nDefault mode is `ALLOW_ANY`, which means outbound traffic to unknown destinations will be allowed.",
+                      "type": "object",
+                      "properties": {
+                        "mode": {
+                          "type": "string",
+                          "enum": [
+                            "REGISTRY_ONLY",
+                            "ALLOW_ANY"
+                          ]
+                        }
+                      }
+                    },
+                    "pathNormalization": {
+                      "description": "ProxyPathNormalization configures how URL paths in incoming and outgoing HTTP requests are\nnormalized by the sidecars and gateways.\nThe normalized paths will be used in all aspects through the requests' lifetime on the\nsidecars and gateways, which includes routing decisions in outbound direction (client proxy),\nauthorization policy match and enforcement in inbound direction (server proxy), and the URL\npath proxied to the upstream service.\nIf not set, the NormalizationType.DEFAULT configuration will be used.",
+                      "type": "object",
+                      "properties": {
+                        "normalization": {
+                          "type": "string",
+                          "enum": [
+                            "DEFAULT",
+                            "NONE",
+                            "BASE",
+                            "MERGE_SLASHES",
+                            "DECODE_AND_MERGE_SLASHES"
+                          ]
+                        }
+                      }
+                    },
+                    "protocolDetectionTimeout": {
+                      "description": "Automatic protocol detection uses a set of heuristics to\ndetermine whether the connection is using TLS or not (on the\nserver side), as well as the application protocol being used\n(e.g., http vs tcp). These heuristics rely on the client sending\nthe first bits of data. For server first protocols like MySQL,\nMongoDB, etc. Envoy will timeout on the protocol detection after\nthe specified period, defaulting to non mTLS plain TCP\ntraffic. Set this field to tweak the period that Envoy will wait\nfor the client to send the first bits of data. (MUST be >=1ms or\n0s to disable). Default detection timeout is 0s (no timeout).\n\nSetting a timeout is not recommended nor safe. Even high timeouts (>5s) will be hit\noccasionally, and when they occur the result is typically broken traffic that may not\nrecover on its own. Exceptionally high values might solve this, but injecting 60s delays\nonto new connections is generally not tenable anyways.",
+                      "type": "string"
+                    },
+                    "proxyHttpPort": {
+                      "description": "Port on which Envoy should listen for HTTP PROXY requests if set.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "proxyInboundListenPort": {
+                      "description": "Port on which Envoy should listen for all inbound traffic to the pod/vm will be captured to.\nDefault port is 15006.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "proxyListenPort": {
+                      "description": "Port on which Envoy should listen for all outbound traffic to other services.\nDefault port is 15001.",
+                      "type": "integer",
+                      "format": "int32"
+                    },
+                    "rootNamespace": {
+                      "description": "The namespace to treat as the administrative root namespace for\nIstio configuration. When processing a leaf namespace Istio will search for\ndeclarations in that namespace first and if none are found it will\nsearch in the root namespace. Any matching declaration found in the root\nnamespace is processed as if it were declared in the leaf namespace.\n\nThe precise semantics of this processing are documented on each resource\ntype.",
+                      "type": "string"
+                    },
+                    "serviceSettings": {
+                      "description": "Settings to be applied to select services.",
+                      "type": "array",
+                      "items": {
+                        "description": "Settings to be applied to select services.\n\nFor example, the following configures all services in namespace \"foo\" as well as the\n\"bar\" service in namespace \"baz\" to be considered cluster-local:\n\n```yaml\nserviceSettings:\n  - settings:\n    clusterLocal: true\n    hosts:\n  - \"*.foo.svc.cluster.local\"\n  - \"bar.baz.svc.cluster.local\"\n\n```",
+                        "type": "object",
+                        "properties": {
+                          "hosts": {
+                            "description": "The services to which the Settings should be applied. Services are selected using the hostname\nmatching rules used by DestinationRule.\n\nFor example: foo.bar.svc.cluster.local, *.baz.svc.cluster.local",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "settings": {
+                            "description": "The settings to apply to the selected services.",
+                            "type": "object",
+                            "properties": {
+                              "clusterLocal": {
+                                "description": "If true, specifies that the client and service endpoints must reside in the same cluster.\nBy default, in multi-cluster deployments, the Istio control plane assumes all service\nendpoints to be reachable from any client in any of the clusters which are part of the\nmesh. This configuration option limits the set of service endpoints visible to a client\nto be cluster scoped.\n\nThere are some common scenarios when this can be useful:\n\n  - A service (or group of services) is inherently local to the cluster and has local storage\n    for that cluster. For example, the kube-system namespace (e.g. the Kube API Server).\n  - A mesh administrator wants to slowly migrate services to Istio. They might start by first\n    having services cluster-local and then slowly transition them to mesh-wide. They could do\n    this service-by-service (e.g. mysvc.myns.svc.cluster.local) or as a group\n    (e.g. *.myns.svc.cluster.local).\n\nBy default Istio will consider kubernetes.default.svc (i.e. the API Server) as well as all\nservices in the kube-system namespace to be cluster-local, unless explicitly overridden here.",
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "tcpKeepalive": {
+                      "description": "If set then set `SO_KEEPALIVE` on the socket to enable TCP Keepalives.",
+                      "type": "object",
+                      "properties": {
+                        "interval": {
+                          "description": "The time duration between keep-alive probes.\nDefault is to use the OS level configuration\n(unless overridden, Linux defaults to 75s.)",
+                          "type": "string"
+                        },
+                        "probes": {
+                          "description": "Maximum number of keepalive probes to send without response before\ndeciding the connection is dead. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 9.)",
+                          "type": "integer",
+                          "format": "int32"
+                        },
+                        "time": {
+                          "description": "The time duration a connection needs to be idle before keep-alive\nprobes start being sent. Default is to use the OS level configuration\n(unless overridden, Linux defaults to 7200s (ie 2 hours.)",
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "tlsDefaults": {
+                      "description": "Configuration of TLS for all traffic except for ISTIO_MUTUAL mode.\nCurrently, this supports configuration of ecdhCurves and cipherSuites only.\nFor ISTIO_MUTUAL TLS settings, use meshMTLS configuration.",
+                      "type": "object",
+                      "properties": {
+                        "cipherSuites": {
+                          "description": "Optional: If specified, the TLS connection will only support the specified cipher list when negotiating TLS 1.0-1.2.\nIf not specified, the following cipher suites will be used:\n```\nECDHE-ECDSA-AES256-GCM-SHA384\nECDHE-RSA-AES256-GCM-SHA384\nECDHE-ECDSA-AES128-GCM-SHA256\nECDHE-RSA-AES128-GCM-SHA256\nAES256-GCM-SHA384\nAES128-GCM-SHA256\n```",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "ecdhCurves": {
+                          "description": "Optional: If specified, the TLS connection will only support the specified ECDH curves for the DH key exchange.\nIf not specified, the default curves enforced by Envoy will be used. For details about the default curves, refer to\n[Ecdh Curves](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto).",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "minProtocolVersion": {
+                          "description": "Optional: the minimum TLS protocol version. The default minimum\nTLS version will be TLS 1.2. As servers may not be Envoy and be\nset to TLS 1.2 (e.g., workloads using mTLS without sidecars), the\nminimum TLS version for clients may also be TLS 1.2.\nIn the current Istio implementation, the maximum TLS protocol version\nis TLS 1.3.",
+                          "type": "string",
+                          "enum": [
+                            "TLS_AUTO",
+                            "TLSV1_2",
+                            "TLSV1_3"
+                          ]
+                        }
+                      }
+                    },
+                    "trustDomain": {
+                      "description": "The trust domain corresponds to the trust root of a system.\nRefer to [SPIFFE-ID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md#21-trust-domain)",
+                      "type": "string"
+                    },
+                    "trustDomainAliases": {
+                      "description": "The trust domain aliases represent the aliases of `trustDomain`.\nFor example, if we have\n```yaml\ntrustDomain: td1\ntrustDomainAliases: [\"td2\", \"td3\"]\n```\nAny service with the identity `td1/ns/foo/sa/a-service-account`, `td2/ns/foo/sa/a-service-account`,\nor `td3/ns/foo/sa/a-service-account` will be treated the same in the Istio mesh.",
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "verifyCertificateAtClient": {
+                      "description": "`VerifyCertificateAtClient` sets the mesh global default for peer certificate validation\nat the client-side proxy when `SIMPLE` TLS or `MUTUAL` TLS (non `ISTIO_MUTUAL`) origination\nmodes are used. This setting can be overridden at the host level via DestinationRule API.\nBy default, `VerifyCertificateAtClient` is `true`.\n\n`CaCertificates`: If set, proxy verifies CA signature based on given CaCertificates. If unset,\nand VerifyCertificateAtClient is true, proxy uses default System CA bundle. If unset and\n`VerifyCertificateAtClient` is false, proxy will not verify the CA.\n\n`SubjectAltNames`: If set, proxy verifies subject alt names are present in the SAN. If unset,\nand `VerifyCertificateAtClient` is true, proxy uses host in destination rule to verify the SANs.\nIf unset, and `VerifyCertificateAtClient` is false, proxy does not verify SANs.\n\nFor SAN, client-side proxy will exact match host in `DestinationRule` as well as one level\nwildcard if the specified host in DestinationRule doesn't contain a wildcard.\nFor example, if the host in `DestinationRule` is `x.y.com`, client-side proxy will\nmatch either `x.y.com` or `*.y.com` for the SAN in the presented server certificate.\nFor wildcard host name in DestinationRule, client-side proxy will do a suffix match. For example,\nif host is `*.x.y.com`, client-side proxy will verify the presented server certificate SAN matches\n\u201c.x.y.com` suffix.\n\nDeprecated: Marked as deprecated in mesh/v1alpha1/config.proto.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "multiCluster": {
+                  "description": "Settings for multicluster.\nThe name of the cluster we are installing in. Note this is a user-defined name, which must be consistent\nwith Istiod configuration.",
+                  "type": "object",
+                  "properties": {
+                    "clusterName": {
+                      "description": "The name of the cluster this installation will run in. This is required for sidecar injection\nto properly label proxies",
+                      "type": "string"
+                    },
+                    "enabled": {
+                      "description": "Enables the connection between two kubernetes clusters via their respective ingressgateway services.\nUse if the pods in each cluster cannot directly talk to one another.",
+                      "type": "boolean"
+                    },
+                    "globalDomainSuffix": {
+                      "description": "The suffix for global service names.",
+                      "type": "string"
+                    },
+                    "includeEnvoyFilter": {
+                      "description": "Enable envoy filter to translate `globalDomainSuffix` to cluster local suffix for cross cluster communication.",
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "podAnnotations": {
+                  "description": "Annotations added to each pod. The default annotations are required for scraping prometheus (in most environments).",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "podLabels": {
+                  "description": "Additional labels to apply on the pod level.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                },
+                "resources": {
+                  "description": "The k8s resource requests and limits for the ztunnel Pods.",
+                  "type": "object",
+                  "properties": {
+                    "claims": {
+                      "description": "Claims lists the names of resources, defined in spec.resourceClaims,\nthat are used by this container.\n\nThis is an alpha field and requires enabling the\nDynamicResourceAllocation feature gate.\n\nThis field is immutable. It can only be set for containers.",
+                      "type": "array",
+                      "items": {
+                        "description": "ResourceClaim references one entry in PodSpec.ResourceClaims.",
+                        "type": "object",
+                        "required": [
+                          "name"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name must match the name of one entry in pod.spec.resourceClaims of\nthe Pod where this field is used. It makes that resource available\ninside a container.",
+                            "type": "string"
+                          },
+                          "request": {
+                            "description": "Request is the name chosen for a request in the referenced claim.\nIf empty, everything from the claim is made available, otherwise\nonly the result of this request.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "x-kubernetes-list-map-keys": [
+                        "name"
+                      ],
+                      "x-kubernetes-list-type": "map"
+                    },
+                    "limits": {
+                      "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    },
+                    "requests": {
+                      "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                      "type": "object",
+                      "additionalProperties": {
+                        "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                        "x-kubernetes-int-or-string": true
+                      }
+                    }
+                  }
+                },
+                "revision": {
+                  "description": "Configures the revision this control plane is a part of",
+                  "type": "string"
+                },
+                "tag": {
+                  "description": "The container image tag to pull. Image will be `Hub/Image:Tag-Variant`.",
+                  "type": "string"
+                },
+                "variant": {
+                  "description": "The container image variant to pull. Options are \"debug\" or \"distroless\". Unset will use the default for the given version.",
+                  "type": "string"
+                },
+                "volumeMounts": {
+                  "description": "Additional volumeMounts to the ztunnel container",
+                  "type": "array",
+                  "items": {
+                    "description": "VolumeMount describes a mounting of a Volume within a container.",
+                    "type": "object",
+                    "required": [
+                      "mountPath",
+                      "name"
+                    ],
+                    "properties": {
+                      "mountPath": {
+                        "description": "Path within the container at which the volume should be mounted.  Must\nnot contain ':'.",
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "description": "mountPropagation determines how mounts are propagated from the host\nto container and the other way around.\nWhen not set, MountPropagationNone is used.\nThis field is beta in 1.10.\nWhen RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified\n(which defaults to None).",
+                        "type": "string"
+                      },
+                      "name": {
+                        "description": "This must match the Name of a Volume.",
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "description": "Mounted read-only if true, read-write otherwise (false or unspecified).\nDefaults to false.",
+                        "type": "boolean"
+                      },
+                      "recursiveReadOnly": {
+                        "description": "RecursiveReadOnly specifies whether read-only mounts should be handled\nrecursively.\n\nIf ReadOnly is false, this field has no meaning and must be unspecified.\n\nIf ReadOnly is true, and this field is set to Disabled, the mount is not made\nrecursively read-only.  If this field is set to IfPossible, the mount is made\nrecursively read-only, if it is supported by the container runtime.  If this\nfield is set to Enabled, the mount is made recursively read-only if it is\nsupported by the container runtime, otherwise the pod will not be started and\nan error will be generated to indicate the reason.\n\nIf this field is set to IfPossible or Enabled, MountPropagation must be set to\nNone (or be unspecified, which defaults to None).\n\nIf this field is not specified, it is treated as an equivalent of Disabled.",
+                        "type": "string"
+                      },
+                      "subPath": {
+                        "description": "Path within the volume from which the container's volume should be mounted.\nDefaults to \"\" (volume's root).",
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "description": "Expanded path within the volume from which the container's volume should be mounted.\nBehaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.\nDefaults to \"\" (volume's root).\nSubPathExpr and SubPath are mutually exclusive.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "volumes": {
+                  "description": "Additional volumes to add to the ztunnel Pod.",
+                  "type": "array",
+                  "items": {
+                    "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+                    "type": "object",
+                    "required": [
+                      "name"
+                    ],
+                    "properties": {
+                      "awsElasticBlockStore": {
+                        "description": "awsElasticBlockStore represents an AWS Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree\nawsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly value true will force the readOnly setting in VolumeMounts.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "azureDisk": {
+                        "description": "azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.\nDeprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type\nare redirected to the disk.csi.azure.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "diskName",
+                          "diskURI"
+                        ],
+                        "properties": {
+                          "cachingMode": {
+                            "description": "cachingMode is the Host Caching mode: None, Read Only, Read Write.",
+                            "type": "string"
+                          },
+                          "diskName": {
+                            "description": "diskName is the Name of the data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "diskURI": {
+                            "description": "diskURI is the URI of data disk in the blob storage",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is Filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "kind": {
+                            "description": "kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "azureFile": {
+                        "description": "azureFile represents an Azure File Service mount on the host and bind mount to the pod.\nDeprecated: AzureFile is deprecated. All operations for the in-tree azureFile type\nare redirected to the file.csi.azure.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "secretName",
+                          "shareName"
+                        ],
+                        "properties": {
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the  name of secret that contains Azure Storage Account Name and Key",
+                            "type": "string"
+                          },
+                          "shareName": {
+                            "description": "shareName is the azure share Name",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cephfs": {
+                        "description": "cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.\nDeprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "monitors"
+                        ],
+                        "properties": {
+                          "monitors": {
+                            "description": "monitors is Required: Monitors is a collection of Ceph monitors\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "path": {
+                            "description": "path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretFile": {
+                            "description": "secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is optional: User is the rados user name, default is admin\nMore info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "cinder": {
+                        "description": "cinder represents a cinder volume attached and mounted on kubelets host machine.\nDeprecated: Cinder is deprecated. All operations for the in-tree cinder type\nare redirected to the cinder.csi.openstack.org CSI driver.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is optional: points to a secret object containing parameters used to connect\nto OpenStack.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeID": {
+                            "description": "volumeID used to identify the volume in cinder.\nMore info: https://examples.k8s.io/mysql-cinder-pd/README.md",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "configMap": {
+                        "description": "configMap represents a configMap that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "name": {
+                            "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                            "type": "string"
+                          },
+                          "optional": {
+                            "description": "optional specify whether the ConfigMap or its keys must be defined",
+                            "type": "boolean"
+                          }
+                        },
+                        "x-kubernetes-map-type": "atomic"
+                      },
+                      "csi": {
+                        "description": "csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the CSI driver that handles this volume.\nConsult with your admin for the correct name as registered in the cluster.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType to mount. Ex. \"ext4\", \"xfs\", \"ntfs\".\nIf not provided, the empty value is passed to the associated CSI driver\nwhich will determine the default filesystem to apply.",
+                            "type": "string"
+                          },
+                          "nodePublishSecretRef": {
+                            "description": "nodePublishSecretRef is a reference to the secret object containing\nsensitive information to pass to the CSI driver to complete the CSI\nNodePublishVolume and NodeUnpublishVolume calls.\nThis field is optional, and  may be empty if no secret is required. If the\nsecret object contains more than one secret, all secret references are passed.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly specifies a read-only configuration for the volume.\nDefaults to false (read/write).",
+                            "type": "boolean"
+                          },
+                          "volumeAttributes": {
+                            "description": "volumeAttributes stores driver-specific properties that are passed to the CSI\ndriver. Consult your driver's documentation for supported values.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      },
+                      "downwardAPI": {
+                        "description": "downwardAPI represents downward API about the pod that should populate this volume",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "Optional: mode bits to use on created files by default. Must be a\nOptional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDefaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "Items is a list of downward API volume file",
+                            "type": "array",
+                            "items": {
+                              "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                              "type": "object",
+                              "required": [
+                                "path"
+                              ],
+                              "properties": {
+                                "fieldRef": {
+                                  "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                  "type": "object",
+                                  "required": [
+                                    "fieldPath"
+                                  ],
+                                  "properties": {
+                                    "apiVersion": {
+                                      "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                      "type": "string"
+                                    },
+                                    "fieldPath": {
+                                      "description": "Path of the field to select in the specified API version.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "mode": {
+                                  "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                  "type": "string"
+                                },
+                                "resourceFieldRef": {
+                                  "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                  "type": "object",
+                                  "required": [
+                                    "resource"
+                                  ],
+                                  "properties": {
+                                    "containerName": {
+                                      "description": "Container name: required for volumes, optional for env vars",
+                                      "type": "string"
+                                    },
+                                    "divisor": {
+                                      "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                      "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                      "x-kubernetes-int-or-string": true
+                                    },
+                                    "resource": {
+                                      "description": "Required: resource to select",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "emptyDir": {
+                        "description": "emptyDir represents a temporary directory that shares a pod's lifetime.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                        "type": "object",
+                        "properties": {
+                          "medium": {
+                            "description": "medium represents what type of storage medium should back this directory.\nThe default is \"\" which means to use the node's default medium.\nMust be an empty string (default) or Memory.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "type": "string"
+                          },
+                          "sizeLimit": {
+                            "description": "sizeLimit is the total amount of local storage required for this EmptyDir volume.\nThe size limit is also applicable for memory medium.\nThe maximum usage on memory medium EmptyDir would be the minimum value between\nthe SizeLimit specified here and the sum of memory limits of all containers in a pod.\nThe default is nil which means that the limit is undefined.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
+                            "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                            "x-kubernetes-int-or-string": true
+                          }
+                        }
+                      },
+                      "ephemeral": {
+                        "description": "ephemeral represents a volume that is handled by a cluster storage driver.\nThe volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,\nand deleted when the pod is removed.\n\nUse this if:\na) the volume is only needed while the pod runs,\nb) features of normal volumes like restoring from snapshot or capacity\n   tracking are needed,\nc) the storage driver is specified through a storage class, and\nd) the storage driver supports dynamic volume provisioning through\n   a PersistentVolumeClaim (see EphemeralVolumeSource for more\n   information on the connection between this volume type\n   and PersistentVolumeClaim).\n\nUse PersistentVolumeClaim or one of the vendor-specific\nAPIs for volumes that persist for longer than the lifecycle\nof an individual pod.\n\nUse CSI for light-weight local ephemeral volumes if the CSI driver is meant to\nbe used that way - see the documentation of the driver for\nmore information.\n\nA pod can use both types of ephemeral volumes and\npersistent volumes at the same time.",
+                        "type": "object",
+                        "properties": {
+                          "volumeClaimTemplate": {
+                            "description": "Will be used to create a stand-alone PVC to provision the volume.\nThe pod in which this EphemeralVolumeSource is embedded will be the\nowner of the PVC, i.e. the PVC will be deleted together with the\npod.  The name of the PVC will be `<pod name>-<volume name>` where\n`<volume name>` is the name from the `PodSpec.Volumes` array\nentry. Pod validation will reject the pod if the concatenated name\nis not valid for a PVC (for example, too long).\n\nAn existing PVC with that name that is not owned by the pod\nwill *not* be used for the pod to avoid using an unrelated\nvolume by mistake. Starting the pod is then blocked until\nthe unrelated PVC is removed. If such a pre-created PVC is\nmeant to be used by the pod, the PVC has to updated with an\nowner reference to the pod once the pod exists. Normally\nthis should not be necessary, but it may be useful when\nmanually reconstructing a broken cluster.\n\nThis field is read-only and no changes will be made by Kubernetes\nto the PVC after it has been created.\n\nRequired, must not be nil.",
+                            "type": "object",
+                            "required": [
+                              "spec"
+                            ],
+                            "properties": {
+                              "metadata": {
+                                "description": "May contain labels and annotations that will be copied into the PVC\nwhen creating it. No other fields are allowed and will be rejected during\nvalidation.",
+                                "type": "object"
+                              },
+                              "spec": {
+                                "description": "The specification for the PersistentVolumeClaim. The entire content is\ncopied unchanged into the PVC that gets created from this\ntemplate. The same fields as in a PersistentVolumeClaim\nare also valid here.",
+                                "type": "object",
+                                "properties": {
+                                  "accessModes": {
+                                    "description": "accessModes contains the desired access modes the volume should have.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-kubernetes-list-type": "atomic"
+                                  },
+                                  "dataSource": {
+                                    "description": "dataSource field can be used to specify either:\n* An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)\n* An existing PVC (PersistentVolumeClaim)\nIf the provisioner or an external controller can support the specified data source,\nit will create a new volume based on the contents of the specified data source.\nWhen the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,\nand dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.\nIf the namespace is specified, then dataSourceRef will not be copied to dataSource.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "dataSourceRef": {
+                                    "description": "dataSourceRef specifies the object from which to populate the volume with data, if a non-empty\nvolume is desired. This may be any object from a non-empty API group (non\ncore object) or a PersistentVolumeClaim object.\nWhen this field is specified, volume binding will only succeed if the type of\nthe specified object matches some installed volume populator or dynamic\nprovisioner.\nThis field will replace the functionality of the dataSource field and as such\nif both fields are non-empty, they must have the same value. For backwards\ncompatibility, when namespace isn't specified in dataSourceRef,\nboth fields (dataSource and dataSourceRef) will be set to the same\nvalue automatically if one of them is empty and the other is non-empty.\nWhen namespace is specified in dataSourceRef,\ndataSource isn't set to the same value and must be empty.\nThere are three important differences between dataSource and dataSourceRef:\n* While dataSource only allows two specific types of objects, dataSourceRef\n  allows any non-core object, as well as PersistentVolumeClaim objects.\n* While dataSource ignores disallowed values (dropping them), dataSourceRef\n  preserves all values, and generates an error if a disallowed value is\n  specified.\n* While dataSource only allows local objects, dataSourceRef allows objects\n  in any namespaces.\n(Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.\n(Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                    "type": "object",
+                                    "required": [
+                                      "kind",
+                                      "name"
+                                    ],
+                                    "properties": {
+                                      "apiGroup": {
+                                        "description": "APIGroup is the group for the resource being referenced.\nIf APIGroup is not specified, the specified Kind must be in the core API group.\nFor any other third-party types, APIGroup is required.",
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "description": "Kind is the type of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "description": "Name is the name of resource being referenced",
+                                        "type": "string"
+                                      },
+                                      "namespace": {
+                                        "description": "Namespace is the namespace of resource being referenced\nNote that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.\n(Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.",
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "resources": {
+                                    "description": "resources represents the minimum resources the volume should have.\nIf RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements\nthat are lower than previous value but must still be higher than capacity recorded in the\nstatus field of the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources",
+                                    "type": "object",
+                                    "properties": {
+                                      "limits": {
+                                        "description": "Limits describes the maximum amount of compute resources allowed.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      },
+                                      "requests": {
+                                        "description": "Requests describes the minimum amount of compute resources required.\nIf Requests is omitted for a container, it defaults to Limits if that is explicitly specified,\notherwise to an implementation-defined value. Requests cannot exceed Limits.\nMore info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                          "x-kubernetes-int-or-string": true
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "selector": {
+                                    "description": "selector is a label query over volumes to consider for binding.",
+                                    "type": "object",
+                                    "properties": {
+                                      "matchExpressions": {
+                                        "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                        "type": "array",
+                                        "items": {
+                                          "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                          "type": "object",
+                                          "required": [
+                                            "key",
+                                            "operator"
+                                          ],
+                                          "properties": {
+                                            "key": {
+                                              "description": "key is the label key that the selector applies to.",
+                                              "type": "string"
+                                            },
+                                            "operator": {
+                                              "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                              "type": "string"
+                                            },
+                                            "values": {
+                                              "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                              "type": "array",
+                                              "items": {
+                                                "type": "string"
+                                              },
+                                              "x-kubernetes-list-type": "atomic"
+                                            }
+                                          }
+                                        },
+                                        "x-kubernetes-list-type": "atomic"
+                                      },
+                                      "matchLabels": {
+                                        "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                        "type": "object",
+                                        "additionalProperties": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    "x-kubernetes-map-type": "atomic"
+                                  },
+                                  "storageClassName": {
+                                    "description": "storageClassName is the name of the StorageClass required by the claim.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1",
+                                    "type": "string"
+                                  },
+                                  "volumeAttributesClassName": {
+                                    "description": "volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.\nIf specified, the CSI driver will create or update the volume with the attributes defined\nin the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,\nit can be changed after the claim is created. An empty string value means that no VolumeAttributesClass\nwill be applied to the claim but it's not allowed to reset this field to empty string once it is set.\nIf unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass\nwill be set by the persistentvolume controller if it exists.\nIf the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be\nset to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource\nexists.\nMore info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/\n(Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).",
+                                    "type": "string"
+                                  },
+                                  "volumeMode": {
+                                    "description": "volumeMode defines what type of volume is required by the claim.\nValue of Filesystem is implied when not included in claim spec.",
+                                    "type": "string"
+                                  },
+                                  "volumeName": {
+                                    "description": "volumeName is the binding reference to the PersistentVolume backing this claim.",
+                                    "type": "string"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "fc": {
+                        "description": "fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun is Optional: FC target lun number",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "targetWWNs": {
+                            "description": "targetWWNs is Optional: FC target worldwide names (WWNs)",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "wwids": {
+                            "description": "wwids Optional: FC volume world wide identifiers (wwids)\nEither wwids or combination of targetWWNs and lun must be set, but not both simultaneously.",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "flexVolume": {
+                        "description": "flexVolume represents a generic volume resource that is\nprovisioned/attached using an exec based plugin.\nDeprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.",
+                        "type": "object",
+                        "required": [
+                          "driver"
+                        ],
+                        "properties": {
+                          "driver": {
+                            "description": "driver is the name of the driver to use for this volume.",
+                            "type": "string"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". The default filesystem depends on FlexVolume script.",
+                            "type": "string"
+                          },
+                          "options": {
+                            "description": "options is Optional: this field holds extra command options if any.",
+                            "type": "object",
+                            "additionalProperties": {
+                              "type": "string"
+                            }
+                          },
+                          "readOnly": {
+                            "description": "readOnly is Optional: defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is Optional: secretRef is reference to the secret object containing\nsensitive information to pass to the plugin scripts. This may be\nempty if no secret object is specified. If the secret object\ncontains more than one secret, all secrets are passed to the plugin\nscripts.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          }
+                        }
+                      },
+                      "flocker": {
+                        "description": "flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.\nDeprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.",
+                        "type": "object",
+                        "properties": {
+                          "datasetName": {
+                            "description": "datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker\nshould be considered as deprecated",
+                            "type": "string"
+                          },
+                          "datasetUUID": {
+                            "description": "datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "gcePersistentDisk": {
+                        "description": "gcePersistentDisk represents a GCE Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nDeprecated: GCEPersistentDisk is deprecated. All operations for the in-tree\ngcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                        "type": "object",
+                        "required": [
+                          "pdName"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "partition": {
+                            "description": "partition is the partition in the volume that you want to mount.\nIf omitted, the default is to mount by volume name.\nExamples: For volume /dev/sda1, you specify the partition as \"1\".\nSimilarly, the volume partition for /dev/sda is \"0\" (or you can leave the property empty).\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "pdName": {
+                            "description": "pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "gitRepo": {
+                        "description": "gitRepo represents a git repository at a particular revision.\nDeprecated: GitRepo is deprecated. To provision a container with a git repo, mount an\nEmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir\ninto the Pod's container.",
+                        "type": "object",
+                        "required": [
+                          "repository"
+                        ],
+                        "properties": {
+                          "directory": {
+                            "description": "directory is the target directory name.\nMust not contain or start with '..'.  If '.' is supplied, the volume directory will be the\ngit repository.  Otherwise, if specified, the volume will contain the git repository in\nthe subdirectory with the given name.",
+                            "type": "string"
+                          },
+                          "repository": {
+                            "description": "repository is the URL",
+                            "type": "string"
+                          },
+                          "revision": {
+                            "description": "revision is the commit hash for the specified revision.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "glusterfs": {
+                        "description": "glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.\nDeprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md",
+                        "type": "object",
+                        "required": [
+                          "endpoints",
+                          "path"
+                        ],
+                        "properties": {
+                          "endpoints": {
+                            "description": "endpoints is the endpoint name that details Glusterfs topology.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "path": {
+                            "description": "path is the Glusterfs volume path.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Glusterfs volume to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "hostPath": {
+                        "description": "hostPath represents a pre-existing file or directory on the host\nmachine that is directly exposed to the container. This is generally\nused for system agents or other privileged things that are allowed\nto see the host machine. Most containers will NOT need this.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                        "type": "object",
+                        "required": [
+                          "path"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path of the directory on the host.\nIf the path is a symlink, it will follow the link to the real path.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          },
+                          "type": {
+                            "description": "type for HostPath Volume\nDefaults to \"\"\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "image": {
+                        "description": "image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.\nThe volume is resolved at pod startup depending on which PullPolicy value is provided:\n\n- Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\n- Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\n- IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\n\nThe volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.\nA failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.\nThe types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.\nThe OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.\nThe volume will be mounted read-only (ro) and non-executable files (noexec).\nSub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).\nThe field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.",
+                        "type": "object",
+                        "properties": {
+                          "pullPolicy": {
+                            "description": "Policy for pulling OCI objects. Possible values are:\nAlways: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.\nNever: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.\nIfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.\nDefaults to Always if :latest tag is specified, or IfNotPresent otherwise.",
+                            "type": "string"
+                          },
+                          "reference": {
+                            "description": "Required: Image or artifact reference to be used.\nBehaves in the same way as pod.spec.containers[*].image.\nPull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.\nMore info: https://kubernetes.io/docs/concepts/containers/images\nThis field is optional to allow higher level config management to default or override\ncontainer images in workload controllers like Deployments and StatefulSets.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "iscsi": {
+                        "description": "iscsi represents an ISCSI Disk resource that is attached to a\nkubelet's host machine and then exposed to the pod.\nMore info: https://examples.k8s.io/volumes/iscsi/README.md",
+                        "type": "object",
+                        "required": [
+                          "iqn",
+                          "lun",
+                          "targetPortal"
+                        ],
+                        "properties": {
+                          "chapAuthDiscovery": {
+                            "description": "chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "chapAuthSession": {
+                            "description": "chapAuthSession defines whether support iSCSI Session CHAP authentication",
+                            "type": "boolean"
+                          },
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi",
+                            "type": "string"
+                          },
+                          "initiatorName": {
+                            "description": "initiatorName is the custom iSCSI Initiator Name.\nIf initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface\n<target portal>:<volume name> will be created for the connection.",
+                            "type": "string"
+                          },
+                          "iqn": {
+                            "description": "iqn is the target iSCSI Qualified Name.",
+                            "type": "string"
+                          },
+                          "iscsiInterface": {
+                            "description": "iscsiInterface is the interface Name that uses an iSCSI transport.\nDefaults to 'default' (tcp).",
+                            "type": "string"
+                          },
+                          "lun": {
+                            "description": "lun represents iSCSI Target Lun number.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "portals": {
+                            "description": "portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is the CHAP Secret for iSCSI target and initiator authentication",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "targetPortal": {
+                            "description": "targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port\nis other than default (typically TCP ports 860 and 3260).",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "name": {
+                        "description": "name of the volume.\nMust be a DNS_LABEL and unique within the pod.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                        "type": "string"
+                      },
+                      "nfs": {
+                        "description": "nfs represents an NFS mount on the host that shares a pod's lifetime\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                        "type": "object",
+                        "required": [
+                          "path",
+                          "server"
+                        ],
+                        "properties": {
+                          "path": {
+                            "description": "path that is exported by the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the NFS export to be mounted with read-only permissions.\nDefaults to false.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "boolean"
+                          },
+                          "server": {
+                            "description": "server is the hostname or IP address of the NFS server.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#nfs",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "persistentVolumeClaim": {
+                        "description": "persistentVolumeClaimVolumeSource represents a reference to a\nPersistentVolumeClaim in the same namespace.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                        "type": "object",
+                        "required": [
+                          "claimName"
+                        ],
+                        "properties": {
+                          "claimName": {
+                            "description": "claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Will force the ReadOnly setting in VolumeMounts.\nDefault false.",
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "photonPersistentDisk": {
+                        "description": "photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.\nDeprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "pdID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "pdID": {
+                            "description": "pdID is the ID that identifies Photon Controller persistent disk",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "portworxVolume": {
+                        "description": "portworxVolume represents a portworx volume attached and mounted on kubelets host machine.\nDeprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type\nare redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate\nis on.",
+                        "type": "object",
+                        "required": [
+                          "volumeID"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fSType represents the filesystem type to mount\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "volumeID": {
+                            "description": "volumeID uniquely identifies a Portworx volume",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "projected": {
+                        "description": "projected items for all in one resources secrets, configmaps, and downward API",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode are the mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "sources": {
+                            "description": "sources is the list of volume projections. Each entry in this list\nhandles one source.",
+                            "type": "array",
+                            "items": {
+                              "description": "Projection that may be projected along with other supported volume types.\nExactly one of these fields must be set.",
+                              "type": "object",
+                              "properties": {
+                                "clusterTrustBundle": {
+                                  "description": "ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field\nof ClusterTrustBundle objects in an auto-updating file.\n\nAlpha, gated by the ClusterTrustBundleProjection feature gate.\n\nClusterTrustBundle objects can either be selected by name, or by the\ncombination of signer name and a label selector.\n\nKubelet performs aggressive normalization of the PEM contents written\ninto the pod filesystem.  Esoteric PEM features such as inter-block\ncomments and block headers are stripped.  Certificates are deduplicated.\nThe ordering of certificates within the file is arbitrary, and Kubelet\nmay change the order over time.",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "labelSelector": {
+                                      "description": "Select all ClusterTrustBundles that match this label selector.  Only has\neffect if signerName is set.  Mutually-exclusive with name.  If unset,\ninterpreted as \"match nothing\".  If set but empty, interpreted as \"match\neverything\".",
+                                      "type": "object",
+                                      "properties": {
+                                        "matchExpressions": {
+                                          "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+                                          "type": "array",
+                                          "items": {
+                                            "description": "A label selector requirement is a selector that contains values, a key, and an operator that\nrelates the key and values.",
+                                            "type": "object",
+                                            "required": [
+                                              "key",
+                                              "operator"
+                                            ],
+                                            "properties": {
+                                              "key": {
+                                                "description": "key is the label key that the selector applies to.",
+                                                "type": "string"
+                                              },
+                                              "operator": {
+                                                "description": "operator represents a key's relationship to a set of values.\nValid operators are In, NotIn, Exists and DoesNotExist.",
+                                                "type": "string"
+                                              },
+                                              "values": {
+                                                "description": "values is an array of string values. If the operator is In or NotIn,\nthe values array must be non-empty. If the operator is Exists or DoesNotExist,\nthe values array must be empty. This array is replaced during a strategic\nmerge patch.",
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "x-kubernetes-list-type": "atomic"
+                                              }
+                                            }
+                                          },
+                                          "x-kubernetes-list-type": "atomic"
+                                        },
+                                        "matchLabels": {
+                                          "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels\nmap is equivalent to an element of matchExpressions, whose key field is \"key\", the\noperator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-map-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Select a single ClusterTrustBundle by object name.  Mutually-exclusive\nwith signerName and labelSelector.",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "If true, don't block pod startup if the referenced ClusterTrustBundle(s)\naren't available.  If using name, then the named ClusterTrustBundle is\nallowed not to exist.  If using signerName, then the combination of\nsignerName and labelSelector is allowed to match zero\nClusterTrustBundles.",
+                                      "type": "boolean"
+                                    },
+                                    "path": {
+                                      "description": "Relative path from the volume root to write the bundle.",
+                                      "type": "string"
+                                    },
+                                    "signerName": {
+                                      "description": "Select all ClusterTrustBundles that match this signer name.\nMutually-exclusive with name.  The contents of all selected\nClusterTrustBundles will be unified and deduplicated.",
+                                      "type": "string"
+                                    }
+                                  }
+                                },
+                                "configMap": {
+                                  "description": "configMap information about the configMap data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nConfigMap will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the ConfigMap,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional specify whether the ConfigMap or its keys must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "downwardAPI": {
+                                  "description": "downwardAPI information about the downwardAPI data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "Items is a list of DownwardAPIVolume file",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+                                        "type": "object",
+                                        "required": [
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "fieldRef": {
+                                            "description": "Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "fieldPath"
+                                            ],
+                                            "properties": {
+                                              "apiVersion": {
+                                                "description": "Version of the schema the FieldPath is written in terms of, defaults to \"v1\".",
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "description": "Path of the field to select in the specified API version.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          },
+                                          "mode": {
+                                            "description": "Optional: mode bits used to set permissions on this file, must be an octal value\nbetween 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+                                            "type": "string"
+                                          },
+                                          "resourceFieldRef": {
+                                            "description": "Selects a resource of the container: only resources limits and requests\n(limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+                                            "type": "object",
+                                            "required": [
+                                              "resource"
+                                            ],
+                                            "properties": {
+                                              "containerName": {
+                                                "description": "Container name: required for volumes, optional for env vars",
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
+                                                "pattern": "^(\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\\+|-)?(([0-9]+(\\.[0-9]*)?)|(\\.[0-9]+))))?$",
+                                                "x-kubernetes-int-or-string": true
+                                              },
+                                              "resource": {
+                                                "description": "Required: resource to select",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "x-kubernetes-map-type": "atomic"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    }
+                                  }
+                                },
+                                "secret": {
+                                  "description": "secret information about the secret data to project",
+                                  "type": "object",
+                                  "properties": {
+                                    "items": {
+                                      "description": "items if unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                                      "type": "array",
+                                      "items": {
+                                        "description": "Maps a string key to a path within a volume.",
+                                        "type": "object",
+                                        "required": [
+                                          "key",
+                                          "path"
+                                        ],
+                                        "properties": {
+                                          "key": {
+                                            "description": "key is the key to project.",
+                                            "type": "string"
+                                          },
+                                          "mode": {
+                                            "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                            "type": "integer",
+                                            "format": "int32"
+                                          },
+                                          "path": {
+                                            "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                            "type": "string"
+                                          }
+                                        }
+                                      },
+                                      "x-kubernetes-list-type": "atomic"
+                                    },
+                                    "name": {
+                                      "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                      "type": "string"
+                                    },
+                                    "optional": {
+                                      "description": "optional field specify whether the Secret or its key must be defined",
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "x-kubernetes-map-type": "atomic"
+                                },
+                                "serviceAccountToken": {
+                                  "description": "serviceAccountToken is information about the serviceAccountToken data to project",
+                                  "type": "object",
+                                  "required": [
+                                    "path"
+                                  ],
+                                  "properties": {
+                                    "audience": {
+                                      "description": "audience is the intended audience of the token. A recipient of a token\nmust identify itself with an identifier specified in the audience of the\ntoken, and otherwise should reject the token. The audience defaults to the\nidentifier of the apiserver.",
+                                      "type": "string"
+                                    },
+                                    "expirationSeconds": {
+                                      "description": "expirationSeconds is the requested duration of validity of the service\naccount token. As the token approaches expiration, the kubelet volume\nplugin will proactively rotate the service account token. The kubelet will\nstart trying to rotate the token if the token is older than 80 percent of\nits time to live or if the token is older than 24 hours.Defaults to 1 hour\nand must be at least 10 minutes.",
+                                      "type": "integer",
+                                      "format": "int64"
+                                    },
+                                    "path": {
+                                      "description": "path is the path relative to the mount point of the file to project the\ntoken into.",
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          }
+                        }
+                      },
+                      "quobyte": {
+                        "description": "quobyte represents a Quobyte mount on the host that shares a pod's lifetime.\nDeprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "registry",
+                          "volume"
+                        ],
+                        "properties": {
+                          "group": {
+                            "description": "group to map volume access to\nDefault is no group",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the Quobyte volume to be mounted with read-only permissions.\nDefaults to false.",
+                            "type": "boolean"
+                          },
+                          "registry": {
+                            "description": "registry represents a single or multiple Quobyte Registry services\nspecified as a string as host:port pair (multiple entries are separated with commas)\nwhich acts as the central registry for volumes",
+                            "type": "string"
+                          },
+                          "tenant": {
+                            "description": "tenant owning the given Quobyte volume in the Backend\nUsed with dynamically provisioned Quobyte volumes, value is set by the plugin",
+                            "type": "string"
+                          },
+                          "user": {
+                            "description": "user to map volume access to\nDefaults to serivceaccount user",
+                            "type": "string"
+                          },
+                          "volume": {
+                            "description": "volume is a string that references an already created Quobyte volume by name.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "rbd": {
+                        "description": "rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.\nDeprecated: RBD is deprecated and the in-tree rbd type is no longer supported.\nMore info: https://examples.k8s.io/volumes/rbd/README.md",
+                        "type": "object",
+                        "required": [
+                          "image",
+                          "monitors"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type of the volume that you want to mount.\nTip: Ensure that the filesystem type is supported by the host operating system.\nExamples: \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#rbd",
+                            "type": "string"
+                          },
+                          "image": {
+                            "description": "image is the rados image name.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "keyring": {
+                            "description": "keyring is the path to key ring for RBDUser.\nDefault is /etc/ceph/keyring.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "monitors": {
+                            "description": "monitors is a collection of Ceph monitors.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "pool": {
+                            "description": "pool is the rados pool name.\nDefault is rbd.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly here will force the ReadOnly setting in VolumeMounts.\nDefaults to false.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef is name of the authentication secret for RBDUser. If provided\noverrides keyring.\nDefault is nil.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "user": {
+                            "description": "user is the rados user name.\nDefault is admin.\nMore info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "scaleIO": {
+                        "description": "scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.\nDeprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.",
+                        "type": "object",
+                        "required": [
+                          "gateway",
+                          "secretRef",
+                          "system"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\".\nDefault is \"xfs\".",
+                            "type": "string"
+                          },
+                          "gateway": {
+                            "description": "gateway is the host address of the ScaleIO API Gateway.",
+                            "type": "string"
+                          },
+                          "protectionDomain": {
+                            "description": "protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly Defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef references to the secret for ScaleIO user and other\nsensitive information. If this is not provided, Login operation will fail.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "sslEnabled": {
+                            "description": "sslEnabled Flag enable/disable SSL communication with Gateway, default false",
+                            "type": "boolean"
+                          },
+                          "storageMode": {
+                            "description": "storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.\nDefault is ThinProvisioned.",
+                            "type": "string"
+                          },
+                          "storagePool": {
+                            "description": "storagePool is the ScaleIO Storage Pool associated with the protection domain.",
+                            "type": "string"
+                          },
+                          "system": {
+                            "description": "system is the name of the storage system as configured in ScaleIO.",
+                            "type": "string"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the name of a volume already created in the ScaleIO system\nthat is associated with this volume source.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "secret": {
+                        "description": "secret represents a secret that should populate this volume.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                        "type": "object",
+                        "properties": {
+                          "defaultMode": {
+                            "description": "defaultMode is Optional: mode bits used to set permissions on created files by default.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values\nfor mode bits. Defaults to 0644.\nDirectories within the path are not affected by this setting.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                            "type": "integer",
+                            "format": "int32"
+                          },
+                          "items": {
+                            "description": "items If unspecified, each key-value pair in the Data field of the referenced\nSecret will be projected into the volume as a file whose name is the\nkey and content is the value. If specified, the listed keys will be\nprojected into the specified paths, and unlisted keys will not be\npresent. If a key is specified which is not present in the Secret,\nthe volume setup will error unless it is marked optional. Paths must be\nrelative and may not contain the '..' path or start with '..'.",
+                            "type": "array",
+                            "items": {
+                              "description": "Maps a string key to a path within a volume.",
+                              "type": "object",
+                              "required": [
+                                "key",
+                                "path"
+                              ],
+                              "properties": {
+                                "key": {
+                                  "description": "key is the key to project.",
+                                  "type": "string"
+                                },
+                                "mode": {
+                                  "description": "mode is Optional: mode bits used to set permissions on this file.\nMust be an octal value between 0000 and 0777 or a decimal value between 0 and 511.\nYAML accepts both octal and decimal values, JSON requires decimal values for mode bits.\nIf not specified, the volume defaultMode will be used.\nThis might be in conflict with other options that affect the file\nmode, like fsGroup, and the result can be other mode bits set.",
+                                  "type": "integer",
+                                  "format": "int32"
+                                },
+                                "path": {
+                                  "description": "path is the relative path of the file to map the key to.\nMay not be an absolute path.\nMay not contain the path element '..'.\nMay not start with the string '..'.",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "x-kubernetes-list-type": "atomic"
+                          },
+                          "optional": {
+                            "description": "optional field specify whether the Secret or its keys must be defined",
+                            "type": "boolean"
+                          },
+                          "secretName": {
+                            "description": "secretName is the name of the secret in the pod's namespace to use.\nMore info: https://kubernetes.io/docs/concepts/storage/volumes#secret",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "storageos": {
+                        "description": "storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.\nDeprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.",
+                        "type": "object",
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is the filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "readOnly": {
+                            "description": "readOnly defaults to false (read/write). ReadOnly here will force\nthe ReadOnly setting in VolumeMounts.",
+                            "type": "boolean"
+                          },
+                          "secretRef": {
+                            "description": "secretRef specifies the secret to use for obtaining the StorageOS API\ncredentials.  If not specified, default values will be attempted.",
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "description": "Name of the referent.\nThis field is effectively required, but due to backwards compatibility is\nallowed to be empty. Instances of this type with an empty value here are\nalmost certainly wrong.\nMore info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
+                                "type": "string"
+                              }
+                            },
+                            "x-kubernetes-map-type": "atomic"
+                          },
+                          "volumeName": {
+                            "description": "volumeName is the human-readable name of the StorageOS volume.  Volume\nnames are only unique within a namespace.",
+                            "type": "string"
+                          },
+                          "volumeNamespace": {
+                            "description": "volumeNamespace specifies the scope of the volume within StorageOS.  If no\nnamespace is specified then the Pod's namespace will be used.  This allows the\nKubernetes name scoping to be mirrored within StorageOS for tighter integration.\nSet VolumeName to any name to override the default behaviour.\nSet to \"default\" if you are not using namespaces within StorageOS.\nNamespaces that do not pre-exist within StorageOS will be created.",
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "vsphereVolume": {
+                        "description": "vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.\nDeprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type\nare redirected to the csi.vsphere.vmware.com CSI driver.",
+                        "type": "object",
+                        "required": [
+                          "volumePath"
+                        ],
+                        "properties": {
+                          "fsType": {
+                            "description": "fsType is filesystem type to mount.\nMust be a filesystem type supported by the host operating system.\nEx. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
+                            "type": "string"
+                          },
+                          "storagePolicyID": {
+                            "description": "storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.",
+                            "type": "string"
+                          },
+                          "storagePolicyName": {
+                            "description": "storagePolicyName is the storage Policy Based Management (SPBM) profile name.",
+                            "type": "string"
+                          },
+                          "volumePath": {
+                            "description": "volumePath is the path that identifies vSphere volume vmdk",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "xdsAddress": {
+                  "description": "The customized XDS address to retrieve configuration.",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "version": {
+          "description": "Defines the version of Istio to install.\nMust be one of: v1.24-latest, v1.24.4, v1.24.3.",
+          "type": "string",
+          "enum": [
+            "v1.24-latest",
+            "v1.24.4",
+            "v1.24.3"
+          ]
+        }
+      }
+    },
+    "status": {
+      "description": "ZTunnelStatus defines the observed state of ZTunnel",
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "description": "Represents the latest available observations of the object's current state.",
+          "type": "array",
+          "items": {
+            "description": "ZTunnelCondition represents a specific observation of the ZTunnel object's state.",
+            "type": "object",
+            "properties": {
+              "lastTransitionTime": {
+                "description": "Last time the condition transitioned from one status to another.",
+                "type": "string",
+                "format": "date-time"
+              },
+              "message": {
+                "description": "Human-readable message indicating details about the last transition.",
+                "type": "string"
+              },
+              "reason": {
+                "description": "Unique, single-word, CamelCase reason for the condition's last transition.",
+                "type": "string"
+              },
+              "status": {
+                "description": "The status of this condition. Can be True, False or Unknown.",
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of this condition.",
+                "type": "string"
+              }
+            }
+          }
+        },
+        "observedGeneration": {
+          "description": "ObservedGeneration is the most recent generation observed for this\nZTunnel object. It corresponds to the object's generation, which is\nupdated on mutation by the API Server. The information in the status\npertains to this particular generation of the object.",
+          "type": "integer",
+          "format": "int64"
+        },
+        "state": {
+          "description": "Reports the current state of the object.",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "ZTunnel",
+      "version": "v1alpha1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "x-kubernetes-validations": [
+    {
+      "message": "metadata.name must be 'default'",
+      "rule": "self.metadata.name == 'default'"
+    }
+  ],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/class_generator/schema/ztunnellist.json
+++ b/class_generator/schema/ztunnellist.json
@@ -1,0 +1,37 @@
+{
+  "description": "ZTunnelList is a list of ZTunnel",
+  "type": "object",
+  "required": [
+    "items"
+  ],
+  "properties": {
+    "apiVersion": {
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
+      "type": "string"
+    },
+    "items": {
+      "description": "List of ztunnels. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md",
+      "type": "array",
+      "items": {
+        "$ref": "_definitions.json#/definitions/io.sailoperator.v1alpha1.ZTunnel"
+      }
+    },
+    "kind": {
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "type": "string"
+    },
+    "metadata": {
+      "description": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
+      "$ref": "_definitions.json#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta"
+    }
+  },
+  "x-kubernetes-group-version-kind": [
+    {
+      "group": "sailoperator.io",
+      "kind": "ZTunnelList",
+      "version": "v1alpha1"
+    }
+  ],
+  "x-kubernetes-selectable-fields": [],
+  "$schema": "http://json-schema.org/schema#"
+}

--- a/ocp_resources/lm_eval_job.py
+++ b/ocp_resources/lm_eval_job.py
@@ -1,6 +1,7 @@
 # Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
 
-from typing import Any, Dict, List, Optional
+from __future__ import annotations
+from typing import Any
 from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentError
 
 
@@ -13,23 +14,25 @@ class LMEvalJob(NamespacedResource):
 
     def __init__(
         self,
-        allow_code_execution: Optional[bool] = None,
-        allow_online: Optional[bool] = None,
-        batch_size: Optional[str] = "",
-        gen_args: Optional[List[Any]] = None,
-        limit: Optional[str] = "",
-        log_samples: Optional[bool] = None,
-        model: Optional[str] = "",
-        model_args: Optional[List[Any]] = None,
-        num_few_shot: Optional[int] = None,
-        offline: Optional[Dict[str, Any]] = None,
-        outputs: Optional[Dict[str, Any]] = None,
-        pod: Optional[Dict[str, Any]] = None,
-        suspend: Optional[bool] = None,
-        task_list: Optional[Dict[str, Any]] = None,
+        allow_code_execution: bool | None = None,
+        allow_online: bool | None = None,
+        batch_size: str | None = None,
+        chat_template: dict[str, Any] | None = None,
+        gen_args: list[Any] | None = None,
+        limit: str | None = None,
+        log_samples: bool | None = None,
+        model: str | None = None,
+        model_args: list[Any] | None = None,
+        num_few_shot: int | None = None,
+        offline: dict[str, Any] | None = None,
+        outputs: dict[str, Any] | None = None,
+        pod: dict[str, Any] | None = None,
+        suspend: bool | None = None,
+        system_instruction: str | None = None,
+        task_list: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
-        """
+        r"""
         Args:
             allow_code_execution (bool): AllowCodeExecution specifies whether the LMEvalJob can execute remote
               code. Default is false.
@@ -40,7 +43,10 @@ class LMEvalJob(NamespacedResource):
             batch_size (str): Batch size for the evaluation. This is used by the models that run and
               are loaded locally and not apply for the commercial APIs.
 
-            gen_args (List[Any]): Map to `--gen_kwargs` parameter for the underlying library.
+            chat_template (dict[str, Any]): ChatTemplate defines whether to apply the default or specified chat
+              template to prompts. This is required for chat-completions models.
+
+            gen_args (list[Any]): Map to `--gen_kwargs` parameter for the underlying library.
 
             limit (str): Accepts an integer, or a float between 0.0 and 1.0 . If passed, will
               limit the number of documents to evaluate to the first X documents
@@ -51,20 +57,23 @@ class LMEvalJob(NamespacedResource):
 
             model (str): Model name
 
-            model_args (List[Any]): Args for the model
+            model_args (list[Any]): Args for the model
 
             num_few_shot (int): Sets the number of few-shot examples to place in context
 
-            offline (Dict[str, Any]): Offline specifies settings for running LMEvalJobs in an offline mode
+            offline (dict[str, Any]): Offline specifies settings for running LMEvalJobs in an offline mode
 
-            outputs (Dict[str, Any]): Outputs specifies storage for evaluation results
+            outputs (dict[str, Any]): Outputs specifies storage for evaluation results
 
-            pod (Dict[str, Any]): Specify extra information for the lm-eval job's pod
+            pod (dict[str, Any]): Specify extra information for the lm-eval job's pod
 
             suspend (bool): Suspend keeps the job but without pods. This is intended to be used by
               the Kueue integration
 
-            task_list (Dict[str, Any]): Evaluation task list
+            system_instruction (str): SystemInstruction will set the system instruction for all prompts
+              passed to the evaluated model
+
+            task_list (dict[str, Any]): Evaluation task list
 
         """
         super().__init__(**kwargs)
@@ -72,6 +81,7 @@ class LMEvalJob(NamespacedResource):
         self.allow_code_execution = allow_code_execution
         self.allow_online = allow_online
         self.batch_size = batch_size
+        self.chat_template = chat_template
         self.gen_args = gen_args
         self.limit = limit
         self.log_samples = log_samples
@@ -82,16 +92,17 @@ class LMEvalJob(NamespacedResource):
         self.outputs = outputs
         self.pod = pod
         self.suspend = suspend
+        self.system_instruction = system_instruction
         self.task_list = task_list
 
     def to_dict(self) -> None:
         super().to_dict()
 
         if not self.kind_dict and not self.yaml_file:
-            if not self.model:
+            if self.model is None:
                 raise MissingRequiredArgumentError(argument="self.model")
 
-            if not self.task_list:
+            if self.task_list is None:
                 raise MissingRequiredArgumentError(argument="self.task_list")
 
             self.res["spec"] = {}
@@ -106,34 +117,40 @@ class LMEvalJob(NamespacedResource):
             if self.allow_online is not None:
                 _spec["allowOnline"] = self.allow_online
 
-            if self.batch_size:
+            if self.batch_size is not None:
                 _spec["batchSize"] = self.batch_size
 
-            if self.gen_args:
+            if self.chat_template is not None:
+                _spec["chatTemplate"] = self.chat_template
+
+            if self.gen_args is not None:
                 _spec["genArgs"] = self.gen_args
 
-            if self.limit:
+            if self.limit is not None:
                 _spec["limit"] = self.limit
 
             if self.log_samples is not None:
                 _spec["logSamples"] = self.log_samples
 
-            if self.model_args:
+            if self.model_args is not None:
                 _spec["modelArgs"] = self.model_args
 
-            if self.num_few_shot:
+            if self.num_few_shot is not None:
                 _spec["numFewShot"] = self.num_few_shot
 
-            if self.offline:
+            if self.offline is not None:
                 _spec["offline"] = self.offline
 
-            if self.outputs:
+            if self.outputs is not None:
                 _spec["outputs"] = self.outputs
 
-            if self.pod:
+            if self.pod is not None:
                 _spec["pod"] = self.pod
 
             if self.suspend is not None:
                 _spec["suspend"] = self.suspend
+
+            if self.system_instruction is not None:
+                _spec["systemInstruction"] = self.system_instruction
 
     # End of generated code


### PR DESCRIPTION
##### Short description:
Updates LMEvalJob resource with two new fields: `system_instruction` and `chat_template`.

##### More details:
These new fields that were added to lm-evaluation-harness allow to pass a chat template:
```
chatTemplate:
    enabled: true
    name: "some_name"
```

and a system instruction, to be used in the evaluation.
Also updated the class_generator schema.

##### What this PR does / why we need it:
Needed in order to use the new fields with the CR.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a chat template and a system instruction when creating evaluation jobs.

- **Bug Fixes**
  - Improved handling of optional fields to ensure valid values are not mistakenly ignored.

- **Documentation**
  - Updated descriptions to reflect new options and improved type annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->