### PR TITLE
WIP: refactor: remove deprecated wait() method from DataVolume class

### DIFF
--- a/ocp_resources/datavolume.py
+++ b/ocp_resources/datavolume.py
@@ -259,23 +259,6 @@ class DataVolume(NamespacedResource):
         super().wait_deleted(timeout=timeout)
         return self.pvc.wait_deleted(timeout=timeout)
 
-    def wait(self, timeout=TIMEOUT_10MINUTES, failure_timeout=TIMEOUT_2MINUTES, wait_for_exists_only=False, sleep=1):
-        warn(
-            message="DataVolume.wait() is deprecated and will be removed in "
-            "the next version. Use wait_for_dv_success() instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        if wait_for_exists_only:
-            return super().wait(timeout=timeout, sleep=sleep)
-        else:
-            self._check_none_pending_status(failure_timeout=failure_timeout)
-
-            # If DV's status is not Pending, continue with the flow
-            self.wait_for_status(status=self.Status.SUCCEEDED, timeout=timeout)
-            self.pvc.wait_for_status(status=PersistentVolumeClaim.Status.BOUND, timeout=timeout)
-            return None
-
     @property
     def pvc(self):
         return PersistentVolumeClaim(


### PR DESCRIPTION
##### Short description:
The intention is to allow `DataVolume.wait()` to fall back to the parent `Resource.wait()` method.

##### More details:

##### What this PR does / why we need it:
Deprecate DataVolume.wait() in favor of wait_for_dv_success() to fix bad practice and prevent bugs.

##### Which issue(s) this PR fixes:
This PR will allow us to safely de-quarantine https://github.com/RedHatQE/openshift-virtualization-tests/blob/2ee0d6e604bc3ade241bfb1a53879875eb7d2ecc/tests/storage/cdi_import/test_import_http.py#L62

##### Special notes for reviewer:
[This PR ](https://github.com/RedHatQE/openshift-virtualization-tests/pull/4605) needs to be merged first

This PR is part of [this task](https://redhat.atlassian.net/browse/CNV-73197), and continues the work started in https://github.com/RedHatQE/openshift-python-wrapper/pull/2613

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the `wait()` method from DataVolume. This is a breaking change—applications relying on this method will require updates. The removal eliminates deprecation warnings and simplifies the DataVolume interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->