### PR TITLE
fix: ocp_resources, resource: Extend 'wait_for_condition' criteria

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -1222,13 +1222,23 @@ class Resource(ResourceConstants):
             resource_version=resource_version or self.initial_resource_version,
         )
 
-    def wait_for_condition(self, condition: str, status: str, timeout: int = 300, sleep_time: int = 1) -> None:
+    def wait_for_condition(
+        self,
+        condition: str,
+        status: str,
+        timeout: int = 300,
+        sleep_time: int = 1,
+        reason: str | None = None,
+        message: str = "",
+    ) -> None:
         """
         Wait for Resource condition to be in desire status.
 
         Args:
             condition (str): Condition to query.
             status (str): Expected condition status.
+            reason (None): Expected condition reason.
+            message (str): Expected condition text inclusion.
             timeout (int): Time to wait for the resource.
             sleep_time(int): Interval between each retry when checking the resource's condition.
 
@@ -1238,14 +1248,7 @@ class Resource(ResourceConstants):
         self.logger.info(f"Wait for {self.kind}/{self.name}'s '{condition}' condition to be '{status}'")
 
         timeout_watcher = TimeoutWatch(timeout=timeout)
-        for sample in TimeoutSampler(
-            wait_timeout=timeout,
-            sleep=sleep_time,
-            func=lambda: self.exists,
-        ):
-            if sample:
-                break
-
+        self.wait(timeout=timeout, sleep=sleep_time)
         for sample in TimeoutSampler(
             wait_timeout=timeout_watcher.remaining_time(),
             sleep=sleep_time,
@@ -1253,7 +1256,13 @@ class Resource(ResourceConstants):
         ):
             if sample:
                 for cond in sample.get("status", {}).get("conditions", []):
-                    if cond["type"] == condition and cond["status"] == status:
+                    actual_condition = {"type": cond["type"], "status": cond["status"]}
+                    expected_condition = {"type": condition, "status": status}
+                    if reason is not None:
+                        actual_condition["reason"] = cond.get("reason", "")
+                        expected_condition["reason"] = reason
+
+                    if actual_condition == expected_condition and message in cond.get("message", ""):
                         return
 
     def api_request(


### PR DESCRIPTION
##### What this PR does / why we need it:

In some scenarios, tests are looking for a specific reason or message to be included in the condition.

Although not a formal strict API, the message text includes extended reasoning which is useful for a user operator.
Therefore, it is also included but with an inclusion check.

See usage at:
https://github.com/RedHatQE/openshift-virtualization-tests/blob/0116f056176dbb25da5e8846537264dccb8ef202/tests/network/general/test_bridge_marker.py#L130

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced resource condition checks with optional reason and message filters for more precise validation.
  * Checks now wait for the resource to be available before evaluating conditions.
  * Matching requires the condition status, optional reason, and that the condition message contains the provided substring.
  * Improved error behavior when the expected condition or message isn’t found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->