### PR TITLE
Add openTelemetry Collector resource

### DIFF
--- a/ocp_resources/open_telemetry_collector.py
+++ b/ocp_resources/open_telemetry_collector.py
@@ -1,0 +1,65 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+from ocp_resources.resource import NamespacedResource
+from ocp_resources.exceptions import MissingRequiredArgumentError
+
+
+class OpenTelemetryCollector(NamespacedResource):
+    """
+    OpenTelemetryCollector is the Schema for the opentelemetrycollectors API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.OPENTELEMETRY_IO
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        management_state: str | None = None,
+        mode: str | None = None,
+        replicas: int | None = None,
+        resources: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Args:
+            config (dict[str, Any]): Required. OpenTelemetry pipeline configuration.
+            management_state (str): Required. Usually "Managed".
+            mode (str): Deployment mode ("deployment", "daemonset", "sidecar").
+            replicas (int): Number of collector replicas (if mode=deployment).
+            resources (dict[str, Any]): Resource requests/limits.
+        """
+        super().__init__(**kwargs)
+        self.config = config
+        self.management_state = management_state
+        self.mode = mode
+        self.replicas = replicas
+        self.resources = resources
+
+    def to_dict(self) -> None:
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.config is None:
+                raise MissingRequiredArgumentError(argument="self.config")
+
+            if self.management_state is None:
+                raise MissingRequiredArgumentError(argument="self.management_state")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["config"] = self.config
+            _spec["managementState"] = self.management_state
+
+            if self.mode is not None:
+                _spec["mode"] = self.mode
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.resources is not None:
+                _spec["resources"] = self.resources
+
+    # End of generated code

--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -530,6 +530,7 @@ class Resource(ResourceConstants):
         NODEMAINTENANCE_KUBEVIRT_IO: str = "nodemaintenance.kubevirt.io"
         OBSERVABILITY_OPEN_CLUSTER_MANAGEMENT_IO: str = "observability.open-cluster-management.io"
         OCS_OPENSHIFT_IO: str = "ocs.openshift.io"
+        OPENTELEMETRY_IO = "opentelemetry.io"
         OPERATOR_AUTHORINO_KUADRANT_IO: str = "operator.authorino.kuadrant.io"
         OPERATOR_OPEN_CLUSTER_MANAGEMENT_IO: str = "operator.open-cluster-management.io"
         OPERATOR_OPENSHIFT_IO: str = "operator.openshift.io"


### PR DESCRIPTION
Adds openTelemetry resource to the wrapper

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the OpenTelemetry Collector custom resource, including fields for config, management state, mode, replicas, and resources.
  - Enforced validation when generating resource definitions, raising errors if required fields are missing.
  - Exposed a new API group for OpenTelemetry to align with the custom resource.

- Documentation
  - Updated public API surface to include the new resource and API group.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->