### PR TITLE
fix: class-generator duplicate resources on update schema

### DIFF
--- a/class_generator/class_generator.py
+++ b/class_generator/class_generator.py
@@ -649,7 +649,7 @@ def class_generator(
             elif run_update_schema.lower() == "y":
                 update_kind_schema()
 
-                class_generator(
+                return class_generator(
                     overwrite=overwrite,
                     dry_run=dry_run,
                     kind=kind,


### PR DESCRIPTION
When running class-generator and we need to update the schema there was a bug that call class_generator function twice.