### PR TITLE
docs: update install instructions to use uv in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,19 @@ From source:
 ```bash
 git clone https://github.com/RedHatQE/openshift-python-wrapper.git
 cd openshift-python-wrapper
-python setup.py install --user
+uv sync
 ```
 
-From pypi:
+To use the wrapper in another project:
 
 ```bash
-pip install openshift-python-wrapper --user
+uv pip install /path/to/openshift-python-wrapper
+```
+
+From Pypi:
+
+```bash
+uv pip install openshift-python-wrapper
 ```
 
 ## Fake Kubernetes Client


### PR DESCRIPTION
This PR updates the README to reflect the correct installation using uv with `pyproject.toml`
* `setup.py` doesn't exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to unify commands under the `uv` tool.
  * Added guidance for local installation and usage of the wrapper in other projects.
  * Revised PyPI installation command for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->