### PR TITLE
feat: add LLMInferenceServiceConfig resource class

### DIFF
--- a/class_generator/tests/manifests/LLMInferenceServiceConfig/llm_inference_service_config.py
+++ b/class_generator/tests/manifests/LLMInferenceServiceConfig/llm_inference_service_config.py
@@ -1,0 +1,90 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.resource import NamespacedResource
+
+
+class LLMInferenceServiceConfig(NamespacedResource):
+    """
+    No field description from API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.SERVING_KSERVE_IO
+
+    def __init__(
+        self,
+        base_refs: list[Any] | None = None,
+        model: dict[str, Any] | None = None,
+        parallelism: dict[str, Any] | None = None,
+        prefill: dict[str, Any] | None = None,
+        replicas: int | None = None,
+        router: dict[str, Any] | None = None,
+        template: dict[str, Any] | None = None,
+        worker: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            base_refs (list[Any]): No field description from API
+
+            model (dict[str, Any]): No field description from API
+
+            parallelism (dict[str, Any]): No field description from API
+
+            prefill (dict[str, Any]): No field description from API
+
+            replicas (int): No field description from API
+
+            router (dict[str, Any]): No field description from API
+
+            template (dict[str, Any]): No field description from API
+
+            worker (dict[str, Any]): No field description from API
+
+        """
+        super().__init__(**kwargs)
+
+        self.base_refs = base_refs
+        self.model = model
+        self.parallelism = parallelism
+        self.prefill = prefill
+        self.replicas = replicas
+        self.router = router
+        self.template = template
+        self.worker = worker
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.base_refs is not None:
+                _spec["baseRefs"] = self.base_refs
+
+            if self.model is not None:
+                _spec["model"] = self.model
+
+            if self.parallelism is not None:
+                _spec["parallelism"] = self.parallelism
+
+            if self.prefill is not None:
+                _spec["prefill"] = self.prefill
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.router is not None:
+                _spec["router"] = self.router
+
+            if self.template is not None:
+                _spec["template"] = self.template
+
+            if self.worker is not None:
+                _spec["worker"] = self.worker
+
+    # End of generated code

--- a/class_generator/tests/test_class_generator.py
+++ b/class_generator/tests/test_class_generator.py
@@ -95,16 +95,17 @@ def test_parse_explain(tmp_path: Path) -> None:
         "DNS",
         "Deployment",
         "ImageContentSourcePolicy",
+        "Ingress",
         "Machine",
         "NMState",
-        "Pod",
-        "Secret",
-        "ServiceMeshMember",
-        "Ingress",
         "OAuth",
         "Pipeline",
+        "Pod",
         "RouteAdvertisements",
+        "Secret",
+        "ServiceMeshMember",
         "ServingRuntime",
+        "LLMInferenceServiceConfig",
     ]
 
     failures: list[tuple[str, str]] = []

--- a/ocp_resources/llm_inference_service_config.py
+++ b/ocp_resources/llm_inference_service_config.py
@@ -1,0 +1,90 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.resource import NamespacedResource
+
+
+class LLMInferenceServiceConfig(NamespacedResource):
+    """
+    No field description from API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.SERVING_KSERVE_IO
+
+    def __init__(
+        self,
+        base_refs: list[Any] | None = None,
+        model: dict[str, Any] | None = None,
+        parallelism: dict[str, Any] | None = None,
+        prefill: dict[str, Any] | None = None,
+        replicas: int | None = None,
+        router: dict[str, Any] | None = None,
+        template: dict[str, Any] | None = None,
+        worker: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            base_refs (list[Any]): No field description from API
+
+            model (dict[str, Any]): No field description from API
+
+            parallelism (dict[str, Any]): No field description from API
+
+            prefill (dict[str, Any]): No field description from API
+
+            replicas (int): No field description from API
+
+            router (dict[str, Any]): No field description from API
+
+            template (dict[str, Any]): No field description from API
+
+            worker (dict[str, Any]): No field description from API
+
+        """
+        super().__init__(**kwargs)
+
+        self.base_refs = base_refs
+        self.model = model
+        self.parallelism = parallelism
+        self.prefill = prefill
+        self.replicas = replicas
+        self.router = router
+        self.template = template
+        self.worker = worker
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.base_refs is not None:
+                _spec["baseRefs"] = self.base_refs
+
+            if self.model is not None:
+                _spec["model"] = self.model
+
+            if self.parallelism is not None:
+                _spec["parallelism"] = self.parallelism
+
+            if self.prefill is not None:
+                _spec["prefill"] = self.prefill
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.router is not None:
+                _spec["router"] = self.router
+
+            if self.template is not None:
+                _spec["template"] = self.template
+
+            if self.worker is not None:
+                _spec["worker"] = self.worker
+
+    # End of generated code


### PR DESCRIPTION
## Summary

Add auto-generated `LLMInferenceServiceConfig` resource class for `serving.kserve.io/v1alpha1`.

Generated using `class-generator --kind LLMInferenceServiceConfig` from a cluster running RHOAI 3.4.

This resource is used by RHOAI's LLM-d (llm-d) component to store configuration templates for LLMInferenceService deployments. The CRs are created by the llmisvc-controller-manager in the `redhat-ods-applications` namespace.

## Usage

Needed by [opendatahub-tests#1738](https://github.com/opendatahub-io/opendatahub-tests/pull/1738) for upgrade test validation — verifying that LLMInferenceServiceConfig CRs survive RHOAI upgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM Inference Service configuration support, enabling users to manage inference service deployments with customizable parameters including model specifications, scaling configuration, parallelism settings, and routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->