### PR TITLE
feat: add VirtualMachineTemplate and VirtualMachineTemplateRequest

### DIFF
--- a/ocp_resources/virtual_machine_template.py
+++ b/ocp_resources/virtual_machine_template.py
@@ -1,0 +1,66 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import NamespacedResource
+
+
+class VirtualMachineTemplate(NamespacedResource):
+    """
+    VirtualMachineTemplate is the Schema for the virtualmachinetemplates API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.TEMPLATE_KUBEVIRT_IO
+
+    def __init__(
+        self,
+        message: str | None = None,
+        parameters: list[Any] | None = None,
+        virtual_machine: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            message (str): Message is an optional instructional message for this template. This
+              field should inform the user how to utilize the newly created
+              VirtualMachine.
+
+            parameters (list[Any]): Parameters is an optional list of Parameters used during processing of
+              the template.
+
+            virtual_machine (dict[str, Any]): VirtualMachine is the template VirtualMachine to include in this
+              template. If a namespace value is hardcoded, it will be removed
+              during processing of the template. If the namespace value however
+              contains a ${PARAMETER_REFERENCE}, the resolved value after
+              parameter substitution will be respected and the VirtualMachine
+              will be created in that namespace.
+
+        """
+        super().__init__(**kwargs)
+
+        self.message = message
+        self.parameters = parameters
+        self.virtual_machine = virtual_machine
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.virtual_machine is None:
+                raise MissingRequiredArgumentError(argument="self.virtual_machine")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["virtualMachine"] = self.virtual_machine
+
+            if self.message is not None:
+                _spec["message"] = self.message
+
+            if self.parameters is not None:
+                _spec["parameters"] = self.parameters
+
+    # End of generated code

--- a/ocp_resources/virtual_machine_template_request.py
+++ b/ocp_resources/virtual_machine_template_request.py
@@ -1,0 +1,54 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import NamespacedResource
+
+
+class VirtualMachineTemplateRequest(NamespacedResource):
+    """
+    VirtualMachineTemplateRequest is the Schema for the virtualmachinetemplaterequests API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.TEMPLATE_KUBEVIRT_IO
+
+    def __init__(
+        self,
+        template_name: str | None = None,
+        virtual_machine_ref: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            template_name (str): TemplateName holds the optional name for the new
+              VirtualMachineTemplate. If not specified the template will have
+              the same name as the VirtualMachineTemplateRequest.
+
+            virtual_machine_ref (dict[str, Any]): VirtualMachineReference holds a reference to a
+              VirtualMachine.kubevirt.io
+
+        """
+        super().__init__(**kwargs)
+
+        self.template_name = template_name
+        self.virtual_machine_ref = virtual_machine_ref
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.virtual_machine_ref is None:
+                raise MissingRequiredArgumentError(argument="self.virtual_machine_ref")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["virtualMachineRef"] = self.virtual_machine_ref
+
+            if self.template_name is not None:
+                _spec["templateName"] = self.template_name
+
+    # End of generated code


### PR DESCRIPTION
##### Short description:
feat: add VirtualMachineTemplate and VirtualMachineTemplateRequest to ocp_resources

##### More details:
The resources are added when the `Template` feature gate is enabled.

##### What this PR does / why we need it:
Allow use of VirtualMachineTemplate and VirtualMachineTemplateRequest classes to deploy the new resources


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for VirtualMachineTemplate resource definitions enabling template-based VM configuration in KubeVirt.
  * Added support for VirtualMachineTemplateRequest resource definitions for requesting virtual machine instances from templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-python-wrapper/pull/2729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->