### PR TITLE
feat: update generate_template_labels method

### DIFF
--- a/ocp_resources/template.py
+++ b/ocp_resources/template.py
@@ -14,6 +14,11 @@ class Template(NamespacedResource):
         WORKLOAD = "workload.template.kubevirt.io"
         ARCHITECTURE = f"{NamespacedResource.ApiGroup.TEMPLATE_KUBEVIRT_IO}/architecture"
 
+    class Architecture:
+        AMD64 = "amd64"
+        ARM64 = "arm64"
+        S390X = "s390x"
+
     class Workload:
         DESKTOP = "desktop"
         HIGHPERFORMANCE = "highperformance"
@@ -69,5 +74,5 @@ class Template(NamespacedResource):
             f"{Template.Labels.FLAVOR}/{getattr(Template.Flavor, flavor.upper())}=true",
         ]
         if architecture:
-            labels.append(f"{Template.Labels.ARCHITECTURE}={architecture}")
+            labels.append(f"{Template.Labels.ARCHITECTURE}={getattr(Template.Architecture, architecture.upper())}")
         return labels


### PR DESCRIPTION
##### Short description:
on multi-arch clusters multiple templates of same OS (with diff arch) exists
added optional architecture param

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates can include an optional Architecture label with supported values: AMD64, ARM64, S390X.

* **Improvements**
  * OS, workload, and flavor labels now follow a consistent boolean format (e.g., =true).
  * Architecture remains optional to preserve backward compatibility with existing templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->