### PR TITLE
feat: VMI Reset Added

### DIFF
--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -70,6 +70,9 @@ class VirtualMachineInstance(NamespacedResource):
         if wait:
             return self.wait_for_pause_status(pause=False, timeout=timeout)
 
+    def reset(self) -> dict[str, Any]:
+        return self.api_request(method="PUT", action="reset")
+
     @property
     def interfaces(self):
         return self.instance.status.interfaces


### PR DESCRIPTION
**This PR adds a reset() method to the VirtualMachineInstance class, providing the ability to reset  a running VMI.**

**_Why this was needed_**

- KubeVirt provides a reset subresource for VMIs that performs a reset without recreating the pod

- Completes the set of VMI lifecycle operations alongside pause() and unpause()

This PR is a part of https://issues.redhat.com/browse/CNV-6439 

and https://github.com/RedHatQE/openshift-virtualization-tests/pull/2507



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Virtual machine instances can now be reset via API requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->