### PR TITLE
fix: Migrate from deprecated tool.uv.dev-dependencies to dependency-groups.dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,9 +62,6 @@ include = [
   "class_generator/schema/_definitions.json",
 ]
 
-[tool.uv]
-dev-dependencies = ["ipdb>=0.13.13", "ipython>=8.12.3"]
-
 [project]
 requires-python = ">=3.10"
 name = "openshift-python-wrapper"
@@ -128,3 +125,4 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 tests = ["pytest>=8.3.5", "pytest-cov>=6.1.1"]
+dev = ["ipdb>=0.13.13", "ipython>=8.12.3"]


### PR DESCRIPTION
- Removed deprecated [tool.uv] dev-dependencies section
- Added dev dependencies to [dependency-groups] section
- Fixes uv deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

##### Short description:

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized development dependency configuration structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->