### PR TITLE
feat: Add EXECUTING status to ResourceConstants

### DIFF
--- a/ocp_resources/utils/resource_constants.py
+++ b/ocp_resources/utils/resource_constants.py
@@ -18,6 +18,7 @@ class ResourceConstants:
         ERR_IMAGE_PULL: str = "ErrImagePull"
         ACTIVE: str = "Active"
         ESTABLISHED: str = "Established"
+        EXECUTING: str = "Executing"
 
     class Condition:
         UPGRADEABLE: str = "Upgradeable"


### PR DESCRIPTION
## Summary
Adds `EXECUTING` status to `ResourceConstants.Status`.
This status is needed for checking concurrent migration execution in MTV API tests.

## Test plan
- Verified the constant is available for import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new "Executing" status to system status constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->