### PR TITLE
docs: restructure AGENTS.md, add CLAUDE.md, update CONTRIBUTING.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,6 @@ package-lock.json
 
 # AI
 .cursor/
-CLAUDE.md
 .agent-os/
 .cursorrules
 .claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,15 +8,15 @@ Python wrapper for kubernetes-python-client providing simplified CRUD and resour
 - Build/sync: `uv sync`
 - Test all: `uv run --group tests pytest`
 - Test specific: `uv run --group tests pytest tests/test_daemonset.py`
-- Lint: `uvx pre-commit run --all-files`
+- Lint: `prek run`
 - Pre-commit setup: `prek install`
 - Generate resource: `class-generator --kind Pod --add-tests`
-- Full verify: `uvx pre-commit run --all-files && uv run --group tests pytest`
+- Full verify: `prek run && uv run --group tests pytest`
 
 ## Definition of Done
 
 A task is complete when ALL pass:
-1. `uvx pre-commit run --all-files` exits 0 (ruff, mypy, flake8, detect-secrets, gitleaks)
+1. `prek run` exits 0 (ruff, mypy, flake8, detect-secrets, gitleaks)
 2. `uv run --group tests pytest` exits 0 — coverage ≥ 65%
 3. Type hints on all new code (enforced by mypy)
 4. Committed with message: `type(scope): description`
@@ -30,7 +30,7 @@ A task is complete when ALL pass:
 
 ## Project
 
-- Stack: Python 3.12+, kubernetes-python-client, timeout-sampler, uv
+- Stack: Python 3.10+, kubernetes-python-client, timeout-sampler, uv
 - Structure: `ocp_resources/` (resource wrappers), `tests/` (pytest), `class_generator/` (code gen), `fake_kubernetes_client/` (mock client)
 - Key deps: `kubernetes` (API client), `timeout-sampler` (polling), `openshift-python-utilities` (shared utils)
 - Docs: `examples/`, inline docstrings (Google style)
@@ -38,7 +38,7 @@ A task is complete when ALL pass:
 ## When Adding a Resource
 
 - New resources MUST be generated via `class-generator --kind ResourceName --add-tests` — manual creation is not allowed
-- Reference implementations: `ocp_resources/config_map.py` (namespaced), `ocp_resources/backup.py` (cluster-scoped)
+- Reference implementations: `ocp_resources/config_map.py` (namespaced), `ocp_resources/node.py` (cluster-scoped)
 - File naming: `snake_case.py` — class naming: exact Kubernetes `kind` (PascalCase)
 - Namespaced → inherit `NamespacedResource`, cluster-scoped → inherit `Resource`
 - Must implement: `__init__()`, `to_dict()`, `api_group` (if not core v1)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,90 @@
-/home/myakove/dotfiles/AGENTS.md
+# openshift-python-wrapper
+
+Python wrapper for kubernetes-python-client providing simplified CRUD and resource-specific methods for Kubernetes/OpenShift resources (233+ wrappers).
+
+## Commands
+
+- **Package manager**: `uv` — NEVER use `python` or `pip` directly
+- Build/sync: `uv sync`
+- Test all: `uv run --group tests pytest`
+- Test specific: `uv run --group tests pytest tests/test_daemonset.py`
+- Lint: `uvx pre-commit run --all-files`
+- Pre-commit setup: `prek install`
+- Generate resource: `class-generator --kind Pod --add-tests`
+- Full verify: `uvx pre-commit run --all-files && uv run --group tests pytest`
+
+## Definition of Done
+
+A task is complete when ALL pass:
+1. `uvx pre-commit run --all-files` exits 0 (ruff, mypy, flake8, detect-secrets, gitleaks)
+2. `uv run --group tests pytest` exits 0 — coverage ≥ 65%
+3. Type hints on all new code (enforced by mypy)
+4. Committed with message: `type(scope): description`
+
+## When Blocked
+
+- Tests fail after 3 attempts → stop, report failing test with full output
+- Missing dependency → `uv add <package>`, never `pip install`
+- Pre-commit fails → read the error, fix the specific violation
+- 🚫 NEVER: skip tests, force push to main, delete files to fix errors
+
+## Project
+
+- Stack: Python 3.12+, kubernetes-python-client, timeout-sampler, uv
+- Structure: `ocp_resources/` (resource wrappers), `tests/` (pytest), `class_generator/` (code gen), `fake_kubernetes_client/` (mock client)
+- Key deps: `kubernetes` (API client), `timeout-sampler` (polling), `openshift-python-utilities` (shared utils)
+- Docs: `examples/`, inline docstrings (Google style)
+
+## When Adding a Resource
+
+- New resources MUST be generated via `class-generator --kind ResourceName --add-tests` — manual creation is not allowed
+- Reference implementations: `ocp_resources/config_map.py` (namespaced), `ocp_resources/backup.py` (cluster-scoped)
+- File naming: `snake_case.py` — class naming: exact Kubernetes `kind` (PascalCase)
+- Namespaced → inherit `NamespacedResource`, cluster-scoped → inherit `Resource`
+- Must implement: `__init__()`, `to_dict()`, `api_group` (if not core v1)
+- Reference: `class_generator/README.md`
+
+## Generated Code Markers
+
+Resource files from `class-generator` use markers to separate generated from manual code:
+- **Start**: `# Generated using https://...class_generator/README.md` (line 1)
+- **End**: `# End of generated code` (inside class)
+
+Code between markers is auto-generated — do NOT modify manually. Use `class-generator --kind <Kind> --overwrite --backup` to regenerate. Custom code (helper methods, overrides) goes BELOW the end marker.
+
+## When Writing Code
+
+- No client-side validation in `to_dict()` — let the K8s/OCP API server return errors. Helper functions in resource classes CAN validate.
+- Context managers for auto-cleanup: `with Pod(name="test", namespace="default") as pod:`
+- Wait utilities: `wait_for_status()`, `wait_for_condition()` via timeout-sampler
+- Sensitive data: add keys to `keys_to_hash` property for automatic log hashing
+- Fake client for tests: `get_client(fake=True)` — no cluster required
+
+## When Reviewing Code
+
+- Verify generated code markers are intact — no manual edits between markers
+- Check type hints on all new functions/parameters
+- Verify tests exist for new helper methods (not needed for generated `__init__`/`to_dict`)
+- Import path: `ocp_resources.resource_name` (snake_case with underscores)
+
+## Boundaries
+
+- ✅ Always: use `uv` for Python ops, run `prek install` before first commit, add typing
+- ⚠️ Ask first: adding new dependencies, modifying base `Resource` class, changing CI
+- 🚫 Never: use `python`/`pip` directly, edit generated code between markers, edit files in `docs/` (regenerate with docsfy instead)
+
+## Environment
+
+```bash
+OPENSHIFT_PYTHON_WRAPPER_LOG_LEVEL=DEBUG        # DEBUG, INFO, WARNING, ERROR, CRITICAL
+OPENSHIFT_PYTHON_WRAPPER_HASH_LOG_DATA="false"   # Disable log hashing
+HTTPS_PROXY="http://proxy:8080"                  # Proxy support
+```
+
+## Additional References
+
+- Contributing guide: `CONTRIBUTING.md`
+- Class generator details: `class_generator/README.md`
+- MCP server: `mcp_server/README.md`
+- Release process: `CONTRIBUTING.md` + `.release-it.json`
+- Fake client: `fake_kubernetes_client/` (CRUD, selectors, watch, status generation)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ To get an overview of the project, read the [README](README.md).
 ### Create a new issue
 
 If you find a problem with the code, [search if an issue already exists](https://github.com/RedHatQE/openshift-python-wrapper/issues).  
-If you open a pull request to fix the problem, an issue will ba automatically created.  
+If you open a pull request to fix the problem, an issue will be automatically created.  
 If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/RedHatQE/openshift-python-wrapper/issues/new/choose).
 
 ## Pull requests
@@ -37,13 +37,15 @@ prek install
 
 ## Adding a new module (resource)
 
-##### Using generator script
+##### Using generator script (REQUIRED)
+
+New resources MUST be added via the class generator — manual creation is not allowed.
 
 - [class_generator](class_generator/README.md)
 
-##### Manual
+##### Manual code (below `# End of generated code` only)
 
-A new resource must follow rules:
+Custom helper methods can be added below the end marker. The generated class structure must follow these rules:
 
 - A new file named as the resource under `ocp_resources`; If the resource name is composed of multiple words, separate them with an underscore.
 - A class named as the resource kind.
@@ -56,4 +58,21 @@ A new resource must follow rules:
   Define all the required arguments that are **required** to instantiate the new resource. Optional parameters may be added as well.
 - Implement `to_dict` function.
 
-Check [ConfigMap](ocp_resources/configmap.py) and [Backup](ocp_resources/backup.py) for reference.
+Check [ConfigMap](ocp_resources/config_map.py) and [Backup](ocp_resources/backup.py) for reference.
+
+### Generated code markers
+
+Resource files created by `class-generator` use markers to separate generated from manual code:
+
+- **Start marker** (line 1): `# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md`
+- **End marker** (inside class): `# End of generated code`
+
+Code between these markers is **auto-generated and must NOT be modified manually**.
+To update generated code, use `class-generator --kind <Kind> --overwrite --backup`.
+Custom code (helper methods, overrides) goes **below** the `# End of generated code` marker.
+
+### No client-side validation on resource creation
+
+When building resource payloads (`to_dict()`), do NOT validate or block at code level (e.g., mutual exclusivity of fields).
+If a payload can be sent to the API, send it — let the Kubernetes/OpenShift API server return the error.
+Helper functions in resource classes (e.g., `wait_for_rollout()`, `restart()`) CAN perform validation and guarding as needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Custom helper methods can be added below the end marker. The generated class str
   Define all the required arguments that are **required** to instantiate the new resource. Optional parameters may be added as well.
 - Implement `to_dict` function.
 
-Check [ConfigMap](ocp_resources/config_map.py) and [Backup](ocp_resources/backup.py) for reference.
+Check [ConfigMap](ocp_resources/config_map.py) and [Node](ocp_resources/node.py) for reference.
 
 ### Generated code markers
 


### PR DESCRIPTION
## What

Restructure project documentation for AI agents and human contributors.

## Changes

### AGENTS.md (replaced symlink → proper tracked file)
- Replaced broken symlink to local dotfiles with a standalone 90-line file
- Restructured following AGENTS.md best practices: commands first, definition of done, escalation rules, task-organized sections
- Reduced from 357 lines to 90 lines (detail moved to referenced files)
- New resources MUST use class-generator — manual creation not allowed

### CLAUDE.md (new)
- Points to AGENTS.md via `@AGENTS.md` — single source of truth

### CONTRIBUTING.md (updated)
- Added "Generated code markers" section — explains start/end markers in class-generator files
- Added "No client-side validation on resource creation" rule
- Made class-generator mandatory for new resources
- Fixed typo: `ba` → `be`
- Fixed broken reference: `configmap.py` → `config_map.py`

### .gitignore
- Removed `CLAUDE.md` from ignore list (now a tracked file)

## Why

- AGENTS.md was a symlink to a local machine path — broken for all other contributors
- Previous content was 357 lines of prose-heavy documentation that buried actionable commands
- CONTRIBUTING.md was missing rules about generated code markers and validation conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new contributor guide with setup, testing, linting, and code-generation workflows.
  * Expanded contribution instructions for adding resources, generated-code boundaries, and validation expectations.
  * Updated a project reference file to point to the new guidance.

* **Chores**
  * Updated ignore rules to skip the Cursor editor workspace and removed an outdated ignored entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->