### PR TITLE
feat(Plan): add runPreflightInspection field

### DIFF
--- a/ocp_resources/plan.py
+++ b/ocp_resources/plan.py
@@ -42,6 +42,7 @@ class Plan(NamespacedResource):
                                         rules should be applied to the target VM resource.
         enable_nested_virtualization (bool, optional): Whether to enable nested virtualization on migrated VMs.
                                                       When False, CPU features vmx/svm are disabled on the target VM.
+        run_preflight_inspection (bool, optional): Whether to run preflight deep inspection on warm migrations.
     """
 
     api_group = NamespacedResource.ApiGroup.FORKLIFT_KONVEYOR_IO
@@ -78,6 +79,7 @@ class Plan(NamespacedResource):
         target_labels: dict[str, str] | None = None,
         target_affinity: dict[str, Any] | None = None,
         enable_nested_virtualization: bool | None = None,
+        run_preflight_inspection: bool | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -112,6 +114,7 @@ class Plan(NamespacedResource):
         self.target_labels = target_labels
         self.target_affinity = target_affinity
         self.enable_nested_virtualization = enable_nested_virtualization
+        self.run_preflight_inspection = run_preflight_inspection
 
         if self.pre_hook_name and self.pre_hook_namespace:
             self.hooks_array.append(
@@ -213,6 +216,9 @@ class Plan(NamespacedResource):
 
             if self.enable_nested_virtualization is not None:
                 spec["enableNestedVirtualization"] = self.enable_nested_virtualization
+
+            if self.run_preflight_inspection is not None:
+                spec["runPreflightInspection"] = self.run_preflight_inspection
 
     def _generate_hook_spec(self, hook_name: str, hook_namespace: str, hook_type: str) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary

Add support for the `spec.runPreflightInspection` boolean field on the Plan CR.

This field controls whether preflight deep inspection runs on warm migrations. It defaults to `true` via kubebuilder (`+kubebuilder:default:=true` in `plan.go:331-335`).

## Changes

4 standard touch points in `ocp_resources/plan.py`:
- Docstring
- `__init__` parameter (`bool | None = None`)
- `self` assignment
- `to_dict()` conditional

Follows the same pattern as `enable_nested_virtualization`, `skip_guest_conversion`, etc.

## Ref

- forklift field definition: `pkg/apis/forklift/v1beta1/plan.go:331-335`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional preflight inspection parameter to the Plan resource, enabling additional configuration during plan execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->