### PR TITLE
fix: Update VMI pause/unpause

### DIFF
--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -1,5 +1,6 @@
 import shlex
 from typing import Any
+from warnings import warn
 
 import xmltodict
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
@@ -154,10 +155,14 @@ class VirtualMachineInstance(NamespacedResource):
             TimeoutExpiredError: If resource not exists.
         """
         self.logger.info(f"Wait until {self.kind} {self.name} is {'Paused' if pause else 'Unpuased'}")
-        self.wait_for_domstate_pause_status(pause=pause, timeout=timeout)
         self.wait_for_vmi_condition_pause_status(pause=pause, timeout=timeout)
 
     def wait_for_domstate_pause_status(self, pause, timeout=TIMEOUT_4MINUTES):
+        warn(
+            message="wait_for_domstate_pause_status is deprecated and will be removed the next version.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         pause_status = "paused" if pause else "running"
         samples = TimeoutSampler(
             wait_timeout=timeout,
@@ -272,6 +277,11 @@ class VirtualMachineInstance(NamespacedResource):
         Returns:
             String: VMI Status as string
         """
+        warn(
+            message="get_domstate is deprecated and will be removed the next version.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
         return self.execute_virsh_command(command="domstate")
 
     def get_dommemstat(self):


### PR DESCRIPTION
##### Short description:
removed wait_for_domstate_pause_status from pause/unpause (when called with wait=True):
  1. check for domstate was an old w/a which is irrelevant now
  2. executing domstate command on virt-launhcer pod can be done only with admin client (even though pause/unpause can be executed by unpriv client)

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified virtual machine pause status detection by consolidating the status-checking logic into a single unified method.

* **Chores**
  * Added runtime deprecation warnings for legacy pause-status routines; behavior and public interfaces remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->