### PR TITLE
fix: add setter to DataSource

### DIFF
--- a/ocp_resources/data_source.py
+++ b/ocp_resources/data_source.py
@@ -75,8 +75,11 @@ class DataSource(NamespacedResource):
 
     @source.setter
     def source(self, value):
-        source_type_mapping = {"pvc": PersistentVolumeClaim, "snapshot": VolumeSnapshot}
-        source_type = next((key for key, cls in source_type_mapping.items() if isinstance(value, cls)), None)
-        if not source_type:
-            raise ValueError(f"source must be a PersistentVolumeClaim or VolumeSnapshot, got {type(value)}")
-        self._source = {source_type: {"name": value.name, "namespace": value.namespace}}
+        if not isinstance(value, dict):
+            raise ValueError(f"source must be a dict, got {type(value)}")
+
+        source_types = {"pvc", "snapshot"}
+        if next(iter(value)) not in source_types:
+            raise ValueError(f"source must be a 'pvc' or 'snapshot', got {next(iter(value))}")
+
+        self._source = value

--- a/ocp_resources/data_source.py
+++ b/ocp_resources/data_source.py
@@ -72,3 +72,7 @@ class DataSource(NamespacedResource):
             name=instance_source[ds_source].name,
             namespace=instance_source[ds_source].namespace,
         )
+
+    @source.setter
+    def source(self, value):
+        self.instance.spec.source = value

--- a/ocp_resources/data_source.py
+++ b/ocp_resources/data_source.py
@@ -79,4 +79,4 @@ class DataSource(NamespacedResource):
         source_type = next((key for key, cls in source_type_mapping.items() if isinstance(value, cls)), None)
         if not source_type:
             raise ValueError(f"source must be a PersistentVolumeClaim or VolumeSnapshot, got {type(value)}")
-        self.instance.spec.source = {source_type: {"name": value.name, "namespace": value.namespace}}
+        self._source = {source_type: {"name": value.name, "namespace": value.namespace}}

--- a/ocp_resources/data_source.py
+++ b/ocp_resources/data_source.py
@@ -75,4 +75,8 @@ class DataSource(NamespacedResource):
 
     @source.setter
     def source(self, value):
-        self.instance.spec.source = value
+        source_type_mapping = {"pvc": PersistentVolumeClaim, "snapshot": VolumeSnapshot}
+        source_type = next((key for key, cls in source_type_mapping.items() if isinstance(value, cls)), None)
+        if not source_type:
+            raise ValueError(f"source must be a PersistentVolumeClaim or VolumeSnapshot, got {type(value)}")
+        self.instance.spec.source = {source_type: {"name": value.name, "namespace": value.namespace}}


### PR DESCRIPTION
##### Short description:
Add setter to a `source` property in `DataSource` object.

##### More details:
It's because the source needs to be assigned as needed (when the resource gets created) not when it gets checked whether it exists or not.
https://github.com/RedHatQE/openshift-virtualization-tests/pull/4571

##### What this PR does / why we need it:
Ways how to get around it are convoluted, we just need to set the attribute as needed and create a resource, if it exists yield as is.

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### Bug:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now update a data source’s source value after it has been created (it is no longer read-only).
  * The assigned value is validated to ensure it’s a supported PVC or snapshot format.
  * Unsupported formats are rejected with a clear error.
  * Valid updates are preserved and will be correctly reflected when the resource is rendered/serialized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->