### PR TITLE
feat: Add pvc_name_template parameter support

### DIFF
--- a/ocp_resources/plan.py
+++ b/ocp_resources/plan.py
@@ -22,6 +22,7 @@ class Plan(NamespacedResource):
         warm_migration (bool, default: False): Warm (True) or Cold (False) migration.
         type (str, optional): Migration type. Valid values: "cold", "warm", "live", "conversion".
         pvc_name_template_use_generate_name (bool, optional): Whether to use generateName for PVC name templates.
+        pvc_name_template (str, optional): Template for generating PVC names.
         skip_guest_conversion (bool, optional): Whether to skip guest conversion.
         target_power_state (str, optional): Specifies the desired power state of the target VM after migration.
                                           - "on": Target VM will be powered on after migration
@@ -52,6 +53,7 @@ class Plan(NamespacedResource):
         after_hook_namespace: str | None = None,
         type: str | None = None,
         pvc_name_template_use_generate_name: bool | None = None,
+        pvc_name_template: str | None = None,
         skip_guest_conversion: bool | None = None,
         target_power_state: str | None = None,
         use_compatibility_mode: bool | None = None,
@@ -77,6 +79,7 @@ class Plan(NamespacedResource):
         self.hooks_array = []
         self.type = type
         self.pvc_name_template_use_generate_name = pvc_name_template_use_generate_name
+        self.pvc_name_template = pvc_name_template
         self.skip_guest_conversion = skip_guest_conversion
         self.target_power_state = target_power_state
         self.use_compatibility_mode = use_compatibility_mode
@@ -143,6 +146,9 @@ class Plan(NamespacedResource):
 
             if self.pvc_name_template_use_generate_name is not None:
                 spec["pvcNameTemplateUseGenerateName"] = self.pvc_name_template_use_generate_name
+
+            if self.pvc_name_template is not None:
+                spec["pvcNameTemplate"] = self.pvc_name_template
 
             if self.skip_guest_conversion is not None:
                 spec["skipGuestConversion"] = self.skip_guest_conversion


### PR DESCRIPTION
Add support for the pvcNameTemplate field in the Plan resource, which allows customization of PVC names during VM migrations.

The pvcNameTemplate field enables users to define custom naming patterns for Persistent Volume Claims using Go template syntax. This is especially important for copy-offload migrations where the volume populator framework requires explicit PVC naming templates.

Changes:
- Add pvc_name_template parameter to Plan.__init__()
- Store pvc_name_template as instance variable
- Add pvcNameTemplate to Plan spec in to_dict()
- Update docstring with parameter documentation

The template supports variables like:
- .VmName: source VM name
- .TargetVmName: target VM name
- .DiskIndex: disk index
- .PlanName: plan name

Example usage:
  plan = Plan( ... pvc_name_template="{{.TargetVmName}}-disk-{{.DiskIndex}}", pvc_name_template_use_generate_name=False, )

This feature is part of the Forklift Plan API and works with both standard and copy-offload migrations.

##### Which issue(s) this PR fixes:
related to these PRs: 
https://github.com/RedHatQE/mtv-api-tests/pull/172
https://github.com/RedHatQE/mtv-api-tests/pull/163
 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plans now support PVC name template configuration, enabling custom naming conventions for persistent volume claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->