### PR TITLE
chore: update generated code marker to class_generator path

### DIFF
--- a/class_generator/core/generator.py
+++ b/class_generator/core/generator.py
@@ -54,7 +54,9 @@ def generate_resource_file_from_dict(
         template_name="class_generator_template.j2",
     )
 
-    output = "# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md\n\n"
+    output = (
+        "# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md\n\n"
+    )
     formatted_kind_str = convert_camel_case_to_snake_case(name=resource_dict["kind"])
 
     if re.search(r"_[a-z]_", formatted_kind_str):

--- a/class_generator/tests/manifests/APIServer/api_server.py
+++ b/class_generator/tests/manifests/APIServer/api_server.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/ClusterOperator/cluster_operator.py
+++ b/class_generator/tests/manifests/ClusterOperator/cluster_operator.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/ConfigMap/config_map.py
+++ b/class_generator/tests/manifests/ConfigMap/config_map.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/DNS/dns_config_openshift_io.py
+++ b/class_generator/tests/manifests/DNS/dns_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/DNS/dns_operator_openshift_io.py
+++ b/class_generator/tests/manifests/DNS/dns_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/Deployment/deployment.py
+++ b/class_generator/tests/manifests/Deployment/deployment.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/ImageContentSourcePolicy/image_content_source_policy.py
+++ b/class_generator/tests/manifests/ImageContentSourcePolicy/image_content_source_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/Ingress/ingress_config_openshift_io.py
+++ b/class_generator/tests/manifests/Ingress/ingress_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/Ingress/ingress_networking_k8s_io.py
+++ b/class_generator/tests/manifests/Ingress/ingress_networking_k8s_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/Machine/machine.py
+++ b/class_generator/tests/manifests/Machine/machine.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/NMState/nm_state.py
+++ b/class_generator/tests/manifests/NMState/nm_state.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/OAuth/oauth.py
+++ b/class_generator/tests/manifests/OAuth/oauth.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/Pipeline/pipeline.py
+++ b/class_generator/tests/manifests/Pipeline/pipeline.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/Pod/pod.py
+++ b/class_generator/tests/manifests/Pod/pod.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/RouteAdvertisements/route_advertisements.py
+++ b/class_generator/tests/manifests/RouteAdvertisements/route_advertisements.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/Secret/secret.py
+++ b/class_generator/tests/manifests/Secret/secret.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/ServiceMeshMember/service_mesh_member.py
+++ b/class_generator/tests/manifests/ServiceMeshMember/service_mesh_member.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/ServingRuntime/serving_runtime.py
+++ b/class_generator/tests/manifests/ServingRuntime/serving_runtime.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/class_generator/tests/manifests/test_parse_explain.j2
+++ b/class_generator/tests/manifests/test_parse_explain.j2
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md#adding-tests
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md#adding-tests
 
 import filecmp
 import traceback

--- a/class_generator/tests/test_batch_regeneration.py
+++ b/class_generator/tests/test_batch_regeneration.py
@@ -28,7 +28,7 @@ class TestResourceDiscovery:
 
     def create_generated_file(self, path: Path, class_name: str, with_user_code: bool = False) -> None:
         """Helper to create a generated resource file."""
-        content = f'''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = f'''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.resource import NamespacedResource
@@ -63,7 +63,7 @@ class ManualResource(Resource):
 
     def create_malformed_file(self, path: Path) -> None:
         """Helper to create a malformed Python file."""
-        content = """# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = """# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 class BrokenSyntax(
     # Missing closing parenthesis
@@ -185,7 +185,7 @@ class BrokenSyntax(
     def test_discover_handles_multiple_classes(self, temp_resources_dir, monkeypatch):
         """Test discovery handles files with multiple classes correctly."""
         # Create a file with multiple classes
-        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from ocp_resources.resource import NamespacedResource, Resource
 

--- a/class_generator/tests/test_class_generator.py
+++ b/class_generator/tests/test_class_generator.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md#adding-tests
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md#adding-tests
 
 import filecmp
 import traceback

--- a/class_generator/tests/test_user_code_parser.py
+++ b/class_generator/tests/test_user_code_parser.py
@@ -13,7 +13,7 @@ class TestUserCodeParser:
 
     def test_parse_file_with_user_code_and_imports(self):
         """Test parsing a file with both user code and user imports."""
-        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.resource import NamespacedResource
@@ -88,7 +88,7 @@ class MyResource(Resource):
 
     def test_parse_file_with_multiline_imports(self):
         """Test parsing a file with multi-line imports."""
-        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.resource import Resource
@@ -131,7 +131,7 @@ class MyResource(Resource):
 
     def test_parse_file_with_different_template_imports(self):
         """Test parsing with different combinations of template imports."""
-        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.exceptions import MissingRequiredArgumentError
@@ -181,7 +181,7 @@ class MyResource(NamespacedResource):
 
     def test_parse_file_with_only_marker(self):
         """Test parsing a file with only the marker and no user code."""
-        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.resource import Resource
@@ -207,7 +207,7 @@ class MyResource(Resource):
 
     def test_parse_file_with_exceptions_import(self):
         """Test parsing a file with import from ocp_resources.exceptions module."""
-        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.resource import NamespacedResource
@@ -245,7 +245,7 @@ class MyResource(NamespacedResource):
 
     def test_parse_file_with_syntax_error(self):
         """Test parsing a file with syntax errors in imports section."""
-        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.resource import Resource

--- a/class_generator/tests/test_utils.py
+++ b/class_generator/tests/test_utils.py
@@ -84,7 +84,7 @@ class TestResourceScanner:
     def test_scan_resources_with_valid_files(self, temp_ocp_resources_dir):
         """Test scanning resources with valid resource files."""
         # Create a valid resource file
-        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentError
@@ -145,7 +145,7 @@ class CustomResource(Resource):
 
     def test_extract_resource_info_with_base_resource(self, temp_ocp_resources_dir):
         """Test extracting info from a Resource-based class."""
-        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from ocp_resources.resource import Resource
 
@@ -176,7 +176,7 @@ class ClusterResource(Resource):
 
     def test_extract_resource_info_ephemeral_resource(self, temp_ocp_resources_dir):
         """Test extracting info for ephemeral resources like ProjectRequest."""
-        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from ocp_resources.resource import Resource
 
@@ -201,7 +201,7 @@ class ProjectRequest(Resource):
 
     def test_analyze_init_with_defaults(self, temp_ocp_resources_dir):
         """Test analyzing __init__ method with default parameters."""
-        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from ocp_resources.resource import NamespacedResource
 
@@ -229,7 +229,7 @@ class Deployment(NamespacedResource):
 
     def test_analyze_to_dict_required_params(self, temp_ocp_resources_dir):
         """Test analyzing to_dict method to find truly required parameters."""
-        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from ocp_resources.resource import NamespacedResource, MissingRequiredArgumentError
 
@@ -264,7 +264,7 @@ class Service(NamespacedResource):
 
     def test_extract_api_info_with_enum_style(self, temp_ocp_resources_dir):
         """Test extracting API info using enum-style attributes."""
-        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+        resource_content = '''# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from ocp_resources.resource import NamespacedResource
 
@@ -300,7 +300,7 @@ class Ingress(NamespacedResource):
         """Test that resources are returned sorted by name."""
         # Create multiple resource files
         for name in ["zebra", "alpha", "beta"]:
-            content = f"""# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+            content = f"""# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from ocp_resources.resource import Resource
 

--- a/class_generator/utils.py
+++ b/class_generator/utils.py
@@ -269,7 +269,7 @@ class ResourceScanner:
 
         # Only consider resources with the generated marker comment
         if (
-            "# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md"
+            "# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md"
             not in content
         ):
             return None

--- a/ocp_resources/aaq.py
+++ b/ocp_resources/aaq.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/api_server.py
+++ b/ocp_resources/api_server.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/authentication_config_openshift_io.py
+++ b/ocp_resources/authentication_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/authentication_operator_openshift_io.py
+++ b/ocp_resources/authentication_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/authorino.py
+++ b/ocp_resources/authorino.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/bgp_session_state.py
+++ b/ocp_resources/bgp_session_state.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/cdi.py
+++ b/ocp_resources/cdi.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/cdi_config.py
+++ b/ocp_resources/cdi_config.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/cluster_resource_quota.py
+++ b/ocp_resources/cluster_resource_quota.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/cluster_user_defined_network.py
+++ b/ocp_resources/cluster_user_defined_network.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/config_imageregistry_operator_openshift_io.py
+++ b/ocp_resources/config_imageregistry_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/config_map.py
+++ b/ocp_resources/config_map.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/config_operator_openshift_io.py
+++ b/ocp_resources/config_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/config_samples_operator_openshift_io.py
+++ b/ocp_resources/config_samples_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/console_config_openshift_io.py
+++ b/ocp_resources/console_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/console_operator_openshift_io.py
+++ b/ocp_resources/console_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/conversion.py
+++ b/ocp_resources/conversion.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/csi_driver.py
+++ b/ocp_resources/csi_driver.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/data_import_cron.py
+++ b/ocp_resources/data_import_cron.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/data_protection_application.py
+++ b/ocp_resources/data_protection_application.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/data_science_cluster.py
+++ b/ocp_resources/data_science_cluster.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/data_science_pipelines_application.py
+++ b/ocp_resources/data_science_pipelines_application.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/deployment.py
+++ b/ocp_resources/deployment.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/direct_volume_migration.py
+++ b/ocp_resources/direct_volume_migration.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/direct_volume_migration_progress.py
+++ b/ocp_resources/direct_volume_migration_progress.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/dns_config_openshift_io.py
+++ b/ocp_resources/dns_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/dns_operator_openshift_io.py
+++ b/ocp_resources/dns_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/dsc_initialization.py
+++ b/ocp_resources/dsc_initialization.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/evalhub.py
+++ b/ocp_resources/evalhub.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/frr_configuration.py
+++ b/ocp_resources/frr_configuration.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/gateway_class.py
+++ b/ocp_resources/gateway_class.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/gateway_config.py
+++ b/ocp_resources/gateway_config.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/gateway_gateway_networking_k8s_io.py
+++ b/ocp_resources/gateway_gateway_networking_k8s_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/gateway_networking_istio_io.py
+++ b/ocp_resources/gateway_networking_istio_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/group.py
+++ b/ocp_resources/group.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/guardrails_orchestrator.py
+++ b/ocp_resources/guardrails_orchestrator.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/image_caching_internal_knative_dev.py
+++ b/ocp_resources/image_caching_internal_knative_dev.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/image_config_openshift_io.py
+++ b/ocp_resources/image_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/image_content_source_policy.py
+++ b/ocp_resources/image_content_source_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/image_image_openshift_io.py
+++ b/ocp_resources/image_image_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/inference_graph.py
+++ b/ocp_resources/inference_graph.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/ingress_config_openshift_io.py
+++ b/ocp_resources/ingress_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/ingress_networking_k8s_io.py
+++ b/ocp_resources/ingress_networking_k8s_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/jaeger.py
+++ b/ocp_resources/jaeger.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/kube_descheduler.py
+++ b/ocp_resources/kube_descheduler.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/kubelet_config.py
+++ b/ocp_resources/kubelet_config.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/kubevirt.py
+++ b/ocp_resources/kubevirt.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/llama_stack_distribution.py
+++ b/ocp_resources/llama_stack_distribution.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/llm_inference_service.py
+++ b/ocp_resources/llm_inference_service.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/lm_eval_job.py
+++ b/ocp_resources/lm_eval_job.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/maa_s_auth_policy.py
+++ b/ocp_resources/maa_s_auth_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/maa_s_model.py
+++ b/ocp_resources/maa_s_model.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/maa_s_subscription.py
+++ b/ocp_resources/maa_s_subscription.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/maas_auth_policy.py
+++ b/ocp_resources/maas_auth_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/maas_model_ref.py
+++ b/ocp_resources/maas_model_ref.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/maas_subscription.py
+++ b/ocp_resources/maas_subscription.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/machine.py
+++ b/ocp_resources/machine.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/maria_db.py
+++ b/ocp_resources/maria_db.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mariadb_operator.py
+++ b/ocp_resources/mariadb_operator.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mig_analytic.py
+++ b/ocp_resources/mig_analytic.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mig_cluster.py
+++ b/ocp_resources/mig_cluster.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mig_controller.py
+++ b/ocp_resources/mig_controller.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mig_migration.py
+++ b/ocp_resources/mig_migration.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mig_plan.py
+++ b/ocp_resources/mig_plan.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mlflow.py
+++ b/ocp_resources/mlflow.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mlflow_config.py
+++ b/ocp_resources/mlflow_config.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/model_registry.py
+++ b/ocp_resources/model_registry.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from warnings import warn

--- a/ocp_resources/model_registry_components_platform_opendatahub_io.py
+++ b/ocp_resources/model_registry_components_platform_opendatahub_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/model_registry_modelregistry_opendatahub_io.py
+++ b/ocp_resources/model_registry_modelregistry_opendatahub_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/mtq.py
+++ b/ocp_resources/mtq.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/multi_namespace_virtual_machine_storage_migration.py
+++ b/ocp_resources/multi_namespace_virtual_machine_storage_migration.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/multi_namespace_virtual_machine_storage_migration_plan.py
+++ b/ocp_resources/multi_namespace_virtual_machine_storage_migration_plan.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/namespace.py
+++ b/ocp_resources/namespace.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/nemo_guardrails.py
+++ b/ocp_resources/nemo_guardrails.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/network_config_openshift_io.py
+++ b/ocp_resources/network_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/network_operator_openshift_io.py
+++ b/ocp_resources/network_operator_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/network_policy.py
+++ b/ocp_resources/network_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/nm_state.py
+++ b/ocp_resources/nm_state.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/node.py
+++ b/ocp_resources/node.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/node_config_openshift_io.py
+++ b/ocp_resources/node_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/node_network_configuration_policy_latest.py
+++ b/ocp_resources/node_network_configuration_policy_latest.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/notebook.py
+++ b/ocp_resources/notebook.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/oauth.py
+++ b/ocp_resources/oauth.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/open_telemetry_collector.py
+++ b/ocp_resources/open_telemetry_collector.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/operator.py
+++ b/ocp_resources/operator.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/pipeline.py
+++ b/ocp_resources/pipeline.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/pipeline_run.py
+++ b/ocp_resources/pipeline_run.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/pod.py
+++ b/ocp_resources/pod.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 import json
 from typing import Any

--- a/ocp_resources/pod_metrics.py
+++ b/ocp_resources/pod_metrics.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/project_config_openshift_io.py
+++ b/ocp_resources/project_config_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/project_project_openshift_io.py
+++ b/ocp_resources/project_project_openshift_io.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/project_request.py
+++ b/ocp_resources/project_request.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/prometheus.py
+++ b/ocp_resources/prometheus.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/rate_limit_policy.py
+++ b/ocp_resources/rate_limit_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/replica_set.py
+++ b/ocp_resources/replica_set.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/route_advertisements.py
+++ b/ocp_resources/route_advertisements.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/scaled_object.py
+++ b/ocp_resources/scaled_object.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/scheduler.py
+++ b/ocp_resources/scheduler.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/securesign.py
+++ b/ocp_resources/securesign.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/security_context_constraints.py
+++ b/ocp_resources/security_context_constraints.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/self_subject_review.py
+++ b/ocp_resources/self_subject_review.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/service.py
+++ b/ocp_resources/service.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/service_mesh_member.py
+++ b/ocp_resources/service_mesh_member.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/service_serving_knative_dev.py
+++ b/ocp_resources/service_serving_knative_dev.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 

--- a/ocp_resources/serving_runtime.py
+++ b/ocp_resources/serving_runtime.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/snapshot.py
+++ b/ocp_resources/snapshot.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/ssp.py
+++ b/ocp_resources/ssp.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/storage_cluster.py
+++ b/ocp_resources/storage_cluster.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/task.py
+++ b/ocp_resources/task.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/task_run.py
+++ b/ocp_resources/task_run.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/tempo_stack.py
+++ b/ocp_resources/tempo_stack.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/token_rate_limit_policy.py
+++ b/ocp_resources/token_rate_limit_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/user.py
+++ b/ocp_resources/user.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/user_defined_network.py
+++ b/ocp_resources/user_defined_network.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 from typing import Any
 from warnings import warn

--- a/ocp_resources/validating_admission_policy.py
+++ b/ocp_resources/validating_admission_policy.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/validating_admission_policy_binding.py
+++ b/ocp_resources/validating_admission_policy_binding.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_cluster_instancetype.py
+++ b/ocp_resources/virtual_machine_cluster_instancetype.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_cluster_preference.py
+++ b/ocp_resources/virtual_machine_cluster_preference.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_export.py
+++ b/ocp_resources/virtual_machine_export.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_instance.py
+++ b/ocp_resources/virtual_machine_instance.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 import shlex

--- a/ocp_resources/virtual_machine_instance_migration.py
+++ b/ocp_resources/virtual_machine_instance_migration.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_instance_preset.py
+++ b/ocp_resources/virtual_machine_instance_preset.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_instance_replica_set.py
+++ b/ocp_resources/virtual_machine_instance_replica_set.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_instancetype.py
+++ b/ocp_resources/virtual_machine_instancetype.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_preference.py
+++ b/ocp_resources/virtual_machine_preference.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_storage_migration.py
+++ b/ocp_resources/virtual_machine_storage_migration.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_storage_migration_plan.py
+++ b/ocp_resources/virtual_machine_storage_migration_plan.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_template.py
+++ b/ocp_resources/virtual_machine_template.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/virtual_machine_template_request.py
+++ b/ocp_resources/virtual_machine_template_request.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/volume_snapshot.py
+++ b/ocp_resources/volume_snapshot.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/volume_snapshot_class.py
+++ b/ocp_resources/volume_snapshot_class.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/ocp_resources/vtep.py
+++ b/ocp_resources/vtep.py
@@ -1,4 +1,4 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
 
 
 from typing import Any

--- a/tests/scripts/validate_resources.py
+++ b/tests/scripts/validate_resources.py
@@ -120,7 +120,7 @@ def parse_resource_file_for_errors(data) -> list[str]:
     _resources_definitions = resources_definitions()
 
     if data.startswith(
-        "# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md"
+        "# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md"
     ):
         return []
 


### PR DESCRIPTION
## What this PR does
Updates the generated code comment marker in all 132 `ocp_resources/` files from the old path (`scripts/resource/README.md`) to the current class-generator path (`class_generator/README.md`).

## Why
The `.coderabbit.yaml` skip instruction references the new marker (`class_generator/README.md`), but all existing generated files still used the old marker (`scripts/resource/README.md`). This meant CodeRabbit was not skipping generated code sections during reviews.

## Changes
- **132 files** in `ocp_resources/`: replaced `scripts/resource/README.md` → `class_generator/README.md` in the generated code start marker comment.
- No functional code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated generated-file header comments across many resource modules to point to the current generator documentation path.
  * Standardized source references in file headers for consistency.
  * No runtime behavior, public APIs, or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->