### PR TITLE
fix: Set explicit API Version for HyperConverged

### DIFF
--- a/ocp_resources/hyperconverged.py
+++ b/ocp_resources/hyperconverged.py
@@ -4,6 +4,7 @@ from ocp_resources.utils.constants import TIMEOUT_4MINUTES
 
 class HyperConverged(NamespacedResource):
     api_group = NamespacedResource.ApiGroup.HCO_KUBEVIRT_IO
+    api_version = NamespacedResource.ApiVersion.V1BETA1
 
     def __init__(
         self,


### PR DESCRIPTION
##### Short description:
As a preparation for the planned introduction of the `v1` API of the `HyperConverged` resource, explicitly set its API version to `v1beta1`.

##### More details:
The planned `v1` API of the `HyperConverged` resource, is going to restructure fields, moving them around, deprecating several fields and so on.

The current implementation takes the latest version of the API, so once the new version is introduced, the client will try to read or write the `HyperConverged` resource as `v1`, while the code is using its `v1beta1` API. This will break any test uses this type.

To avoid that, and give the developers some time to adjust, this PR explicitly sets the API version of the `HyperConverged` type to `v1beta1`.

That way, the client will explicitly read and write the HyperConverged resource as `v1beta1`, and with the planned conversion webhook, the addition of the new `v1` API version will be transparent.

##### What this PR does / why we need it:
See above.

##### Which issue(s) this PR fixes:
n/a

##### Special notes for reviewer:
None.

##### Bug:
n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the API version specification for HyperConverged resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->