### PR TITLE
feat(plan): add scsiReservation field

### DIFF
--- a/ocp_resources/plan.py
+++ b/ocp_resources/plan.py
@@ -47,6 +47,9 @@ class Plan(NamespacedResource):
                                      with SCSI bus on the target VM. When True, RDM disks use
                                      lun.bus: scsi instead of the default disk.bus: virtio.
                                      Only applies to vSphere source providers.
+        scsi_reservation (bool, optional): Whether to enable SCSI persistent reservations on shared RDM disks.
+                                           When True, sets lun.reservation: true and errorPolicy: report
+                                           on target VM disks. Only applies to vSphere source providers.
     """
 
     api_group = NamespacedResource.ApiGroup.FORKLIFT_KONVEYOR_IO
@@ -85,6 +88,7 @@ class Plan(NamespacedResource):
         enable_nested_virtualization: bool | None = None,
         run_preflight_inspection: bool | None = None,
         rdm_as_lun: bool | None = None,
+        scsi_reservation: bool | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -121,6 +125,7 @@ class Plan(NamespacedResource):
         self.enable_nested_virtualization = enable_nested_virtualization
         self.run_preflight_inspection = run_preflight_inspection
         self.rdm_as_lun = rdm_as_lun
+        self.scsi_reservation = scsi_reservation
 
         if self.pre_hook_name and self.pre_hook_namespace:
             self.hooks_array.append(
@@ -228,6 +233,9 @@ class Plan(NamespacedResource):
 
             if self.rdm_as_lun is not None:
                 spec["rdmAsLun"] = self.rdm_as_lun
+
+            if self.scsi_reservation is not None:
+                spec["scsiReservation"] = self.scsi_reservation
 
     def _generate_hook_spec(self, hook_name: str, hook_namespace: str, hook_type: str) -> dict[str, Any]:
         return {


### PR DESCRIPTION
## Summary

Add support for the `spec.scsiReservation` boolean field on the Plan CR.

This field enables SCSI persistent reservations on shared RDM disks during migration. When set to `true`, it configures `lun.reservation: true` and `errorPolicy: report` on target VM disks.

## Changes

4 standard touch points in `ocp_resources/plan.py`:
- Docstring
- `__init__` parameter (`bool | None = None`)
- `self` assignment
- `to_dict()` conditional

Follows the same pattern as `rdm_as_lun`, `run_preflight_inspection`, etc.

## Ref

- Jira: MTV-6392
- Forklift PRs: kubev2v/forklift#7417, kubev2v/forklift#7422

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring SCSI persistent reservations on shared RDM disks.
  - Added options for reservation behavior and error policies on target virtual machine disks in vSphere environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->