### PR TITLE
feat: add RouteAdvertisements and FRRConfiguration classes

### DIFF
--- a/ocp_resources/frr_configuration.py
+++ b/ocp_resources/frr_configuration.py
@@ -1,0 +1,57 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+from ocp_resources.resource import NamespacedResource
+
+
+class FRRConfiguration(NamespacedResource):
+    """
+    FRRConfiguration is a piece of FRR configuration.
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.FRRK8S_METALLB_IO
+
+    def __init__(
+        self,
+        bgp: dict[str, Any] | None = None,
+        node_selector: dict[str, Any] | None = None,
+        raw: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            bgp (dict[str, Any]): BGP is the configuration related to the BGP protocol.
+
+            node_selector (dict[str, Any]): NodeSelector limits the nodes that will attempt to apply this config.
+              When specified, the configuration will be considered only on nodes
+              whose labels match the specified selectors. When it is not
+              specified all nodes will attempt to apply this config.
+
+            raw (dict[str, Any]): Raw is a snippet of raw frr configuration that gets appended to the
+              one rendered translating the type safe API.
+
+        """
+        super().__init__(**kwargs)
+
+        self.bgp = bgp
+        self.node_selector = node_selector
+        self.raw = raw
+
+    def to_dict(self) -> None:
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.bgp is not None:
+                _spec["bgp"] = self.bgp
+
+            if self.node_selector is not None:
+                _spec["nodeSelector"] = self.node_selector
+
+            if self.raw is not None:
+                _spec["raw"] = self.raw
+
+    # End of generated code

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -491,6 +491,7 @@ class Resource(ResourceConstants):
         EXPORT_KUBEVIRT_IO: str = "export.kubevirt.io"
         FENCE_AGENTS_REMEDIATION_MEDIK8S_IO: str = "fence-agents-remediation.medik8s.io"
         FORKLIFT_KONVEYOR_IO: str = "forklift.konveyor.io"
+        FRRK8S_METALLB_IO = "frrk8s.metallb.io"
         HCO_KUBEVIRT_IO: str = "hco.kubevirt.io"
         HELM_MARIADB_MMONTES_IO: str = "helm.mariadb.mmontes.io"
         HIVE_OPENSHIFT_IO: str = "hive.openshift.io"

--- a/ocp_resources/route_advertisements.py
+++ b/ocp_resources/route_advertisements.py
@@ -1,0 +1,78 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+from ocp_resources.resource import Resource
+from ocp_resources.exceptions import MissingRequiredArgumentError
+
+
+class RouteAdvertisements(Resource):
+    """
+    RouteAdvertisements is the Schema for the routeadvertisements API
+    """
+
+    api_group: str = Resource.ApiGroup.K8S_OVN_ORG
+
+    def __init__(
+        self,
+        advertisements: list[Any] | None = None,
+        frr_configuration_selector: dict[str, Any] | None = None,
+        network_selectors: list[Any] | None = None,
+        node_selector: dict[str, Any] | None = None,
+        target_vrf: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            advertisements (list[Any]): advertisements determines what is advertised.
+
+            frr_configuration_selector (dict[str, Any]): frrConfigurationSelector determines which FRRConfigurations will the
+              OVN-Kubernetes driven FRRConfigurations be based on. This field
+              follows standard label selector semantics.
+
+            network_selectors (list[Any]): networkSelectors determines which network routes should be advertised.
+              Only ClusterUserDefinedNetworks and the default network can be
+              selected.
+
+            node_selector (dict[str, Any]): nodeSelector limits the advertisements to selected nodes. This field
+              follows standard label selector semantics.
+
+            target_vrf (str): targetVRF determines which VRF the routes should be advertised in.
+
+        """
+        super().__init__(**kwargs)
+
+        self.advertisements = advertisements
+        self.frr_configuration_selector = frr_configuration_selector
+        self.network_selectors = network_selectors
+        self.node_selector = node_selector
+        self.target_vrf = target_vrf
+
+    def to_dict(self) -> None:
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.advertisements is None:
+                raise MissingRequiredArgumentError(argument="self.advertisements")
+
+            if self.frr_configuration_selector is None:
+                raise MissingRequiredArgumentError(argument="self.frr_configuration_selector")
+
+            if self.network_selectors is None:
+                raise MissingRequiredArgumentError(argument="self.network_selectors")
+
+            if self.node_selector is None:
+                raise MissingRequiredArgumentError(argument="self.node_selector")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["advertisements"] = self.advertisements
+            _spec["frrConfigurationSelector"] = self.frr_configuration_selector
+            _spec["networkSelectors"] = self.network_selectors
+            _spec["nodeSelector"] = self.node_selector
+
+            if self.target_vrf is not None:
+                _spec["targetVRF"] = self.target_vrf
+
+    # End of generated code


### PR DESCRIPTION
##### Short description:
This PR adds classes for new BGP resources: `RouteAdvertisements` and `FRRConfiguration`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for managing FRR Configuration resources with optional BGP settings, node selector, and raw configuration data.
  * Introduced Route Advertisements resource to configure advertisements, FRR configuration selector, network selectors, node selector, and optional target VRF.
  * Route Advertisements now validate required fields before use.
  * Added FRR-related API group identifier for new resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->