### PR TITLE
feat: add retentionPolicy in storage migration plan

### DIFF
--- a/ocp_resources/multi_namespace_virtual_machine_storage_migration_plan.py
+++ b/ocp_resources/multi_namespace_virtual_machine_storage_migration_plan.py
@@ -17,16 +17,25 @@ class MultiNamespaceVirtualMachineStorageMigrationPlan(NamespacedResource):
     def __init__(
         self,
         namespaces: list[Any] | None = None,
+        retention_policy: str | None = None,
         **kwargs: Any,
     ) -> None:
         r"""
         Args:
-            namespaces (list[Any]): The virtual machines to migrate.
+            namespaces (list[Any]): The virtual machines to migrate per namespace.
+
+            retention_policy (str): RetentionPolicy indicates whether to keep or delete the source
+              DataVolume/PVC after each VM migration completes in each created
+              namespace plan. When set to "deleteSource", every created
+              VirtualMachineStorageMigrationPlan will have retentionPolicy set
+              to deleteSource. When "keepSource" or unset, child plans keep
+              their per-namespace spec or default to keepSource.
 
         """
         super().__init__(**kwargs)
 
         self.namespaces = namespaces
+        self.retention_policy = retention_policy
 
     def to_dict(self) -> None:
 
@@ -40,5 +49,8 @@ class MultiNamespaceVirtualMachineStorageMigrationPlan(NamespacedResource):
             _spec = self.res["spec"]
 
             _spec["namespaces"] = self.namespaces
+
+            if self.retention_policy is not None:
+                _spec["retentionPolicy"] = self.retention_policy
 
     # End of generated code

--- a/ocp_resources/virtual_machine_storage_migration_plan.py
+++ b/ocp_resources/virtual_machine_storage_migration_plan.py
@@ -16,16 +16,24 @@ class VirtualMachineStorageMigrationPlan(NamespacedResource):
 
     def __init__(
         self,
+        retention_policy: str | None = None,
         virtual_machines: list[Any] | None = None,
         **kwargs: Any,
     ) -> None:
         r"""
         Args:
+            retention_policy (str): RetentionPolicy indicates whether to keep or delete the source
+              DataVolume/PVC after each VM migration completes. When
+              "keepSource" (default), the source is preserved. When
+              "deleteSource", the source DataVolume is deleted if it exists,
+              otherwise the source PVC is deleted.
+
             virtual_machines (list[Any]): The virtual machines to migrate.
 
         """
         super().__init__(**kwargs)
 
+        self.retention_policy = retention_policy
         self.virtual_machines = virtual_machines
 
     def to_dict(self) -> None:
@@ -40,5 +48,8 @@ class VirtualMachineStorageMigrationPlan(NamespacedResource):
             _spec = self.res["spec"]
 
             _spec["virtualMachines"] = self.virtual_machines
+
+            if self.retention_policy is not None:
+                _spec["retentionPolicy"] = self.retention_policy
 
     # End of generated code


### PR DESCRIPTION
##### Short description:
Add retentionPolicy in storage migration plan resources

##### More details:

##### What this PR does / why we need it:

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional retention policy for virtual machine storage migration plans. Users can now set a retention policy (optional) for both single-namespace and multi-namespace migration plans; the policy is included in plan definitions only when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->