### PR TITLE
feat: Add migController resources

### DIFF
--- a/ocp_resources/mig_controller.py
+++ b/ocp_resources/mig_controller.py
@@ -1,0 +1,55 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.resource import NamespacedResource
+
+
+class MigController(NamespacedResource):
+    """
+    MigController is the Schema for the migcontrollers API.
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.MIGRATIONS_KUBEVIRT_IO
+
+    def __init__(
+        self,
+        image_pull_policy: str | None = None,
+        infra: dict[str, Any] | None = None,
+        priority_class: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            image_pull_policy (str): PullPolicy describes a policy for if/when to pull a container image
+
+            infra (dict[str, Any]): Rules on which nodes infrastructure pods will be scheduled
+
+            priority_class (str): PriorityClass of the control plane
+
+        """
+        super().__init__(**kwargs)
+
+        self.image_pull_policy = image_pull_policy
+        self.infra = infra
+        self.priority_class = priority_class
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.image_pull_policy is not None:
+                _spec["imagePullPolicy"] = self.image_pull_policy
+
+            if self.infra is not None:
+                _spec["infra"] = self.infra
+
+            if self.priority_class is not None:
+                _spec["priorityClass"] = self.priority_class
+
+    # End of generated code


### PR DESCRIPTION
Add migController resource following https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md

##### Short description:

CNV 4.21 includes this new resource and it's needed to support it in the wrapper for running the tests in openshift-virtualization-tests repository.

##### More details:
N/A
##### What this PR does / why we need it:
N/A
##### Which issue(s) this PR fixes:
N/A
##### Special notes for reviewer:
N/A
##### Bug:
https://issues.redhat.com/browse/CNV-75589

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MigController support to configure and manage migration controllers, allowing users to set image pull policy, infrastructure type, and priority class for migration workloads—providing per-controller configuration for deployment and scheduling behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->