### PR TITLE
refactor(wait_for_status): Use self.instance to get status

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -971,14 +971,16 @@ class Resource(ResourceConstants):
                 **PROTOCOL_ERROR_EXCEPTION_DICT,
                 **DEFAULT_CLUSTER_RETRY_EXCEPTIONS,
             },
-            func=lambda: self.instance.status.phase,
+            func=lambda: self.exists,
         )
         current_status = None
         last_logged_status = None
         try:
             for sample in samples:
                 if sample:
-                    current_status = sample
+                    instance_dict = sample.to_dict()
+                    current_status = instance_dict.get("status", {}).get("phase")
+
                     if current_status != last_logged_status:
                         last_logged_status = current_status
                         self.logger.info(f"Status of {self.kind} {self.name} is {current_status}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Improvements
  - More reliable and efficient resource status polling during waits.
  - Reduced logging noise by only reporting status changes.
  - Early exit when encountering terminal failure statuses.
  - Clearer timeout messages that include the last-known status.

- Bug Fixes
  - Fixes issues from parsing list-style responses for status.
  - Prevents redundant logs during long-running waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->