### PR TITLE
feat: Retry  exceptions in create() by adding PROTOCOL_ERROR_EXCEPTION_DICT

### DIFF
--- a/ocp_resources/resource.py
+++ b/ocp_resources/resource.py
@@ -1009,7 +1009,10 @@ class Resource(ResourceConstants):
             raise
 
     def create(
-        self, wait: bool = False, exceptions_dict: dict[type[Exception], list[str]] = DEFAULT_CLUSTER_RETRY_EXCEPTIONS
+        self,
+        wait: bool = False,
+        exceptions_dict: dict[type[Exception], list[str]] = DEFAULT_CLUSTER_RETRY_EXCEPTIONS
+        | PROTOCOL_ERROR_EXCEPTION_DICT,
     ) -> ResourceInstance | None:
         """
         Create resource.


### PR DESCRIPTION

##### Short description:
Update the create() method to handle ProtocolError exceptions during resource creation by including PROTOCOL_ERROR_EXCEPTION_DICT in the default exceptions_dict. This ensures retries for connection aborts and remote disconnects without changing the global defaults.


##### More details:

failed on setup with "urllib3.exceptions.ProtocolError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))"

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource creation now retries a broader set of transient and protocol-related errors by default, improving reliability and reducing intermittent failures during provisioning.
  * Fewer manual retries are needed for operations that previously failed due to temporary protocol or network issues.
  * Default retry behavior expanded to handle additional protocol error cases, making provisioning more resilient without configuration changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->